### PR TITLE
Use pickling to serialize objects

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,8 +125,15 @@ jobs:
     displayName: 'Download ML-100K'
     
   - script: |
-      python3 -m pytest
+      mkdir -p build
+      python3 -m pytest --junitxml=build/test-results.xml
     displayName: 'pytest'
+
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: 'build/test-results.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'
   
   - script: |
       env NUMBA_DISABLE_JIT=1 invoke test --cover --no-eval
@@ -169,8 +176,15 @@ jobs:
     displayName: 'Install partial extra deps'
     
   - script: |
-      python3 -m pytest
+      mkdir -p build
+      python3 -m pytest --junitxml=build/test-results.xml
     displayName: 'pytest'
+
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: 'build/test-results.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'
   
   - script: |
       env NUMBA_DISABLE_JIT=1 invoke test --cover --no-eval
@@ -247,8 +261,14 @@ jobs:
     displayName: 'Build LKPY'
 
   - script: |
-      python -m pytest
+      python -m pytest --junitxml=build/test-results.xml
     displayName: 'Test LKPY'
+  
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: 'build/test-results.xml'
+      testRunTitle: 'Publish test results for Windows Python $(python.version)'
 
 - job: 'MacConda'
   pool:
@@ -284,5 +304,12 @@ jobs:
     displayName: 'Build LKPY'
 
   - script: |
-      python3 -m pytest
+      mkdir -p build
+      python3 -m pytest --junitxml=build/test-results.xml
     displayName: 'Test LKPY'
+
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: 'build/test-results.xml'
+      testRunTitle: 'Publish test results for Mac Python $(python.version)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ variables:
     invoke coverage pytest pytest-cov pytest-doctestplus cython
   pip.deps: >
     invoke pytest coverage pytest-cov pytest-doctestplus
-    pandas scipy pyarrow
+    pandas scipy pyarrow numpy<1.16
     numba cython cffi
   pip.extras: >
     hpfrec implicit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ variables:
     invoke coverage pytest pytest-cov pytest-doctestplus cython
   pip.deps: >
     invoke pytest coverage pytest-cov pytest-doctestplus
-    pandas scipy pyarrow 'numpy<1.16'
+    pandas scipy pyarrow numpy
     numba cython cffi
   pip.extras: >
     hpfrec implicit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ variables:
     invoke coverage pytest pytest-cov pytest-doctestplus cython
   pip.deps: >
     invoke pytest coverage pytest-cov pytest-doctestplus
-    pandas scipy pyarrow numpy<1.16
+    pandas scipy pyarrow 'numpy<1.16'
     numba cython cffi
   pip.extras: >
     hpfrec implicit

--- a/doc/math.rst
+++ b/doc/math.rst
@@ -6,4 +6,11 @@ Solvers
 
 .. module:: lenskit.math.solve
 
+.. autofunction:: dposv
 .. autofunction:: solve_tri
+
+Numba-accessible internals
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: _dposv
+.. autofunction:: _dtrsv

--- a/doc/matrix.rst
+++ b/doc/matrix.rst
@@ -19,12 +19,7 @@ We use CSR-format sparse matrices in quite a few places. Since SciPy's sparse ma
 directly usable from Numba, we have implemented a Numba-compiled CSR representation that can
 be used from accelerated algorithm implementations.
 
-.. autofunction:: csr_from_coo
-.. autofunction:: csr_from_scipy
-.. autofunction:: csr_to_scipy
-.. autofunction:: csr_rowinds
-.. autofunction:: csr_save
-.. autofunction:: csr_load
-
 .. autoclass:: CSR
     :members:
+
+.. autoclass:: _CSR

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -4,6 +4,8 @@
 
 See the [GitHub milestone](https://github.com/lenskit/lkpy/milestone/1) for a summary of what's happening!
 
+- The `save` and `load` methods on algorithms have been removed.  Just pickle fitted models to save
+  their data.  This is what SciKit does, see no need to deviate.
 - Several bug fixes and testing improvements
 
 ### Internal Changes

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -6,6 +6,13 @@ See the [GitHub milestone](https://github.com/lenskit/lkpy/milestone/1) for a su
 
 - Several bug fixes and testing improvements
 
+### Internal Changes
+
+These changes should not affect you if you are only consuming LensKit's algorithm and evaluation capabilities.
+
+-   Rewrite the `CSR` class to be more ergonomic from Python, at the expense of making the NumPy jitclass
+    indirect. It is available in the `.N` attribute.  Big improvement: it is now picklable.
+
 ## 0.5.0
 
 LensKit 0.5.0 modifies the algorithm APIs to follow the SciKit design patterns instead of

--- a/lenskit/algorithms/__init__.py
+++ b/lenskit/algorithms/__init__.py
@@ -61,30 +61,6 @@ class Algorithm(metaclass=ABCMeta):
 
         return params
 
-    def save(self, file):
-        """
-        Save a fit algorithm to a file.  The default implementation pickles the object.
-
-        Args:
-            file(path-like): the file to save.
-        """
-        path = pathlib.Path(file)
-        with path.open('wb') as f:
-            pickle.dump(self, f)
-
-    def load(self, file):
-        """
-        Load a fit algorithm from a file.  The default implementation unpickles the object
-        and transplants its parameters and model into this object.
-
-        Args:
-            file(path-like): the file to load.
-        """
-        path = pathlib.Path(file)
-        with path.open('rb') as f:
-            obj = pickle.load(f)
-            self.__dict__.update(obj.__dict__)
-
 
 class Predictor(Algorithm, metaclass=ABCMeta):
     """

--- a/lenskit/algorithms/als.py
+++ b/lenskit/algorithms/als.py
@@ -6,7 +6,7 @@ from numba import njit, prange
 
 from . import basic
 from .mf_common import BiasMFPredictor, MFPredictor
-from ..matrix import sparse_ratings, CSR
+from ..matrix import sparse_ratings, _CSR
 from .. import util
 from ..math.solve import _dposv
 
@@ -19,7 +19,7 @@ Context = namedtuple('Context', [
 
 
 @njit(parallel=True, nogil=True)
-def _train_matrix(mat: CSR, other: np.ndarray, reg: float):
+def _train_matrix(mat: _CSR, other: np.ndarray, reg: float):
     "One half of an explicit ALS training round."
     nr = mat.nrows
     nf = other.shape[1]
@@ -46,7 +46,7 @@ def _train_matrix(mat: CSR, other: np.ndarray, reg: float):
 
 
 @njit(parallel=True, nogil=True)
-def _train_implicit_matrix(mat: CSR, other: np.ndarray, reg: float):
+def _train_implicit_matrix(mat: _CSR, other: np.ndarray, reg: float):
     "One half of an implicit ALS training round."
     nr = mat.nrows
     nc = other.shape[0]
@@ -205,9 +205,9 @@ class BiasedMF(BiasMFPredictor):
     def _train_iters(self, current, uctx, ictx):
         "Generator of training iterations."
         for epoch in range(self.iterations):
-            umat = _train_matrix(uctx, current.item_matrix, self.regularization)
+            umat = _train_matrix(uctx.N, current.item_matrix, self.regularization)
             _logger.debug('[%s] finished user epoch %d', self.timer, epoch)
-            imat = _train_matrix(ictx, umat, self.regularization)
+            imat = _train_matrix(ictx.N, umat, self.regularization)
             _logger.debug('[%s] finished item epoch %d', self.timer, epoch)
             di = np.linalg.norm(imat - current.item_matrix, 'fro')
             du = np.linalg.norm(umat - current.user_matrix, 'fro')
@@ -274,10 +274,10 @@ class ImplicitMF(MFPredictor):
     def _train_iters(self, current, uctx, ictx):
         "Generator of training iterations."
         for epoch in range(self.iterations):
-            umat = _train_implicit_matrix(uctx, current.item_matrix,
+            umat = _train_implicit_matrix(uctx.N, current.item_matrix,
                                           self.reg)
             _logger.debug('[%s] finished user epoch %d', self.timer, epoch)
-            imat = _train_implicit_matrix(ictx, umat, self.reg)
+            imat = _train_implicit_matrix(ictx.N, umat, self.reg)
             _logger.debug('[%s] finished item epoch %d', self.timer, epoch)
             di = np.linalg.norm(imat - current.item_matrix, 'fro')
             du = np.linalg.norm(umat - current.user_matrix, 'fro')

--- a/lenskit/algorithms/basic.py
+++ b/lenskit/algorithms/basic.py
@@ -241,22 +241,6 @@ class Fallback(Predictor):
 
         return preds.reindex(items)
 
-    def save(self, path):
-        path = pathlib.Path(path)
-        path.mkdir(parents=True, exist_ok=True)
-        for i, algo in enumerate(self.algorithms):
-            mp = path / 'algo-{}.dat'.format(i+1)
-            _logger.debug('saving {} to {}', algo, mp)
-            algo.save(mp)
-
-    def load(self, file):
-        path = pathlib.Path(file)
-
-        for i, algo in enumerate(self.algorithms):
-            mp = path / 'algo-{}.dat'.format(i+1)
-            _logger.debug('loading {} from {}', algo, mp)
-            algo.load(mp)
-
     def __str__(self):
         return 'Fallback([{}])'.format(', '.join(self.algorithms))
 

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -357,44 +357,5 @@ class ItemItem(Predictor):
 
         return results
 
-    def save(self, path):
-        path = pathlib.Path(path)
-        _logger.info('saving I-I model to %s', path)
-
-        data = dict(items=self.item_index_.values, users=self.user_index_.values,
-                    means=self.item_means_)
-        data.update(matrix.csr_save(self.sim_matrix_, 's_'))
-        data.update(matrix.csr_save(self.rating_matrix_, 'r_'))
-
-        np.savez_compressed(path, **data)
-
-    def load(self, path):
-        path = pathlib.Path(path)
-        path = util.npz_path(path)
-        _logger.info('loading I-I model from %s', path)
-
-        with np.load(path) as npz:
-            items = npz['items']
-            users = npz['users']
-            means = npz['means']
-            s_mat = matrix.csr_load(npz, 's_')
-            r_mat = matrix.csr_load(npz, 'r_')
-
-        if means.dtype == np.object:
-            means = None
-
-        self.item_index_ = pd.Index(items, name='item')
-        self.user_index_ = pd.Index(users, name='user')
-        nitems = len(items)
-
-        s_mat.sort_values()
-
-        _logger.info('read %d similarities for %d items', s_mat.nnz, nitems)
-
-        self.item_counts_ = s_mat.row_nnzs()
-        self.item_means_ = means
-        self.sim_matrix_ = s_mat
-        self.rating_matrix_ = r_mat
-
     def __str__(self):
         return 'ItemItem(nnbrs={}, msize={})'.format(self.nnbrs, self.save_nbrs)

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -191,7 +191,7 @@ class ItemItem(Predictor):
         return nmat, item_means
 
     def _normalize(self, rmat):
-        rmat = matrix.csr_to_scipy(rmat)
+        rmat = rmat.to_scipy()
         # compute column norms
         norms = spla.norm(rmat, 2, axis=0)
         # and multiply by a diagonal to normalize columns
@@ -203,7 +203,7 @@ class ItemItem(Predictor):
         # and reset NaN
         norm_mat.data[np.isnan(norm_mat.data)] = 0
         _logger.info('[%s] normalized rating matrix columns', self._timer)
-        return matrix.csr_from_scipy(norm_mat, False)
+        return matrix.CSR.from_scipy(norm_mat, False)
 
     def _compute_similarities(self, rmat):
         mkl = matrix.mkl_ops()
@@ -214,7 +214,7 @@ class ItemItem(Predictor):
 
     def _scipy_similarities(self, rmat):
         nitems = rmat.ncols
-        sp_rmat = matrix.csr_to_scipy(rmat)
+        sp_rmat = rmat.to_scipy()
 
         _logger.info('[%s] multiplying matrix with scipy', self._timer)
         smat = sp_rmat.T @ sp_rmat
@@ -234,7 +234,7 @@ class ItemItem(Predictor):
 
         _logger.info('[%s] multiplying matrix with MKL', self._timer)
         smat = mkl.csr_syrk(rmat)
-        rows = matrix.csr_rowinds(smat)
+        rows = smat.rowinds()
         cols = smat.colinds
         vals = smat.values
 
@@ -269,7 +269,7 @@ class ItemItem(Predictor):
 
     def _select_similarities(self, nitems, rows, cols, vals):
         _logger.info('[%s] ordering similarities', self._timer)
-        csr = matrix.csr_from_coo(rows, cols, vals, shape=(nitems, nitems))
+        csr = matrix.CSR.from_coo(rows, cols, vals, shape=(nitems, nitems))
         csr.sort_values()
 
         if self.save_nbrs is None or self.save_nbrs <= 0:
@@ -337,7 +337,7 @@ class ItemItem(Predictor):
         iscore = np.full(len(self.item_index_), np.nan, dtype=np.float_)
 
         # now compute the predictions
-        iscore = self._predict_agg(self.sim_matrix_,
+        iscore = self._predict_agg(self.sim_matrix_.N,
                                    len(self.item_index_),
                                    (self.min_nbrs, self.nnbrs),
                                    rate_v, i_pos)

--- a/lenskit/algorithms/mf_common.py
+++ b/lenskit/algorithms/mf_common.py
@@ -112,19 +112,6 @@ class MFPredictor(Predictor):
         res = res.reindex(items)
         return res
 
-    def save(self, path):
-        np.savez_compressed(path, users=self.user_index_.values, items=self.item_index_.values,
-                            umat=self.user_features_, imat=self.item_features_)
-
-    def load(self, path):
-        path = util.npz_path(path)
-
-        with np.load(path) as npz:
-            self.user_index_ = pd.Index(npz['users'], name='user')
-            self.item_index_ = pd.Index(npz['items'], name='item')
-            self.user_features_ = npz['umat']
-            self.item_features_ = npz['imat']
-
 
 class BiasMFPredictor(MFPredictor):
     """
@@ -165,21 +152,3 @@ class BiasMFPredictor(MFPredictor):
                 rv = rv + self.item_bias_[items]
 
         return rv
-
-    def save(self, path):
-        np.savez_compressed(path, users=self.user_index_.values, items=self.item_index_.values,
-                            umat=self.user_features_, imat=self.item_features_,
-                            gbias=np.array([self.global_bias_]),
-                            ubias=self.user_bias_, ibias=self.item_bias_)
-
-    def load(self, path: pathlib.Path):
-        path = util.npz_path(path)
-
-        with np.load(path) as npz:
-            self.user_index_ = pd.Index(npz['users'])
-            self.item_index_ = pd.Index(npz['items'])
-            self.user_features_ = npz['umat']
-            self.item_features_ = npz['imat']
-            self.global_bias_ = npz['gbias'][0]
-            self.user_bias_ = npz['ubias']
-            self.item_bias_ = npz['ibias']

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -228,5 +228,17 @@ class UserUser(Predictor):
         mkl = matrix.mkl_ops()
         self._mkl_m_ = mkl.SparseM.from_csr(self.rating_matrix_) if mkl else None
 
+    def __getstate__(self):
+        state = dict(self.__dict__)
+        if '_mkl_m_' in state:
+            del state['_mkl_m_']
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.aggregate = intern(self.aggregate)
+        mkl = matrix.mkl_ops()
+        self._mkl_m_ = mkl.SparseM.from_csr(self.rating_matrix_) if mkl else None
+
     def __str__(self):
         return 'UserUser(nnbrs={}, min_sim={})'.format(self.nnbrs, self.min_sim)

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -196,38 +196,6 @@ class UserUser(Predictor):
 
         return ratings, umean
 
-    def save(self, path):
-        path = pathlib.Path(path)
-        _logger.info('saving to %s', path)
-
-        data = {
-            'users': self.user_index_,
-            'items': self.item_index_,
-            'user_means': self.user_means_
-        }
-        data.update(matrix.csr_save(self.rating_matrix_, prefix='m_'))
-        data.update(matrix.csr_save(self.transpose_matrix_, prefix='t_'))
-
-        np.savez_compressed(path, **data)
-
-    def load(self, path):
-        path = util.npz_path(path)
-
-        with np.load(path) as npz:
-            users = npz['users']
-            self.user_index_ = pd.Index(users, name='user')
-            self.item_index_ = pd.Index(npz['items'], name='item')
-            user_means = npz['user_means']
-            if user_means.ndim > 0:
-                self.user_means_ = pd.Series(user_means, index=users, name='mean')
-            else:
-                self.user_means_ = None
-            self.rating_matrix_ = matrix.csr_load(npz, 'm_')
-            self.transpose_matrix_ = matrix.csr_load(npz, 't_')
-
-        mkl = matrix.mkl_ops()
-        self._mkl_m_ = mkl.SparseM.from_csr(self.rating_matrix_) if mkl else None
-
     def __getstate__(self):
         state = dict(self.__dict__)
         if '_mkl_m_' in state:

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -130,8 +130,7 @@ class UserUser(Predictor):
             nsims = np.zeros(len(self.user_index_))
             nsims = self._mkl_m_.mult_vec(1, ratings, 0, nsims)
         else:
-            rmat = self.rating_matrix_
-            rmat = matrix.csr_to_scipy(rmat)
+            rmat = self.rating_matrix_.to_scipy()
             nsims = rmat @ ratings
         assert len(nsims) == len(self.user_index_)
         if user in self.user_index_:

--- a/lenskit/math/solve.py
+++ b/lenskit/math/solve.py
@@ -11,13 +11,13 @@ from numba.extending import get_cython_function_address
 
 __ffi = cffi.FFI()
 
-__uplo_U = np.array(ord('U'), dtype=np.int8)
-__uplo_L = np.array(ord('L'), dtype=np.int8)
-__trans_N = np.array(ord('N'), dtype=np.int8)
-__trans_T = np.array(ord('T'), dtype=np.int8)
-__trans_C = np.array(ord('C'), dtype=np.int8)
-__diag_U = np.array(ord('U'), dtype=np.int8)
-__diag_N = np.array(ord('N'), dtype=np.int8)
+__uplo_U = np.array([ord('U')], dtype=np.int8)
+__uplo_L = np.array([ord('L')], dtype=np.int8)
+__trans_N = np.array([ord('N')], dtype=np.int8)
+__trans_T = np.array([ord('T')], dtype=np.int8)
+__trans_C = np.array([ord('C')], dtype=np.int8)
+__diag_U = np.array([ord('U')], dtype=np.int8)
+__diag_N = np.array([ord('N')], dtype=np.int8)
 __inc_1 = np.ones(1, dtype=np.int32)
 
 __dtrsv = __ffi.cast("void (*) (char*, char*, char*, int*, double*, int*, double*, int*)",
@@ -89,6 +89,10 @@ def _dposv(A, b, lower):
 
 
 def dposv(A, b, lower=False):
+    """
+    Interface to the BLAS dposv function.  A Numba-accessible verison without
+    error checking is exposed as :py:func:`_dposv`.
+    """
     info = _dposv(A, b, lower)
     if info < 0:
         raise ValueError('invalid args to dposv, code ' + str(info))

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -48,25 +48,10 @@ def mkl_ops():
     'colinds': n.int32[:],
     'values': n.optional(n.float64[:])
 })
-class CSR:
+class _CSR:
     """
-    Simple compressed sparse row matrix.  This is like :py:class:`scipy.sparse.csr_matrix`, with
-    a couple of useful differences:
-
-    * It is a Numba jitclass, so it can be directly used from Numba-optimized functions.
-    * The value array is optional, for cases in which only the matrix structure is required.
-    * The value array, if present, is always double-precision.
-
-    You generally don't want to create this class yourself.  Instead, use one of the related
-    utility functions.
-
-    Attributes:
-        nrows(int): the number of rows.
-        ncols(int): the number of columns.
-        nnz(int): the number of entries.
-        rowptrs(numpy.ndarray): the row pointers.
-        colinds(numpy.ndarray): the column indices.
-        values(numpy.ndarray): the values
+    Internal implementation class for :py:class:`CSR`. If you work with CSRs from Numba,
+    you will use this.
     """
     def __init__(self, nrows, ncols, nnz, ptrs, inds, vals):
         self.nrows = nrows
@@ -109,46 +94,239 @@ class CSR:
         else:
             return self.values[sp:ep]
 
+
+class CSR:
+    """
+    Simple compressed sparse row matrix.  This is like :py:class:`scipy.sparse.csr_matrix`, with
+    a couple of useful differences:
+
+    * It is backed by a Numba jitclass, so it can be directly used from Numba-optimized functions.
+    * The value array is optional, for cases in which only the matrix structure is required.
+    * The value array, if present, is always double-precision.
+
+    You generally don't want to create this class yourself with the constructor.  Instead, use one
+    of its class methods.
+
+    If you need to pass an instance off to a Numba-compiled function, use :py:attr:`N`::
+
+        _some_numba_fun(csr.N)
+
+    We use the indirection between this and the Numba jitclass so that the main CSR implementation
+    can be pickled, and so that we can have class and instance methods that are not compatible with
+    jitclass but which are useful from interpreted code.
+
+    Attributes:
+        N(_CSR): the Numba jitclass backing (has the same attributes and most methods).
+        nrows(int): the number of rows.
+        ncols(int): the number of columns.
+        nnz(int): the number of entries.
+        rowptrs(numpy.ndarray): the row pointers.
+        colinds(numpy.ndarray): the column indices.
+        values(numpy.ndarray): the values
+    """
+    __slots__ = ['N']
+
+    def __init__(self, nrows=None, ncols=None, nnz=None, ptrs=None, inds=None, vals=None, N=None):
+        if N is not None:
+            self.N = N
+        else:
+            self.N = _CSR(nrows, ncols, nnz, ptrs, inds, vals)
+
+    @classmethod
+    def from_coo(cls, rows, cols, vals, shape=None):
+        """
+        Create a CSR matrix from data in COO format.
+
+        Args:
+            rows(array-like): the row indices.
+            cols(array-like): the column indices.
+            vals(array-like): the data values; can be ``None``.
+            shape(tuple): the array shape, or ``None`` to infer from row & column indices.
+        """
+        if shape is not None:
+            nrows, ncols = shape
+            assert np.max(rows) < nrows
+            assert np.max(cols) < ncols
+        else:
+            nrows = np.max(rows) + 1
+            ncols = np.max(cols) + 1
+
+        nnz = len(rows)
+        assert len(cols) == nnz
+        assert vals is None or len(vals) == nnz
+
+        rowptrs = np.zeros(nrows + 1, dtype=np.int32)
+        align = np.full(nnz, -1, dtype=np.int32)
+
+        _csr_align(rows, nrows, rowptrs, align)
+
+        cols = cols[align].copy()
+        vals = vals[align].copy() if vals is not None else None
+
+        return cls(nrows, ncols, nnz, rowptrs, cols, vals)
+
+    @classmethod
+    def from_scipy(cls, mat, copy=True):
+        """
+        Convert a scipy sparse matrix to an internal CSR.
+
+        Args:
+            mat(scipy.sparse.spmatrix): a SciPy sparse matrix.
+            copy(bool): if ``False``, reuse the SciPy storage if possible.
+
+        Returns:
+            CSR: a CSR matrix.
+        """
+        if not sps.isspmatrix_csr(mat):
+            mat = mat.tocsr(copy=copy)
+        rp = np.require(mat.indptr, np.int32, 'C')
+        if copy and rp is mat.indptr:
+            rp = rp.copy()
+        cs = np.require(mat.indices, np.int32, 'C')
+        if copy and cs is mat.indices:
+            cs = cs.copy()
+        vs = mat.data.copy() if copy else mat.data
+        return cls(mat.shape[0], mat.shape[1], mat.nnz, rp, cs, vs)
+
+    def to_scipy(mat):
+        """
+        Convert a CSR matrix to a SciPy :py:class:`scipy.sparse.csr_matrix`.
+
+        Args:
+            mat(CSR): A CSR matrix.
+
+        Returns:
+            scipy.sparse.csr_matrix:
+                A SciPy sparse matrix with the same data.  It shares
+                storage with ``matrix``.
+        """
+        if sps.isspmatrix(mat):
+            warnings.warn('matrix already a SciPy matrix')
+            return mat.tocsr()
+        values = mat.values
+        if values is None:
+            values = np.full(mat.nnz, 1.0)
+        return sps.csr_matrix((values, mat.colinds, mat.rowptrs), shape=(mat.nrows, mat.ncols))
+
+    @property
+    def nrows(self) -> int:
+        return self.N.nrows
+
+    @property
+    def ncols(self) -> int:
+        return self.N.ncols
+
+    @property
+    def nnz(self) -> int:
+        return self.N.nnz
+
+    @property
+    def rowptrs(self) -> np.ndarray:
+        return self.N.rowptrs
+
+    @property
+    def colinds(self) -> np.ndarray:
+        return self.N.colinds
+
+    @property
+    def values(self) -> np.ndarray:
+        return self.N.values
+
+    @values.setter
+    def values(self, vs: np.ndarray):
+        if vs is not None:
+            if not isinstance(vs, np.ndarray):
+                raise TypeError('values not an ndarray')
+            if vs.ndim != 1:
+                raise ValueError('values has {} dimensions, expected 1'.format(vs.ndims))
+            if vs.shape[0] < self.nnz:
+                s = 'values has only {} entries (expected at least {})'
+                raise ValueError(s.format(vs.shape[0], self.nnz))
+
+            vs = vs[:self.nnz]
+            vs = np.require(vs, 'f8')
+
+        self.N.values = vs
+
+    def rowinds(self) -> np.ndarray:
+        """
+        Get the row indices from this array.  Combined with :py:attr:`colinds` and
+        :py:attr:`values`, this can form a COO-format sparse matrix.
+
+        .. note:: This method is not available from Numba.
+        """
+        return np.repeat(np.arange(self.nrows), np.diff(self.rowptrs))
+
+    def row(self, row):
+        """
+        Return a row of this matrix as a dense ndarray.
+
+        Args:
+            row(int): the row index.
+
+        Returns:
+            np.ndarray: the row, with 0s in the place of missing values.
+        """
+        return self.N.row(row)
+
+    def row_extent(self, row):
+        """
+        Get the extent of a row in the underlying column index and value arrays.
+
+        Args:
+            row(int): the row index.
+
+        Returns:
+            tuple: ``(s, e)``, where the row occupies positions :math:`[s, e)` in the
+            CSR data.
+        """
+        return self.N.row_extent(row)
+
+    def row_cs(self, row):
+        """
+        Get the column indcies for the stored values of a row.
+        """
+        return self.N.row_cs(row)
+
+    def row_vs(self, row):
+        """
+        Get the stored values of a row.
+        """
+        return self.N.row_vs(row)
+
     def row_nnzs(self):
-        "Get a vector of the number of nonzero entries in each row."
-        # we want to use np.diff, but numba doesn't like it with our rowptr
-        diff = np.zeros(self.nrows, dtype=np.int32)
-        for i in range(self.nrows):
-            diff[i] = self.rowptrs[i+1] - self.rowptrs[i]
-        return diff
+        """
+        Get a vector of the number of nonzero entries in each row.
+
+        .. note:: This method is not available from Numba.
+
+        Returns:
+            np.ndarray: the number of nonzero entries in each row.
+        """
+        return np.diff(self.rowptrs)
 
     def sort_values(self):
-        "Sort CSR rows in nonincreasing order by value."
+        """
+        Sort CSR rows in nonincreasing order by value.
+
+        .. note:: This method is not available from Numba.
+        """
         _csr_sort(self.nrows, self.rowptrs, self.colinds, self.values)
 
-    def transpose(self):
+    def transpose(self, values=True):
         """
         Transpose a CSR matrix.
+
+        .. note:: This method is not available from Numba.
+
+        Args:
+            values(bool): whether to include the values in the transpose.
 
         Returns:
             CSR: the transpose of this matrix (or, equivalently, this matrix in CSC format).
         """
 
-        return self._transpose(True)
-
-    def transpose_coords(self):
-        """
-        Transpose a CSR matrix without retaining values.
-
-        Returns:
-            CSR: the transpose of this matrix (or, equivalently, this matrix in CSC format),
-            without the value array.
-        """
-
-        return self._transpose(False)
-
-    def _transpose(self, values):
-        rowinds = np.empty(self.nnz, dtype=np.int32)
-        for r in range(self.nrows):
-            rsp = self.rowptrs[r]
-            rep = self.rowptrs[r+1]
-            rowinds[rsp:rep] = r
-
+        rowinds = self.rowinds()
         align = np.empty(self.nnz, dtype=np.int32)
         colptrs = np.zeros(self.ncols + 1, dtype=np.int32)
 
@@ -162,6 +340,21 @@ class CSR:
             n_vs = None
 
         return CSR(self.ncols, self.nrows, self.nnz, n_rps, n_cis, n_vs)
+
+    def __str__(self):
+        return '<CSR {}x{} ({} nnz)>'.format(self.nrows, self.ncols, self.nnz)
+
+    def __getstate__(self):
+        return dict(shape=(self.nrows, self.ncols), nnz=self.nnz,
+                    rowptrs=self.rowptrs, colinds=self.colinds, values=self.values)
+
+    def __setstate__(self, state):
+        nrows, ncols = state['shape']
+        nnz = state['nnz']
+        rps = state['rowptrs']
+        cis = state['colinds']
+        vs = state['values']
+        self.N = _CSR(nrows, ncols, nnz, rps, cis, vs)
 
 
 @njit(n.void(n.intc, n.int32[:], n.int32[:], n.double[:]),
@@ -178,39 +371,6 @@ def _csr_sort(nrows, rowptrs, colinds, values):
             values[sp:ep] = values[sp + ord]
 
 
-def csr_from_coo(rows, cols, vals, shape=None):
-    """
-    Create a CSR matrix from data in COO format.
-
-    Args:
-        rows(array-like): the row indices.
-        cols(array-like): the column indices.
-        vals(array-like): the data values; can be ``None``.
-        shape(tuple): the array shape, or ``None`` to infer from row & column indices.
-    """
-    if shape is not None:
-        nrows, ncols = shape
-        assert np.max(rows) < nrows
-        assert np.max(cols) < ncols
-    else:
-        nrows = np.max(rows) + 1
-        ncols = np.max(cols) + 1
-
-    nnz = len(rows)
-    assert len(cols) == nnz
-    assert vals is None or len(vals) == nnz
-
-    rowptrs = np.zeros(nrows + 1, dtype=np.int32)
-    align = np.full(nnz, -1, dtype=np.int32)
-
-    _csr_align(rows, nrows, rowptrs, align)
-
-    cols = cols[align].copy()
-    vals = vals[align].copy() if vals is not None else None
-
-    return CSR(nrows, ncols, nnz, rowptrs, cols, vals)
-
-
 @njit
 def _csr_align(rowinds, nrows, rowptrs, align):
     rcts = np.zeros(nrows, dtype=np.int32)
@@ -225,63 +385,6 @@ def _csr_align(rowinds, nrows, rowptrs, align):
         pos = rpos[row]
         align[pos] = i
         rpos[row] += 1
-
-
-def csr_from_scipy(mat, copy=True):
-    """
-    Convert a scipy sparse matrix to an internal CSR.
-
-    Args:
-        mat(scipy.sparse.spmatrix): a SciPy sparse matrix.
-        copy(bool): if ``False``, reuse the SciPy storage if possible.
-
-    Returns:
-        CSR: a CSR matrix.
-    """
-    if not sps.isspmatrix_csr(mat):
-        mat = mat.tocsr(copy=copy)
-    rp = np.require(mat.indptr, np.int32, 'C')
-    if copy and rp is mat.indptr:
-        rp = rp.copy()
-    cs = np.require(mat.indices, np.int32, 'C')
-    if copy and cs is mat.indices:
-        cs = cs.copy()
-    vs = mat.data.copy() if copy else mat.data
-    return CSR(mat.shape[0], mat.shape[1], mat.nnz, rp, cs, vs)
-
-
-def csr_to_scipy(mat):
-    """
-    Convert a CSR matrix to a SciPy :py:class:`scipy.sparse.csr_matrix`.
-
-    Args:
-        mat(CSR): A CSR matrix.
-
-    Returns:
-        scipy.sparse.csr_matrix:
-            A SciPy sparse matrix with the same data.  It shares
-            storage with ``matrix``.
-    """
-    if sps.isspmatrix(mat):
-        warnings.warn('matrix already a SciPy matrix')
-        return mat.tocsr()
-    values = mat.values
-    if values is None:
-        values = np.full(mat.nnz, 1.0)
-    return sps.csr_matrix((values, mat.colinds, mat.rowptrs), shape=(mat.nrows, mat.ncols))
-
-
-def csr_rowinds(csr):
-    """
-    Get the row indices for a CSR matrix.
-
-    Args:
-        csr(CSR): a CSR matrix.
-
-    Returns:
-        np.ndarray: the row index array for the CSR matrix.
-    """
-    return np.repeat(np.arange(csr.nrows), np.diff(csr.rowptrs))
 
 
 def csr_save(csr: CSR, prefix=None):
@@ -364,9 +467,9 @@ def sparse_ratings(ratings, scipy=False):
     else:
         vals = None
 
-    matrix = csr_from_coo(row_ind, col_ind, vals, (len(uidx), len(iidx)))
+    matrix = CSR.from_coo(row_ind, col_ind, vals, (len(uidx), len(iidx)))
 
     if scipy:
-        matrix = csr_to_scipy(matrix)
+        matrix = matrix.to_scipy()
 
     return RatingMatrix(matrix, uidx, iidx)

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -265,7 +265,7 @@ class CSR:
             row(int): the row index.
 
         Returns:
-            np.ndarray: the row, with 0s in the place of missing values.
+            numpy.ndarray: the row, with 0s in the place of missing values.
         """
         return self.N.row(row)
 
@@ -301,7 +301,7 @@ class CSR:
         .. note:: This method is not available from Numba.
 
         Returns:
-            np.ndarray: the number of nonzero entries in each row.
+            numpy.ndarray: the number of nonzero entries in each row.
         """
         return np.diff(self.rowptrs)
 

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -383,61 +383,6 @@ def _csr_align(rowinds, nrows, rowptrs, align):
         rpos[row] += 1
 
 
-def csr_save(csr: CSR, prefix=None):
-    """
-    Extract data needed to save a CSR matrix.  This is intended to be used with, for
-    example, :py:func:`numpy.savez` to save a matrix::
-
-        np.savez_compressed('file.npz', **csr_save(csr))
-
-    The ``prefix`` allows multiple matrices to be saved in a single file::
-
-        data = {}
-        data.update(csr_save(m1, prefix='m1'))
-        data.update(csr_save(m2, prefix='m2'))
-        np.savez_compressed('file.npz', **data)
-
-    Args:
-        csr(CSR): the matrix to save.
-        prefix(str): the prefix for the data keys.
-
-    Returns:
-        dict: a dictionary of data to save the matrix.
-    """
-    if prefix is None:
-        prefix = ''
-    return {
-        prefix + 'ncols': csr.ncols,
-        prefix + 'nrows': csr.nrows,
-        prefix + 'rowptrs': csr.rowptrs,
-        prefix + 'colinds': csr.colinds,
-        prefix + 'values': csr.values
-    }
-
-
-def csr_load(data, prefix=None):
-    """
-    Rematerialize a CSR matrix from loaded data.  The inverse of :py:func:`csr_save`.
-
-    Args:
-        data(dict-like): the input data.
-        prefix(str): the prefix for the data keys.
-
-    Returns:
-        CSR: the matrix described by ``data``.
-    """
-    if prefix is None:
-        prefix = ''
-    ncols = int(data[prefix + 'ncols'])
-    nrows = int(data[prefix + 'nrows'])
-    rowptrs = data[prefix + 'rowptrs']
-    colinds = data[prefix + 'colinds']
-    values = data[prefix + 'values']
-    if values.ndim == 0:
-        values = None
-    return CSR(nrows, ncols, len(colinds), rowptrs, colinds, values)
-
-
 def sparse_ratings(ratings, scipy=False):
     """
     Convert a rating table to a sparse matrix of ratings.

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -255,7 +255,7 @@ class CSR:
 
         .. note:: This method is not available from Numba.
         """
-        return np.repeat(np.arange(self.nrows), np.diff(self.rowptrs))
+        return np.repeat(np.arange(self.nrows, dtype=np.int32), np.diff(self.rowptrs))
 
     def row(self, row):
         """

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -188,25 +188,21 @@ class CSR:
         vs = mat.data.copy() if copy else mat.data
         return cls(mat.shape[0], mat.shape[1], mat.nnz, rp, cs, vs)
 
-    def to_scipy(mat):
+    def to_scipy(self):
         """
         Convert a CSR matrix to a SciPy :py:class:`scipy.sparse.csr_matrix`.
 
         Args:
-            mat(CSR): A CSR matrix.
+            self(CSR): A CSR matrix.
 
         Returns:
             scipy.sparse.csr_matrix:
-                A SciPy sparse matrix with the same data.  It shares
-                storage with ``matrix``.
+                A SciPy sparse matrix with the same data.
         """
-        if sps.isspmatrix(mat):
-            warnings.warn('matrix already a SciPy matrix')
-            return mat.tocsr()
-        values = mat.values
+        values = self.values
         if values is None:
-            values = np.full(mat.nnz, 1.0)
-        return sps.csr_matrix((values, mat.colinds, mat.rowptrs), shape=(mat.nrows, mat.ncols))
+            values = np.full(self.nnz, 1.0)
+        return sps.csr_matrix((values, self.colinds, self.rowptrs), shape=(self.nrows, self.ncols))
 
     @property
     def nrows(self) -> int:

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -40,6 +40,13 @@ def mkl_ops():
         return None
 
 
+def _csr_delegate(name):
+    def func(self):
+        return getattr(self.N, name)
+
+    return property(func)
+
+
 @jitclass({
     'nrows': n.int32,
     'ncols': n.int32,
@@ -204,29 +211,12 @@ class CSR:
             values = np.full(self.nnz, 1.0)
         return sps.csr_matrix((values, self.colinds, self.rowptrs), shape=(self.nrows, self.ncols))
 
-    @property
-    def nrows(self) -> int:
-        return self.N.nrows
-
-    @property
-    def ncols(self) -> int:
-        return self.N.ncols
-
-    @property
-    def nnz(self) -> int:
-        return self.N.nnz
-
-    @property
-    def rowptrs(self) -> np.ndarray:
-        return self.N.rowptrs
-
-    @property
-    def colinds(self) -> np.ndarray:
-        return self.N.colinds
-
-    @property
-    def values(self) -> np.ndarray:
-        return self.N.values
+    nrows = _csr_delegate('nrows')
+    ncols = _csr_delegate('ncols')
+    nnz = _csr_delegate('nnz')
+    rowptrs = _csr_delegate('rowptrs')
+    colinds = _csr_delegate('colinds')
+    values = _csr_delegate('values')
 
     @values.setter
     def values(self, vs: np.ndarray):

--- a/lenskit/util.py
+++ b/lenskit/util.py
@@ -186,21 +186,6 @@ def fspath(path):
         return str(path)
 
 
-def npz_path(path):
-    path = pathlib.Path(path)
-    p = path
-    if not p.exists():
-        p = path.with_name(path.name + '.npz')
-
-    if not p.exists():
-        p = path.with_suffix('.npz')
-
-    if not p.exists():
-        raise FileNotFoundError(path)
-
-    return p
-
-
 def read_df_detect(path):
     """
     Read a Pandas data frame, auto-detecting the file format based on filename suffix.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 log_level=INFO
 doctest_plus=enabled
+filterwarnings =
+    ignore:.*matrix subclass.*:PendingDeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ log_level=INFO
 doctest_plus=enabled
 filterwarnings =
     ignore:.*matrix subclass.*:PendingDeprecationWarning
+    ignore:.*np.asscalar.*:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'numpy',
         'scipy',
         'numba >= 0.38',
-        'pyarrow'
+        'pyarrow',
+        'cffi'
     ],
     tests_require=[
         'pytest >= 3.9',

--- a/tests/test_als_explicit.py
+++ b/tests/test_als_explicit.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 
 from lenskit.algorithms import als
 
@@ -105,20 +106,17 @@ def test_als_train_large():
     assert ibias.values == approx(imeans.values)
 
 
-def test_als_save_load(tmp_path):
-    tmp_path = lktu.norm_path(tmp_path)
-    mod_file = tmp_path / 'als.npz'
+def test_als_save_load():
     original = als.BiasedMF(20, iterations=5)
     ratings = lktu.ml_pandas.renamed.ratings
     original.fit(ratings)
 
     assert original.global_bias_ == approx(ratings.rating.mean())
 
-    original.save(mod_file)
-    assert mod_file.exists()
+    mod = pickle.dumps(original)
+    _log.info('serialized to %d bytes', len(mod))
 
-    algo = als.BiasedMF(20)
-    algo.load(mod_file)
+    algo = pickle.loads(mod)
     assert algo.global_bias_ == original.global_bias_
     assert np.all(algo.user_bias_ == original.user_bias_)
     assert np.all(algo.item_bias_ == original.item_bias_)

--- a/tests/test_als_implicit.py
+++ b/tests/test_als_implicit.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 
 from lenskit import topn
 from lenskit.algorithms import als
@@ -70,18 +71,15 @@ def test_als_train_large():
     assert algo.item_features_.shape == (ratings.item.nunique(), 20)
 
 
-def test_als_save_load(tmp_path):
-    tmp_path = lktu.norm_path(tmp_path)
-    mod_file = tmp_path / 'als.npz'
+def test_als_save_load():
     algo = als.ImplicitMF(20, iterations=5)
     ratings = lktu.ml_pandas.renamed.ratings
     algo.fit(ratings)
 
-    algo.save(mod_file)
-    assert mod_file.exists()
+    mod = pickle.dumps(algo)
+    _log.info('serialized to %d bytes', len(mod))
 
-    restored = als.ImplicitMF(20)
-    restored.load(mod_file)
+    restored = pickle.loads(mod)
     assert np.all(restored.user_features_ == algo.user_features_)
     assert np.all(restored.item_features_ == algo.item_features_)
     assert np.all(restored.item_index_ == algo.item_index_)

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -2,6 +2,7 @@ import lenskit.algorithms.basic as bl
 from lenskit import util as lku
 
 import logging
+import pickle
 
 import pandas as pd
 import numpy as np
@@ -233,19 +234,17 @@ def test_bias_separate_damping():
         approx(np.array([0.266234, -0.08333, -0.22727]), abs=1.0e-4)
 
 
-def test_bias_save(tmp_path):
-    tmp_path = lktu.norm_path(tmp_path)
-
+def test_bias_save():
     original = bl.Bias(damping=5)
     original.fit(simple_df)
     assert original.mean_ == approx(3.5)
-    fn = tmp_path / 'bias.dat'
 
-    _log.info('saving to %s', fn)
-    original.save(fn)
+    _log.info('saving baseline model')
+    mod = pickle.dumps(original)
+    _log.info('serialized to %d bytes', len(mod))
 
-    algo = bl.Bias()
-    algo.load(fn)
+    algo = pickle.loads(mod)
+
     assert algo.mean_ == original.mean_
 
     assert algo.item_offsets_ is not None

--- a/tests/test_hpf.py
+++ b/tests/test_hpf.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 
 from lenskit.algorithms import hpf
 
@@ -24,7 +25,7 @@ simple_df = pd.DataFrame({'item': [1, 1, 2, 3],
 
 @mark.slow
 @mark.skipif(not have_hpfrec, reason='hpfrec not installed')
-def test_hpf_train_large():
+def test_hpf_train_large(tmp_path):
     algo = hpf.HPF(20)
     ratings = lktu.ml_pandas.renamed.ratings
     ratings = ratings.assign(rating=ratings.rating + 0.5)
@@ -32,6 +33,16 @@ def test_hpf_train_large():
 
     assert algo.n_users == ratings.user.nunique()
     assert algo.n_items == ratings.item.nunique()
+
+    mfile = tmp_path / 'hpf.dat'
+    with mfile.open('wb') as mf:
+        pickle.dump(algo, mf)
+
+    with mfile.open('rb') as mf:
+        a2 = pickle.load(mf)
+
+    assert a2.n_users == algo.n_users
+    assert a2.n_items == algo.n_items
 
 
 @mark.slow

--- a/tests/test_implicit.py
+++ b/tests/test_implicit.py
@@ -36,6 +36,15 @@ def test_implicit_als_train_rec():
     recs = algo.recommend(100, n=20)
     assert len(recs) == 20
 
+    _log.info('serializing implicit model')
+    mod = pickle.dumps(algo)
+    _log.info('serialized to %d bytes')
+    a2 = pickle.loads(mod)
+
+    r2 = a2.recommend(100, n=20)
+    assert len(r2) == 20
+    assert all(r2 == recs)
+
 
 @mark.slow
 @mark.eval
@@ -81,6 +90,15 @@ def test_implicit_bpr_train_rec():
 
     recs = algo.recommend(100, n=20)
     assert len(recs) == 20
+
+    _log.info('serializing implicit model')
+    mod = pickle.dumps(algo)
+    _log.info('serialized to %d bytes')
+    a2 = pickle.loads(mod)
+
+    r2 = a2.recommend(100, n=20)
+    assert len(r2) == 20
+    assert all(r2 == recs)
 
 
 @mark.skipif(not have_implicit, reason='implicit not installed')

--- a/tests/test_knn_item_item.py
+++ b/tests/test_knn_item_item.py
@@ -42,7 +42,7 @@ def test_ii_train():
     assert isinstance(algo.item_index_, pd.Index)
     assert isinstance(algo.item_means_, np.ndarray)
     assert isinstance(algo.item_counts_, np.ndarray)
-    matrix = lm.csr_to_scipy(algo.sim_matrix_)
+    matrix = algo.sim_matrix_.to_scipy()
 
     # 6 is a neighbor of 7
     six, seven = algo.item_index_.get_indexer([6, 7])
@@ -76,7 +76,7 @@ def test_ii_train_unbounded():
     assert all(algo.sim_matrix_.values < 1 + 1.0e-6)
 
     # 6 is a neighbor of 7
-    matrix = lm.csr_to_scipy(algo.sim_matrix_)
+    matrix = algo.sim_matrix_.to_scipy()
     six, seven = algo.item_index_.get_indexer([6, 7])
     assert matrix[six, seven] > 0
 
@@ -230,8 +230,8 @@ def test_ii_large_models():
                          .join(pd.DataFrame({'item_mean': means}))\
                          .assign(rating=lambda df: df.rating - df.item_mean)
 
-    mat_lim = lm.csr_to_scipy(algo_lim.sim_matrix_)
-    mat_ub = lm.csr_to_scipy(algo_ub.sim_matrix_)
+    mat_lim = algo_lim.sim_matrix_.to_scipy()
+    mat_ub = algo_ub.sim_matrix_.to_scipy()
 
     _log.info('checking a sample of neighborhoods')
     items = pd.Series(algo_ub.item_index_)
@@ -334,7 +334,7 @@ def test_ii_save_load(tmp_path):
     means = ml_ratings.groupby('item').rating.mean()
     assert means[algo.item_index_].values == approx(original.item_means_)
 
-    matrix = lm.csr_to_scipy(algo.sim_matrix_)
+    matrix = algo.sim_matrix_.to_scipy()
 
     items = pd.Series(algo.item_index_)
     items = items[algo.item_counts_ > 0]
@@ -390,7 +390,7 @@ def test_ii_implicit_save_load(tmp_path):
 
     assert algo.item_means_ is None
 
-    matrix = lm.csr_to_scipy(algo.sim_matrix_)
+    matrix = algo.sim_matrix_.to_scipy()
 
     items = pd.Series(algo.item_index_)
     items = items[algo.item_counts_ > 0]

--- a/tests/test_knn_user_user.py
+++ b/tests/test_knn_user_user.py
@@ -30,7 +30,7 @@ def test_uu_train():
 
     # we should be able to reconstruct rating values
     uir = ml_ratings.set_index(['user', 'item']).rating
-    r_items = matrix.csr_rowinds(algo.transpose_matrix_)
+    r_items = algo.transpose_matrix_.rowinds()
     ui_rbdf = pd.DataFrame({
         'user': algo.user_index_[algo.transpose_matrix_.colinds],
         'item': algo.item_index_[r_items],
@@ -109,7 +109,7 @@ def test_uu_save_load(tmp_path):
 
     # we should be able to reconstruct rating values
     uir = ml_ratings.set_index(['user', 'item']).rating
-    r_items = matrix.csr_rowinds(algo.transpose_matrix_)
+    r_items = algo.transpose_matrix_.rowinds()
     ui_rbdf = pd.DataFrame({
         'user': algo.user_index_[algo.transpose_matrix_.colinds],
         'item': algo.item_index_[r_items],
@@ -138,7 +138,7 @@ def test_uu_implicit():
     algo.fit(data)
     assert algo.user_means_ is None
 
-    mat = matrix.csr_to_scipy(algo.rating_matrix_)
+    mat = algo.rating_matrix_.to_scipy()
     norms = sps.linalg.norm(mat, 2, 1)
     assert norms == approx(1.0)
 

--- a/tests/test_knn_user_user.py
+++ b/tests/test_knn_user_user.py
@@ -92,11 +92,11 @@ def test_uu_save_load(tmp_path):
 
     fn = tmp_path / 'uu.model'
     _log.info('saving to %s', fn)
-    with open(fn, 'wb') as f:
+    with fn.open('wb') as f:
         pickle.dump(orig, f)
 
     _log.info('reloading model')
-    with open(fn, 'rb') as f:
+    with fn.open('rb') as f:
         algo = pickle.load(f)
 
     _log.info('checking model')

--- a/tests/test_math_solve.py
+++ b/tests/test_math_solve.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import scipy.linalg as sla
 
@@ -5,9 +6,11 @@ from pytest import approx
 
 from lenskit.math.solve import solve_tri, dposv
 
+_runs = int(os.environ.get('RAND_TEST_ITERS', 10))
+
 
 def test_solve_ltri():
-    for i in range(10):
+    for i in range(_runs):
         size = np.random.randint(5, 50)
         Af = np.random.randn(size, size)
         b = np.random.randn(size)
@@ -21,7 +24,7 @@ def test_solve_ltri():
 
 
 def test_solve_ltri_transpose():
-    for i in range(10):
+    for i in range(_runs):
         size = np.random.randint(5, 50)
         Af = np.random.randn(size, size)
         b = np.random.randn(size)
@@ -35,7 +38,7 @@ def test_solve_ltri_transpose():
 
 
 def test_solve_utri():
-    for i in range(10):
+    for i in range(_runs):
         size = np.random.randint(5, 50)
         Af = np.random.randn(size, size)
         b = np.random.randn(size)
@@ -48,7 +51,7 @@ def test_solve_utri():
 
 
 def test_solve_utri_transpose():
-    for i in range(10):
+    for i in range(_runs):
         size = np.random.randint(5, 50)
         Af = np.random.randn(size, size)
         b = np.random.randn(size)
@@ -61,7 +64,7 @@ def test_solve_utri_transpose():
 
 
 def test_solve_cholesky():
-    for i in range(10):
+    for i in range(_runs):
         size = np.random.randint(5, 50)
         A = np.random.randn(size, size)
         b = np.random.randn(size)
@@ -82,7 +85,7 @@ def test_solve_cholesky():
 
 
 def test_solve_dposv():
-    for i in range(10):
+    for i in range(_runs):
         size = np.random.randint(5, 50)
         A = np.random.randn(size, size)
         b = np.random.randn(size)

--- a/tests/test_matrix_csr.py
+++ b/tests/test_matrix_csr.py
@@ -1,4 +1,3 @@
-from itertools import product
 import pickle
 import numpy as np
 import scipy.sparse as sps
@@ -294,40 +293,6 @@ def test_csr_to_sps():
         ep = smat2.indptr[i+1]
         assert all(smat2.indices[sp:ep] == csr.colinds[sp:ep])
         assert all(smat2.data[sp:ep] == csr.values[sp:ep])
-
-
-@mark.parametrize("prefix,values", product([None, 'p_'], [True, False]))
-def test_csr_save_load(tmp_path, prefix, values):
-    tmp_path = lktu.norm_path(tmp_path)
-    coords = np.random.choice(np.arange(50 * 100, dtype=np.int32), 1000, False)
-    rows = np.mod(coords, 100, dtype=np.int32)
-    cols = np.floor_divide(coords, 100, dtype=np.int32)
-    if values:
-        vals = np.random.randn(1000)
-    else:
-        vals = None
-
-    csr = lm.CSR.from_coo(rows, cols, vals, (100, 50))
-    assert csr.nrows == 100
-    assert csr.ncols == 50
-    assert csr.nnz == 1000
-
-    data = lm.csr_save(csr, prefix=prefix)
-
-    np.savez_compressed(tmp_path / 'matrix.npz', **data)
-
-    with np.load(tmp_path / 'matrix.npz') as npz:
-        csr2 = lm.csr_load(npz, prefix=prefix)
-
-    assert csr2.nrows == csr.nrows
-    assert csr2.ncols == csr.ncols
-    assert csr2.nnz == csr.nnz
-    assert all(csr2.rowptrs == csr.rowptrs)
-    assert all(csr2.colinds == csr.colinds)
-    if values:
-        assert all(csr2.values == csr.values)
-    else:
-        assert csr2.values is None
 
 
 @mark.parametrize("values", [True, False])

--- a/tests/test_matrix_csr.py
+++ b/tests/test_matrix_csr.py
@@ -296,8 +296,7 @@ def test_csr_to_sps():
 
 
 @mark.parametrize("values", [True, False])
-def test_csr_pickle(tmp_path, values):
-    tmp_path = lktu.norm_path(tmp_path)
+def test_csr_pickle(values):
     coords = np.random.choice(np.arange(50 * 100, dtype=np.int32), 1000, False)
     rows = np.mod(coords, 100, dtype=np.int32)
     cols = np.floor_divide(coords, 100, dtype=np.int32)

--- a/tests/test_matrix_csr.py
+++ b/tests/test_matrix_csr.py
@@ -1,11 +1,12 @@
 from itertools import product
+import pickle
 import numpy as np
 import scipy.sparse as sps
 
 import lenskit.matrix as lm
 import lk_test_utils as lktu
 
-from pytest import mark, approx
+from pytest import mark, approx, raises
 
 
 @mark.parametrize('copy', [True, False])
@@ -17,7 +18,7 @@ def test_csr_from_sps(copy):
     # make sure it's sparse
     assert smat.nnz == np.sum(mat > 0)
 
-    csr = lm.csr_from_scipy(smat, copy=copy)
+    csr = lm.CSR.from_scipy(smat, copy=copy)
     assert csr.nnz == smat.nnz
     assert csr.nrows == smat.shape[0]
     assert csr.ncols == smat.shape[1]
@@ -38,7 +39,7 @@ def test_csr_is_numpy_compatible():
     # make sure it's sparse
     assert smat.nnz == np.sum(mat > 0)
 
-    csr = lm.csr_from_scipy(smat)
+    csr = lm.CSR.from_scipy(smat)
 
     d2 = csr.values * 10
     assert d2 == approx(smat.data * 10)
@@ -49,11 +50,86 @@ def test_csr_from_coo():
     cols = np.array([1, 2, 0, 1], dtype=np.int32)
     vals = np.arange(4, dtype=np.float_)
 
-    csr = lm.csr_from_coo(rows, cols, vals)
+    csr = lm.CSR.from_coo(rows, cols, vals)
     assert csr.nrows == 4
     assert csr.ncols == 3
     assert csr.nnz == 4
     assert csr.values == approx(vals)
+
+
+def test_csr_rowinds():
+    rows = np.array([0, 0, 1, 3], dtype=np.int32)
+    cols = np.array([1, 2, 0, 1], dtype=np.int32)
+    vals = np.arange(4, dtype=np.float_)
+    csr = lm.CSR.from_coo(rows, cols, vals)
+
+    ris = csr.rowinds()
+    assert all(ris == rows)
+
+
+def test_csr_set_values():
+    rows = np.array([0, 0, 1, 3], dtype=np.int32)
+    cols = np.array([1, 2, 0, 1], dtype=np.int32)
+    vals = np.arange(4, dtype=np.float_)
+
+    csr = lm.CSR.from_coo(rows, cols, vals)
+
+    v2 = np.random.randn(4)
+    csr.values = v2
+
+    assert all(csr.values == v2)
+
+
+def test_csr_set_values_oversize():
+    rows = np.array([0, 0, 1, 3], dtype=np.int32)
+    cols = np.array([1, 2, 0, 1], dtype=np.int32)
+    vals = np.arange(4, dtype=np.float_)
+
+    csr = lm.CSR.from_coo(rows, cols, vals)
+
+    v2 = np.random.randn(6)
+    csr.values = v2
+
+    assert all(csr.values == v2[:4])
+
+
+def test_csr_set_values_undersize():
+    rows = np.array([0, 0, 1, 3], dtype=np.int32)
+    cols = np.array([1, 2, 0, 1], dtype=np.int32)
+    vals = np.arange(4, dtype=np.float_)
+
+    csr = lm.CSR.from_coo(rows, cols, vals)
+
+    v2 = np.random.randn(3)
+
+    with raises(ValueError):
+        csr.values = v2
+
+    assert all(csr.values == vals)
+
+
+def test_csr_set_values_none():
+    rows = np.array([0, 0, 1, 3], dtype=np.int32)
+    cols = np.array([1, 2, 0, 1], dtype=np.int32)
+    vals = np.arange(4, dtype=np.float_)
+
+    csr = lm.CSR.from_coo(rows, cols, vals)
+    csr.values = None
+
+    assert csr.values is None
+    assert all(csr.row(0) == [0, 1, 1])
+    assert all(csr.row(1) == [1, 0, 0])
+    assert all(csr.row(3) == [0, 1, 0])
+
+
+def test_csr_str():
+    rows = np.array([0, 0, 1, 3], dtype=np.int32)
+    cols = np.array([1, 2, 0, 1], dtype=np.int32)
+    vals = np.arange(4, dtype=np.float_)
+
+    csr = lm.CSR.from_coo(rows, cols, vals)
+
+    assert '4x3' in str(csr)
 
 
 def test_csr_row():
@@ -61,7 +137,7 @@ def test_csr_row():
     cols = np.array([1, 2, 0, 1], dtype=np.int32)
     vals = np.arange(4, dtype=np.float_) + 1
 
-    csr = lm.csr_from_coo(rows, cols, vals)
+    csr = lm.CSR.from_coo(rows, cols, vals)
     assert all(csr.row(0) == np.array([0, 1, 2], dtype=np.float_))
     assert all(csr.row(1) == np.array([3, 0, 0], dtype=np.float_))
     assert all(csr.row(2) == np.array([0, 0, 0], dtype=np.float_))
@@ -73,7 +149,7 @@ def test_csr_sparse_row():
     cols = np.array([1, 2, 0, 1], dtype=np.int32)
     vals = np.arange(4, dtype=np.float_)
 
-    csr = lm.csr_from_coo(rows, cols, vals)
+    csr = lm.CSR.from_coo(rows, cols, vals)
     assert all(csr.row_cs(0) == np.array([1, 2], dtype=np.int32))
     assert all(csr.row_cs(1) == np.array([0], dtype=np.int32))
     assert all(csr.row_cs(2) == np.array([], dtype=np.int32))
@@ -90,7 +166,7 @@ def test_csr_transpose():
     cols = np.array([1, 2, 0, 1], dtype=np.int32)
     vals = np.arange(4, dtype=np.float_)
 
-    csr = lm.csr_from_coo(rows, cols, vals)
+    csr = lm.CSR.from_coo(rows, cols, vals)
     csc = csr.transpose()
     assert csc.nrows == csr.ncols
     assert csc.ncols == csr.nrows
@@ -109,8 +185,8 @@ def test_csr_transpose_coords():
     cols = np.array([1, 2, 0, 1], dtype=np.int32)
     vals = np.arange(4, dtype=np.float_)
 
-    csr = lm.csr_from_coo(rows, cols, vals)
-    csc = csr.transpose_coords()
+    csr = lm.CSR.from_coo(rows, cols, vals)
+    csc = csr.transpose(False)
     assert csc.nrows == csr.ncols
     assert csc.ncols == csr.nrows
 
@@ -130,7 +206,7 @@ def test_csr_row_nnzs():
     smat = sps.csr_matrix(mat)
     # make sure it's sparse
     assert smat.nnz == np.sum(mat > 0)
-    csr = lm.csr_from_scipy(smat)
+    csr = lm.CSR.from_scipy(smat)
 
     nnzs = csr.row_nnzs()
     assert nnzs.sum() == csr.nnz
@@ -146,7 +222,8 @@ def test_csr_from_coo_rand():
         cols = np.floor_divide(coords, 100, dtype=np.int32)
         vals = np.random.randn(1000)
 
-        csr = lm.csr_from_coo(rows, cols, vals, (100, 50))
+        csr = lm.CSR.from_coo(rows, cols, vals, (100, 50))
+        rowinds = csr.rowinds()
         assert csr.nrows == 100
         assert csr.ncols == 50
         assert csr.nnz == 1000
@@ -162,6 +239,8 @@ def test_csr_from_coo_rand():
             assert all(np.sort(csr.colinds[sp:ep]) == cols[points])
             assert all(np.sort(csr.row_cs(i)) == cols[points])
             assert all(csr.values[np.argsort(csr.colinds[sp:ep]) + sp] == vals[points])
+            assert all(rowinds[sp:ep] == i)
+
             row = np.zeros(50)
             row[cols[points]] = vals[points]
             assert np.sum(csr.row(i)) == approx(np.sum(vals[points]))
@@ -174,7 +253,7 @@ def test_csr_from_coo_novals():
         rows = np.mod(coords, 100, dtype=np.int32)
         cols = np.floor_divide(coords, 100, dtype=np.int32)
 
-        csr = lm.csr_from_coo(rows, cols, None, (100, 50))
+        csr = lm.CSR.from_coo(rows, cols, None, (100, 50))
         assert csr.nrows == 100
         assert csr.ncols == 50
         assert csr.nnz == 1000
@@ -199,12 +278,12 @@ def test_csr_to_sps():
     # make sure it's sparse
     assert smat.nnz == np.sum(mat > 0)
 
-    csr = lm.csr_from_coo(smat.row, smat.col, smat.data, shape=smat.shape)
+    csr = lm.CSR.from_coo(smat.row, smat.col, smat.data, shape=smat.shape)
     assert csr.nnz == smat.nnz
     assert csr.nrows == smat.shape[0]
     assert csr.ncols == smat.shape[1]
 
-    smat2 = lm.csr_to_scipy(csr)
+    smat2 = csr.to_scipy()
     assert sps.isspmatrix(smat2)
     assert sps.isspmatrix_csr(smat2)
 
@@ -228,7 +307,7 @@ def test_csr_save_load(tmp_path, prefix, values):
     else:
         vals = None
 
-    csr = lm.csr_from_coo(rows, cols, vals, (100, 50))
+    csr = lm.CSR.from_coo(rows, cols, vals, (100, 50))
     assert csr.nrows == 100
     assert csr.ncols == 50
     assert csr.nnz == 1000
@@ -239,6 +318,36 @@ def test_csr_save_load(tmp_path, prefix, values):
 
     with np.load(tmp_path / 'matrix.npz') as npz:
         csr2 = lm.csr_load(npz, prefix=prefix)
+
+    assert csr2.nrows == csr.nrows
+    assert csr2.ncols == csr.ncols
+    assert csr2.nnz == csr.nnz
+    assert all(csr2.rowptrs == csr.rowptrs)
+    assert all(csr2.colinds == csr.colinds)
+    if values:
+        assert all(csr2.values == csr.values)
+    else:
+        assert csr2.values is None
+
+
+@mark.parametrize("values", [True, False])
+def test_csr_pickle(tmp_path, values):
+    tmp_path = lktu.norm_path(tmp_path)
+    coords = np.random.choice(np.arange(50 * 100, dtype=np.int32), 1000, False)
+    rows = np.mod(coords, 100, dtype=np.int32)
+    cols = np.floor_divide(coords, 100, dtype=np.int32)
+    if values:
+        vals = np.random.randn(1000)
+    else:
+        vals = None
+
+    csr = lm.CSR.from_coo(rows, cols, vals, (100, 50))
+    assert csr.nrows == 100
+    assert csr.ncols == 50
+    assert csr.nnz == 1000
+
+    data = pickle.dumps(csr)
+    csr2 = pickle.loads(data)
 
     assert csr2.nrows == csr.nrows
     assert csr2.ncols == csr.ncols

--- a/tests/test_matrix_mkl.py
+++ b/tests/test_matrix_mkl.py
@@ -18,7 +18,7 @@ def test_mkl_mult_vec():
         s = sps.csr_matrix(M)
         assert s.nnz == np.sum(M > 0)
 
-        csr = lm.csr_from_scipy(s)
+        csr = lm.CSR.from_scipy(s)
         mklM = mkl_ops.SparseM.from_csr(csr)
 
         x = np.random.randn(n)
@@ -40,10 +40,10 @@ def test_mkl_syrk():
         s = sps.csr_matrix(M)
         assert s.nnz == np.sum(M > 0)
 
-        csr = lm.csr_from_scipy(s)
+        csr = lm.CSR.from_scipy(s)
 
         ctc = mkl_ops.csr_syrk(csr)
-        res = lm.csr_to_scipy(ctc).toarray()
+        res = ctc.to_scipy().toarray()
         res = res.T + res
         rd = np.diagonal(res)
         res = res - np.diagflat(rd) * 0.5


### PR DESCRIPTION
This removes our custom save/load support in favor of Python pickling, like SciKit-Learn. Implements #61.

- [x] Make CSR class pickleable
- [x] Item KNN picklable
- [x] User KNN picklable
- [x] MF picklable
- [x] Implicit picklable
- [x] HPF picklable
- [ ] Remove old save/load infrastructure