### PR TITLE
Rewrite top-N metric support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -247,8 +247,6 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python37:
-        python.version: '3.7'
     maxParallel: 4
 
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,8 +230,15 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      python -m pytest
-    displayName: 'pytest'
+      python -m pytest --junitxml=build/test-results.xml
+    displayName: 'Test LKPY'
+  
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: 'build/test-results.xml'
+      testRunTitle: 'Publish test results for Windows Python $(python.version)'
+
 
 - job: 'WindowsConda'
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -258,6 +258,9 @@ jobs:
       environmentName: lkpy
       packageSpecs: $(conda.deps)
 
+  - script: conda update -y --all
+    displayName: 'Refresh Conda'
+
   - script: |
       pip install $(pip.extras)
     displayName: 'Extra PyPI deps'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,6 +217,7 @@ jobs:
       Python37:
         python.version: '3.7'
     maxParallel: 4
+  condition: False
 
   steps:
   - task: UsePythonVersion@0
@@ -246,8 +247,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      # Python37:
-      #   python.version: '3.7'
+      Python37:
+        python.version: '3.7'
     maxParallel: 4
 
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   conda.deps: >
     python=$(python.version)
-    pandas scipy fastparquet python-snappy numba cffi pyarrow
+    pandas numpy scipy fastparquet python-snappy numba cffi pyarrow
     invoke coverage pytest pytest-cov pytest-doctestplus cython
   pip.deps: >
     invoke pytest coverage pytest-cov pytest-doctestplus

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   conda.deps: >
     python=$(python.version)
-    pandas scipy fastparquet python-snappy numba cffi
+    pandas scipy fastparquet python-snappy numba cffi pyarrow
     invoke coverage pytest pytest-cov pytest-doctestplus cython
   pip.deps: >
     invoke pytest coverage pytest-cov pytest-doctestplus

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,7 +230,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      python -m pytest --junitxml=build/test-results.xml --log-file=build/test.log --log-file-level=DEBUG
+      python -m pytest --junitxml=build/test-results.xml
     displayName: 'Test LKPY'
   
   - task: PublishTestResults@2
@@ -238,12 +238,6 @@ jobs:
     inputs:
       testResultsFiles: 'build/test-results.xml'
       testRunTitle: 'Publish test results for Windows Python $(python.version)'
-
-  - task: PublishBuildArtifacts@1
-    condition: succeededOrFailed()
-    inputs:
-      pathtoPublish: build/test.log
-      artifactName: Test log $(python.version)
 
 - job: 'WindowsConda'
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,7 +230,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      python -m pytest --junitxml=build/test-results.xml
+      python -m pytest --junitxml=build/test-results.xml --log-file=build/test.log --log-file-level=DEBUG
     displayName: 'Test LKPY'
   
   - task: PublishTestResults@2
@@ -239,6 +239,11 @@ jobs:
       testResultsFiles: 'build/test-results.xml'
       testRunTitle: 'Publish test results for Windows Python $(python.version)'
 
+  - task: PublishBuildArtifacts@1
+    condition: succeededOrFailed()
+    inputs:
+      pathtoPublish: build/test.log
+      artifactName: Test log $(python.version)
 
 - job: 'WindowsConda'
   pool:

--- a/doc/evaluation/predict-metrics.rst
+++ b/doc/evaluation/predict-metrics.rst
@@ -3,10 +3,20 @@ Prediction Accuracy Metrics
 
 .. module:: lenskit.metrics.predict
 
-The :py:mod:`lenskit.metrics.predict` module containins prediction accuracy metrics.
+The :py:mod:`lenskit.metrics.predict` module contains prediction accuracy metrics.
+These are intended to be used as a part of a Pandas split-apply-combine operation
+on a data frame that contains both predictions and ratings; for convenience, the
+:py:func:`lenskit.batch.predict` function will include ratings in the prediction
+frame when its input user-item pairs contains ratings.  So you can perform the
+following to compute per-user RMSE over some predictions::
+
+    preds = predict(algo, pairs)
+    user_rmse = preds.groupby('user').apply(lambda df: rmse(df.prediction, df.rating))
 
 Metric Functions
 ----------------
+
+Prediction metric functions take two series, `predictions` and `truth`.
 
 .. autofunction:: rmse
 .. autofunction:: mae

--- a/doc/evaluation/topn-metrics.rst
+++ b/doc/evaluation/topn-metrics.rst
@@ -1,5 +1,61 @@
-Top-*N* Accuracy Metrics
-~~~~~~~~~~~~~~~~~~~~~~~~
+Top-*N* Evaluation
+~~~~~~~~~~~~~~~~~~
+
+LensKit's support for top-*N* evaluation is in two parts, because there are some
+subtle complexities that make it more dfficult to get the right data in the right
+place for computing metrics correctly.
+
+Top-*N* Analysis
+================
+
+.. module:: lenskit.topn
+
+The :py:mod:`lenskit.topn` module contains the utilities for carrying out top-*N*
+analysis, in conjucntion with :py:func:`lenskit.batch.recommend` and its wrapper
+in :py:class:`lenskit.batch.MultiEval`.
+
+The entry point to this is :py:class:`RecListAnalysis`.  This class encapsulates
+an analysis with one or more metrics, and can apply it to data frames of recommendations.
+An analysis requires two data frames: the recommendation frame contains the recommendations
+themselves, and the truth frame contains the ground truth data for the users.  The
+analysis is flexible with regards to the columns that identify individual recommendation
+lists; usually these will consist of a user ID, data set identifier, and algorithm
+identifier(s), but the analysis is configurable and its defaults make minimal assumptions.
+The recommendation frame does need an ``item`` column with the recommended item IDs,
+and it should be in order within a single recommendation list.
+
+The truth frame should contain (a subset of) the columns identifying recommendation
+lists, along with ``item`` and, if available, ``rating`` (if no rating is provided,
+the metrics that need a rating value will assume a rating of 1 for every item present).
+It can contain other items that custom metrics may find useful as well.
+
+For example, a recommendation frame may contain:
+
+* DataSet
+* Partition
+* Algorithm
+* user
+* item
+* rank
+* score
+
+And the truth frame:
+
+* DataSet
+* user
+* item
+* rating
+
+The analysis will use this truth as the relevant item data for measuring the accuracy of the
+roecommendation lists.  Recommendations will be matched to test ratings by data set, user, 
+and item, using :py:class:`RecListAnalysis` defaults.
+
+.. autoclass:: RecListAnalysis
+    :members:
+
+
+Metrics
+=======
 
 .. module:: lenskit.metrics.topn
 
@@ -25,8 +81,11 @@ be relevant.
 Utility Metrics
 ---------------
 
-The DCG function estimates a utility score for a ranked list of recommendations.  The results
-can be combined with ideal DCGs to compute nDCG.
+The NDCG function estimates a utility score for a ranked list of recommendations.
 
-.. autofunction:: dcg
-.. autofunction:: compute_ideal_dcgs
+.. autofunction:: ndcg
+
+
+We also expose the internal DCG computation directly.
+
+.. autofunction:: _dcg

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -6,6 +6,9 @@ See the [GitHub milestone](https://github.com/lenskit/lkpy/milestone/1) for a su
 
 - The `save` and `load` methods on algorithms have been removed.  Just pickle fitted models to save
   their data.  This is what SciKit does, see no need to deviate.
+- Top-*N* evaluation has been completely revamped to make it easier to correctly implement and run
+  evaluation metrics.  Batch recommend no longer attaches ratings to recommendations.
+- Batch recommend & predict functions now take `nprocs` as keyword-only.
 - Several bug fixes and testing improvements
 
 ### Internal Changes

--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -297,7 +297,7 @@ class MultiEval:
         watch = util.Stopwatch()
         users = test.user.unique()
         _logger.info('generating recommendations for %d users for %s', len(users), algo)
-        recs = recommend(algo, users, self.recommend, candidates, test,
+        recs = recommend(algo, users, self.recommend, candidates,
                          nprocs=self.nprocs)
         watch.stop()
         _logger.info('generated recommendations in %s', watch)

--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -321,12 +321,12 @@ class MultiEval:
 
         if self.combine_output:
             out = self.workdir / '{}.parquet'.format(name)
-            _logger.info('run %d: writing predictions to %s', run_id, out)
+            _logger.info('run %d: writing results to %s', run_id, out)
             append = run_id > 1
             util.write_parquet(out, df, append=append)
         else:
             out = self.workdir / '{}-{}.parquet'.format(name, run_id)
-            _logger.info('run %d: writing predictions to %s', run_id, out)
+            _logger.info('run %d: writing results to %s', run_id, out)
             df.to_parquet(out)
 
     def collect_results(self):

--- a/lenskit/batch/_predict.py
+++ b/lenskit/batch/_predict.py
@@ -41,7 +41,7 @@ def _predict_worker(job):
     return res.to_msgpack()
 
 
-def predict(algo, pairs, nprocs=None):
+def predict(algo, pairs, *, nprocs=None):
     """
     Generate predictions for user-item pairs.  The provided algorithm should be a
     :py:class:`algorithms.Predictor` or a function of two arguments: the user ID and

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -78,8 +78,10 @@ def recip_rank(recs, relevant):
 
 def _dcg(scores, discount=np.log2):
     ranks = np.arange(1, len(scores) + 1)
-    disc = np.maximum(discount(ranks), 1)
-    return np.dot(scores, 1.0/disc)
+    disc = discount(ranks)
+    np.maximum(disc, 1, out=disc)
+    np.reciprocal(disc, out=disc)
+    return np.dot(scores, disc)
 
 
 def dcg(scores, discount=np.log2):
@@ -115,9 +117,7 @@ def dcg(scores, discount=np.log2):
         double: the DCG of the scored items.
     """
 
-    scores = pd.Series(scores)
-    scores = scores.fillna(0)
-
+    scores = np.nan_to_num(scores, copy=False)
     return _dcg(scores, discount)
 
 

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -2,15 +2,13 @@
 Top-N evaluation metrics.
 """
 
-import pandas as pd
 import numpy as np
 
 
 def precision(recs, truth):
     """
-    Compute the precision of a set of recommendations.
+    Compute recommendation precision.
     """
-
     nrecs = len(recs)
     if nrecs == 0:
         return None
@@ -21,9 +19,8 @@ def precision(recs, truth):
 
 def recall(recs, truth):
     """
-    Compute the recall of a set of recommendations.
+    Compute recommendation recall.
     """
-
     nrel = len(truth)
     if nrel == 0:
         return None
@@ -63,7 +60,6 @@ def _dcg(scores, discount=np.log2):
     Returns:
         double: the DCG of the scored items.
     """
-
     scores = np.nan_to_num(scores, copy=False)
     ranks = np.arange(1, len(scores) + 1)
     disc = discount(ranks)

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -99,10 +99,10 @@ class RecListAnalysis:
             g_rows = grouped.indices[row_key]
             g_recs = recs.iloc[g_rows, :]
             if len(ti_cols) == len(gcols) + 1:
-                tr_key = row_key
+                tr_key = row_key if isinstance(row_key, tuple) else (row_key,)
             else:
                 tr_key = tuple([row_key[gc_map[c]] for c in ti_cols[:-1]])
-            _log.info(tr_key)
+
             g_truth = truth.loc[tr_key, :]
             for j, (mf, mn, margs) in enumerate(self.metrics):
                 res.iloc[i, j] = mf(g_recs, g_truth, **margs)

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -99,7 +99,7 @@ class RecListAnalysis:
             g_rows = grouped.indices[row_key]
             g_recs = recs.iloc[g_rows, :]
             if len(ti_cols) == len(gcols) + 1:
-                tr_key = row_key if isinstance(row_key, tuple) else (row_key,)
+                tr_key = row_key
             else:
                 tr_key = tuple([row_key[gc_map[c]] for c in ti_cols[:-1]])
 

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -5,106 +5,7 @@ import pandas as pd
 
 _log = logging.getLogger(__name__)
 
-
-def precision(recs, truth):
-    """
-    Compute the precision of a set of recommendations.
-    """
-
-    nrecs = len(recs)
-    if nrecs == 0:
-        return None
-
-    ngood = recs['item'].isin(truth.index).sum()
-    return ngood / nrecs
-
-
-def recall(recs, truth):
-    """
-    Compute the recall of a set of recommendations.
-    """
-
-    nrel = len(truth)
-    if nrel == 0:
-        return None
-
-    ngood = recs['item'].isin(truth.index).sum()
-    return ngood / nrel
-
-
-def recip_rank(recs, truth):
-    """
-    Compute the reciprocal rank of the first relevant item in a list of recommendations.
-
-    If no elements are relevant, the reciprocal rank is 0.
-    """
-    good = recs['item'].isin(truth.index)
-    npz, = np.nonzero(good)
-    if len(npz):
-        return 1.0 / (npz[0] + 1.0)
-    else:
-        return 0.0
-
-
-def _dcg(scores, discount=np.log2):
-    """
-    Compute the Discounted Cumulative Gain of a series of recommended items with rating scores.
-    These should be relevance scores; they can be :math:`{0,1}` for binary relevance data.
-
-    Args:
-        scores(array-like):
-            The utility scores of a list of recommendations, in recommendation order.
-        discount(ufunc):
-            the rank discount function.  Each item's score will be divided the discount of its rank,
-            if the discount is greater than 1.
-
-    Returns:
-        double: the DCG of the scored items.
-    """
-
-    scores = np.nan_to_num(scores, copy=False)
-    ranks = np.arange(1, len(scores) + 1)
-    disc = discount(ranks)
-    np.maximum(disc, 1, out=disc)
-    np.reciprocal(disc, out=disc)
-    return np.dot(scores, disc)
-
-
-def ndcg(recs, truth, discount=np.log2):
-    """
-    Compute the normalized discounted cumulative gain.
-
-    Discounted cumultative gain is computed as:
-
-    .. math::
-        \\begin{align*}
-        \\mathrm{DCG}(L,u) & = \\sum_{i=1}^{|L|} \\frac{r_{ui}}{d(i)}
-        \\end{align*}
-
-    This is then normalized as follows:
-
-    .. math::
-        \\begin{align*}
-        \\mathrm{nDCG}(L, u) & = \\frac{\\mathrm{DCG}(L,u)}{\\mathrm{DCG}(L_{\\mathrm{ideal}}, u)}
-        \\end{align*}
-
-    Args:
-        recs: The recommendation list.
-        truth: The user's test data.
-        discount(ufunc):
-            The rank discount function.  Each item's score will be divided the discount of its rank,
-            if the discount is greater than 1.
-    """
-    if 'rating' in truth.columns:
-        ideal = _dcg(truth.rating.sort_values(ascending=False), discount)
-        merged = recs[['item']].join(truth[['rating']], on='item', how='left')
-        achieved = _dcg(merged.rating, discount)
-    else:
-        ideal = _dcg(np.ones(len(truth)), discount)
-        achieved = _dcg(recs.item.isin(truth.index), discount)
-
-    return achieved / ideal
-
+from .metrics.topn import *
 
 class RecListAnalysis:
     """
@@ -141,9 +42,8 @@ class RecListAnalysis:
 
         A metric is a function of two arguments: the a single group of the recommendation
         frame, and the corresponding truth frame.  The truth frame will be indexed by
-        item ID.  The metric functions in this module are usable; the
-        :mod:`lenskit.metrics.topn` module provides underlying implementations
-        for some of them that operate on more raw structures.
+        item ID.  The metrics are defined in :mod:`lenskit.metrics.topn`; they are
+        re-exported from :mod:`lenskit.topn` for convenience.
 
         Args:
             metric: The metric to compute.

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -91,7 +91,7 @@ class RecListAnalysis:
 
         res = pd.DataFrame(od((k, np.nan) for (f, k, args) in self.metrics),
                            index=grouped.grouper.result_index)
-        assert len(res) == len(grouped.groups)
+        assert len(res) == len(grouped.groups), "result set size {} != group count {}".format(len(res), len(grouped.groups))
         assert res.index.nlevels == len(gcols)
 
         for i, row_key in enumerate(res.index):

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -1,5 +1,105 @@
 import numpy as np
 
+
+def precision(recs, truth):
+    """
+    Compute the precision of a set of recommendations.
+    """
+
+    nrecs = len(recs)
+    if nrecs == 0:
+        return None
+
+    ngood = recs['item'].isin(truth.index).sum()
+    return ngood / nrecs
+
+
+def recall(recs, truth):
+    """
+    Compute the recall of a set of recommendations.
+    """
+
+    nrel = len(truth)
+    if nrel == 0:
+        return None
+
+    ngood = recs['item'].isin(truth.index).sum()
+    return ngood / nrel
+
+
+def recip_rank(recs, truth):
+    """
+    Compute the reciprocal rank of the first relevant item in a list of recommendations.
+
+    If no elements are relevant, the reciprocal rank is 0.
+    """
+    good = recs['item'].isin(truth.index)
+    npz, = np.nonzero(good)
+    if len(npz):
+        return 1.0 / (npz[0] + 1.0)
+    else:
+        return 0.0
+
+
+def _dcg(scores, discount=np.log2):
+    """
+    Compute the Discounted Cumulative Gain of a series of recommended items with rating scores.
+    These should be relevance scores; they can be :math:`{0,1}` for binary relevance data.
+
+    Args:
+        scores(array-like):
+            The utility scores of a list of recommendations, in recommendation order.
+        discount(ufunc):
+            the rank discount function.  Each item's score will be divided the discount of its rank,
+            if the discount is greater than 1.
+
+    Returns:
+        double: the DCG of the scored items.
+    """
+
+    scores = np.nan_to_num(scores, copy=False)
+    ranks = np.arange(1, len(scores) + 1)
+    disc = discount(ranks)
+    np.maximum(disc, 1, out=disc)
+    np.reciprocal(disc, out=disc)
+    return np.dot(scores, disc)
+
+
+def ndcg(recs, truth, discount=np.log2):
+    """
+    Compute the normalized discounted cumulative gain.
+
+    Discounted cumultative gain is computed as:
+
+    .. math::
+        \\begin{align*}
+        \\mathrm{DCG}(L,u) & = \\sum_{i=1}^{|L|} \\frac{r_{ui}}{d(i)}
+        \\end{align*}
+
+    This is then normalized as follows:
+
+    .. math::
+        \\begin{align*}
+        \\mathrm{nDCG}(L, u) & = \\frac{\\mathrm{DCG}(L,u)}{\\mathrm{DCG}(L_{\\mathrm{ideal}}, u)}
+        \\end{align*}
+
+    Args:
+        recs: The recommendation list.
+        truth: The user's test data.
+        discount(ufunc):
+            The rank discount function.  Each item's score will be divided the discount of its rank,
+            if the discount is greater than 1.
+    """
+    if 'rating' in truth.columns:
+        ideal = _dcg(truth.rating.sort_values(ascending=False), discount)
+        merged = recs[['item']].join(truth[['rating']], on='item', how='left')
+        achieved = _dcg(merged.rating, discount)
+    else:
+        ideal = _dcg(np.ones(len(truth)), discount)
+        achieved = _dcg(recs.item.isin(truth.index), discount)
+
+    return achieved / ideal
+
 from .metrics.topn import *
 
 

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -91,7 +91,8 @@ class RecListAnalysis:
 
         res = pd.DataFrame(od((k, np.nan) for (f, k, args) in self.metrics),
                            index=grouped.grouper.result_index)
-        assert len(res) == len(grouped.groups), "result set size {} != group count {}".format(len(res), len(grouped.groups))
+        assert len(res) == len(grouped.groups), \
+            "result set size {} != group count {}".format(len(res), len(grouped.groups))
         assert res.index.nlevels == len(gcols)
 
         for i, row_key in enumerate(res.index):

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -185,8 +185,8 @@ class RecListAnalysis:
         key = key.iloc[[0], :]
         g_truth = key.join(truth, on=cols)
         g_truth = g_truth.set_index('item')
-        vals = dict((k, f(recs, truth, **args)) for (f, k, args) in self.metrics)
-        return pd.DataFrame(vals)
+        vals = dict((k, f(recs, g_truth, **args)) for (f, k, args) in self.metrics)
+        return pd.Series(vals)
 
 
 class UnratedCandidates:

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -117,6 +117,7 @@ class RecListAnalysis:
     * ``item``
     * ``rank``
     * ``score``
+    * ``rating``
 
     The truth frame, ``truth``, is expected to match over (a subset of) the
     grouping columns, and contain at least an ``item`` column.  If it also
@@ -128,7 +129,7 @@ class RecListAnalysis:
             The columns to group by, or ``None`` to use the default.
     """
 
-    DEFAULT_SKIP_COLS = ['item', 'rank', 'score']
+    DEFAULT_SKIP_COLS = ['item', 'rank', 'score', 'rating']
 
     def __init__(self, group_cols=None):
         self.group_cols = group_cols

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -3,9 +3,10 @@ import logging
 import numpy as np
 import pandas as pd
 
+from .metrics.topn import *
+
 _log = logging.getLogger(__name__)
 
-from .metrics.topn import *
 
 class RecListAnalysis:
     """

--- a/lenskit/util.py
+++ b/lenskit/util.py
@@ -217,6 +217,9 @@ def write_parquet(path, frame, append=False):
     """
     fn = fspath(path)
     append = append and os.path.exists(fn)
+    _log.debug('%s %d rows to Parquet file %s',
+               'appending' if append else 'writing',
+               len(frame), fn)
     if fastparquet is not None:
         fastparquet.write(fn, frame, append=append, compression='snappy')
     elif append:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-log_level=INFO
+log_level=DEBUG
 doctest_plus=enabled
 filterwarnings =
     ignore:.*matrix subclass.*:PendingDeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import logging
+from pytest import fixture
+
+_log = logging.getLogger('lenskit.tests')
+
+
+@fixture(autouse=True)
+def log_test(request):
+    _log.info('running test %s:%s', request.module.__name__, request.function.__name__)

--- a/tests/test_batch_recommend.py
+++ b/tests/test_batch_recommend.py
@@ -91,11 +91,7 @@ def test_bias_batch_recommend():
         _log.info('testing %d users', test.user.nunique())
         cand_fun = topn.UnratedCandidates(train)
         recs = batch.recommend(algo, test.user.unique(), 100, cand_fun)
-        # combine with test ratings for relevance data
-        res = pd.merge(recs, test, how='left', on=('user', 'item'))
-        # fill in missing 0s
-        res.loc[res.rating.isna(), 'rating'] = 0
-        return res
+        return recs
 
     folds = list(xf.partition_users(ratings, 5, xf.SampleFrac(0.2)))
     test = pd.concat(y for (x, y) in folds)

--- a/tests/test_batch_recommend.py
+++ b/tests/test_batch_recommend.py
@@ -77,7 +77,6 @@ def test_bias_batch_recommend():
     from lenskit.algorithms import basic
     import lenskit.crossfold as xf
     from lenskit import batch, topn
-    import lenskit.metrics.topn as lm
 
     if not os.path.exists('ml-100k/u.data'):
         raise pytest.skip()
@@ -98,13 +97,17 @@ def test_bias_batch_recommend():
         res.loc[res.rating.isna(), 'rating'] = 0
         return res
 
-    recs = pd.concat((eval(train, test)
-                      for (train, test)
-                      in xf.partition_users(ratings, 5, xf.SampleFrac(0.2))))
+    folds = list(xf.partition_users(ratings, 5, xf.SampleFrac(0.2)))
+    test = pd.concat(y for (x, y) in folds)
+
+    recs = pd.concat(eval(train, test) for (train, test) in folds)
 
     _log.info('analyzing recommendations')
-    dcg = recs.groupby('user').rating.apply(lm.dcg)
-    _log.info('DCG for %d users is %f (max=%f)', len(dcg), dcg.mean(), dcg.max())
+    rla = topn.RecListAnalysis()
+    rla.add_metric(topn.ndcg)
+    results = rla.compute(recs, test)
+    dcg = results.ndcg
+    _log.info('nDCG for %d users is %f (max=%f)', len(dcg), dcg.mean(), dcg.max())
     assert dcg.mean() > 0
 
 
@@ -113,7 +116,6 @@ def test_pop_batch_recommend(ncpus):
     from lenskit.algorithms import basic
     import lenskit.crossfold as xf
     from lenskit import batch, topn
-    import lenskit.metrics.topn as lm
 
     if not os.path.exists('ml-100k/u.data'):
         raise pytest.skip()
@@ -128,15 +130,18 @@ def test_pop_batch_recommend(ncpus):
         _log.info('testing %d users', test.user.nunique())
         cand_fun = topn.UnratedCandidates(train)
         recs = batch.recommend(algo, test.user.unique(), 100, cand_fun,
-                               test, nprocs=ncpus)
+                               nprocs=ncpus)
         return recs
 
-    recs = pd.concat((eval(train, test)
-                      for (train, test)
-                      in xf.partition_users(ratings, 5, xf.SampleFrac(0.2))))
+    folds = list(xf.partition_users(ratings, 5, xf.SampleFrac(0.2)))
+    test = pd.concat(f.test for f in folds)
+
+    recs = pd.concat(eval(train, test) for (train, test) in folds)
 
     _log.info('analyzing recommendations')
-    _log.info('have %d recs for good items', (recs.rating > 0).sum())
-    dcg = recs.groupby('user').rating.agg(lm.dcg)
-    _log.info('DCG for %d users is %f (max=%f)', len(dcg), dcg.mean(), dcg.max())
+    rla = topn.RecListAnalysis()
+    rla.add_metric(topn.ndcg)
+    results = rla.compute(recs, test)
+    dcg = results.ndcg
+    _log.info('NDCG for %d users is %f (max=%f)', len(dcg), dcg.mean(), dcg.max())
     assert dcg.mean() > 0

--- a/tests/test_hpf.py
+++ b/tests/test_hpf.py
@@ -52,7 +52,6 @@ def test_hpf_train_large(tmp_path):
 def test_hpf_batch_accuracy():
     import lenskit.crossfold as xf
     from lenskit import batch, topn
-    import lenskit.metrics.topn as lm
 
     ratings = lktu.ml100k.load_ratings()
 
@@ -65,13 +64,18 @@ def test_hpf_batch_accuracy():
         users = test.user.unique()
         _log.info('testing %d users', len(users))
         candidates = topn.UnratedCandidates(train)
-        recs = batch.recommend(algo, users, 100, candidates, test)
+        recs = batch.recommend(algo, users, 100, candidates)
         return recs
 
-    folds = xf.partition_users(ratings, 5, xf.SampleFrac(0.2))
+    folds = list(xf.partition_users(ratings, 5, xf.SampleFrac(0.2)))
+    test = pd.concat(f.test for f in folds)
+
     recs = pd.concat(eval(train, test) for (train, test) in folds)
 
     _log.info('analyzing recommendations')
-    dcg = recs.groupby('user').rating.apply(lm.dcg)
-    _log.info('dcg for users is %.4f', dcg.mean())
+    rla = topn.RecListAnalysis()
+    rla.add_metric(topn.ndcg)
+    results = rla.compute(recs, test)
+    dcg = results.ndcg
+    _log.info('nDCG for users is %.4f', dcg.mean())
     assert dcg.mean() > 0

--- a/tests/test_knn_item_item.py
+++ b/tests/test_knn_item_item.py
@@ -505,11 +505,7 @@ def test_ii_batch_recommend(ncpus):
         _log.info('testing %d users', test.user.nunique())
         cand_fun = topn.UnratedCandidates(train)
         recs = batch.recommend(algo, test.user.unique(), 100, cand_fun, nprocs=ncpus)
-        # combine with test ratings for relevance data
-        res = pd.merge(recs, test, how='left', on=('user', 'item'))
-        # fill in missing 0s
-        res.loc[res.rating.isna(), 'rating'] = 0
-        return res
+        return recs
 
     test_frames = []
     recs = []

--- a/tests/test_knn_user_user.py
+++ b/tests/test_knn_user_user.py
@@ -249,7 +249,7 @@ def test_uu_implicit_batch_accuracy():
     algo = knn.UserUser(30, center=False, aggregate='sum')
 
     folds = list(xf.partition_users(ratings, 5, xf.SampleFrac(0.2)))
-    test = pd.concat(f.test for f in folds)
+    all_test = pd.concat(f.test for f in folds)
 
     rec_lists = []
     for train, test in folds:
@@ -263,7 +263,7 @@ def test_uu_implicit_batch_accuracy():
 
     rla = topn.RecListAnalysis()
     rla.add_metric(topn.ndcg)
-    results = rla.compute(recs, test)
+    results = rla.compute(recs, all_test)
     user_dcg = results.ndcg
 
     dcg = user_dcg.mean()

--- a/tests/test_knn_user_user.py
+++ b/tests/test_knn_user_user.py
@@ -243,23 +243,28 @@ def test_uu_batch_accuracy():
 def test_uu_implicit_batch_accuracy():
     from lenskit import batch, topn
     import lenskit.crossfold as xf
-    import lenskit.metrics.topn as lm
 
     ratings = lktu.ml100k.load_ratings()
 
     algo = knn.UserUser(30, center=False, aggregate='sum')
 
-    folds = xf.partition_users(ratings, 5, xf.SampleFrac(0.2))
+    folds = list(xf.partition_users(ratings, 5, xf.SampleFrac(0.2)))
+    test = pd.concat(f.test for f in folds)
+
     rec_lists = []
     for train, test in folds:
         _log.info('running training')
         algo.fit(train.loc[:, ['user', 'item']])
         cands = topn.UnratedCandidates(train)
         _log.info('testing %d users', test.user.nunique())
-        recs = batch.recommend(algo, test.user.unique(), 100, cands, test)
+        recs = batch.recommend(algo, test.user.unique(), 100, cands, nprocs=2)
         rec_lists.append(recs)
     recs = pd.concat(rec_lists)
 
-    user_dcg = recs.groupby('user').rating.apply(lm.dcg)
+    rla = topn.RecListAnalysis()
+    rla.add_metric(topn.ndcg)
+    results = rla.compute(recs, test)
+    user_dcg = results.ndcg
+
     dcg = user_dcg.mean()
-    assert dcg >= 0.1
+    assert dcg >= 0.03

--- a/tests/test_math_solve.py
+++ b/tests/test_math_solve.py
@@ -81,7 +81,7 @@ def test_solve_cholesky():
         w = solve_tri(L, A.T @ b)
         x = solve_tri(L, w, transpose=True)
 
-        assert x == approx(xexp)
+        assert x == approx(xexp, abs=1.0e-3)
 
 
 def test_solve_dposv():

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from pytest import approx
 
+from lenskit.metrics.topn import _dcg
 from lenskit import topn
 import lk_test_utils as lktu
 
@@ -53,7 +54,7 @@ def test_run_two():
     assert all(res.index.levels[0] == 'a')
     assert all(res.index.levels[1] == ['a', 'b'])
     assert all(res.reset_index().user == ['a', 'b'])
-    partial_ndcg = topn._dcg([0.0, 5.0]) / topn._dcg([5, 4, 3])
+    partial_ndcg = _dcg([0.0, 5.0]) / _dcg([5, 4, 3])
     assert res.ndcg.values == approx([1.0, partial_ndcg])
     assert res.precision.values == approx([1.0, 1/2])
     assert res.recall.values == approx([1.0, 1/3])
@@ -87,7 +88,7 @@ def test_spec_group_cols():
     assert all(res.index.levels[0] == 'a')
     assert all(res.index.levels[1] == ['a', 'b'])
     assert all(res.reset_index().user == ['a', 'b'])
-    partial_ndcg = topn._dcg([0.0, 5.0]) / topn._dcg([5, 4, 3])
+    partial_ndcg = _dcg([0.0, 5.0]) / _dcg([5, 4, 3])
     assert res.ndcg.values == approx([1.0, partial_ndcg])
     assert res.precision.values == approx([1.0, 1/2])
     assert res.recall.values == approx([1.0, 1/3])

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pandas as pd
+
+from pytest import approx
+
+from lenskit import topn
+import lk_test_utils as lktu
+
+
+def test_run_one():
+    rla = topn.RecListAnalysis()
+    rla.add_metric(topn.precision)
+    rla.add_metric(topn.recall)
+
+    recs = pd.DataFrame({'user': 1, 'item': [5]})
+    truth = pd.DataFrame({'user': 1, 'item': [1, 2, 3], 'rating': [3.0, 5.0, 4.0]})
+
+    res = rla.compute(recs, truth)
+
+    assert len(res) == 1
+    assert all(res.user == 1)
+    assert all(res.precision == 0.0)
+    assert all(res.recall.isna())
+
+
+def test_run_two():
+    rla = topn.RecListAnalysis()
+    rla.add_metric(topn.precision)
+    rla.add_metric(topn.recall)
+    rla.add_metric(topn.ndcg)
+
+    recs = pd.DataFrame({
+        'data': 'a',
+        'user': ['a', 'a', 'a', 'b', 'b'],
+        'item': [2, 3, 1, 4, 5]
+    })
+    truth = pd.DataFrame({
+        'user': ['a', 'a', 'a', 'b', 'b', 'b'],
+        'item': [1, 2, 3, 1, 5, 6],
+        'rating': [3.0, 5.0, 4.0, 3.0, 5.0, 4.0]
+    })
+
+    res = rla.compute(recs, truth)
+    assert len(res) == 2
+    assert all(res.user == ['a', 'b'])
+    assert res.ndcg == approx([1.0, 0.0])
+    assert res.precision == approx(1.0, 1/2)
+    assert res.precision == approx(1.0, 1/3)

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -77,7 +77,7 @@ def test_inner_format():
 
     def inner(recs, truth, foo='a'):
         assert foo == 'b'
-        assert all(recs.columns == ['data', 'user', 'item', 'rank'])
+        assert set(recs.columns) == set(['data', 'user', 'item', 'rank'])
         assert len(recs[['data', 'user']].drop_duplicates()) == 1
         assert truth.index.name == 'item'
         assert truth.index.is_unique

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -60,6 +60,43 @@ def test_run_two():
     assert res.recall.values == approx([1.0, 1/3])
 
 
+def test_inner_format():
+    rla = topn.RecListAnalysis()
+
+    recs = pd.DataFrame({
+        'data': 'a',
+        'user': ['a', 'a', 'a', 'b', 'b'],
+        'item': [2, 3, 1, 4, 5],
+        'rank': [1, 2, 3, 1, 2]
+    })
+    truth = pd.DataFrame({
+        'user': ['a', 'a', 'a', 'b', 'b', 'b'],
+        'item': [1, 2, 3, 1, 5, 6],
+        'rating': [3.0, 5.0, 4.0, 3.0, 5.0, 4.0]
+    })
+
+    def inner(recs, truth, foo='a'):
+        assert foo == 'b'
+        assert all(recs.columns == ['data', 'user', 'item', 'rank'])
+        assert len(recs[['data', 'user']].drop_duplicates()) == 1
+        assert truth.index.name == 'item'
+        assert truth.index.is_unique
+        assert all(truth.columns == ['rating'])
+        return len(recs.join(truth, on='item', how='inner'))
+    rla.add_metric(inner, name='bob', foo='b')
+
+    res = rla.compute(recs, truth)
+    print(res)
+
+    assert len(res) == 2
+    assert res.index.nlevels == 2
+    assert res.index.names == ['data', 'user']
+    assert all(res.index.levels[0] == 'a')
+    assert all(res.index.levels[1] == ['a', 'b'])
+    assert all(res.reset_index().user == ['a', 'b'])
+    assert all(res['bob'] == [3, 1])
+
+
 def test_spec_group_cols():
     rla = topn.RecListAnalysis(group_cols=['data', 'user'])
     rla.add_metric(topn.precision)

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -35,7 +35,42 @@ def test_run_two():
     recs = pd.DataFrame({
         'data': 'a',
         'user': ['a', 'a', 'a', 'b', 'b'],
-        'item': [2, 3, 1, 4, 5]
+        'item': [2, 3, 1, 4, 5],
+        'rank': [1, 2, 3, 1, 2]
+    })
+    truth = pd.DataFrame({
+        'user': ['a', 'a', 'a', 'b', 'b', 'b'],
+        'item': [1, 2, 3, 1, 5, 6],
+        'rating': [3.0, 5.0, 4.0, 3.0, 5.0, 4.0]
+    })
+
+    res = rla.compute(recs, truth)
+    print(res)
+
+    assert len(res) == 2
+    assert res.index.nlevels == 2
+    assert res.index.names == ['data', 'user']
+    assert all(res.index.levels[0] == 'a')
+    assert all(res.index.levels[1] == ['a', 'b'])
+    assert all(res.reset_index().user == ['a', 'b'])
+    partial_ndcg = topn._dcg([0.0, 5.0]) / topn._dcg([5, 4, 3])
+    assert res.ndcg.values == approx([1.0, partial_ndcg])
+    assert res.precision.values == approx([1.0, 1/2])
+    assert res.recall.values == approx([1.0, 1/3])
+
+
+def test_spec_group_cols():
+    rla = topn.RecListAnalysis(group_cols=['data', 'user'])
+    rla.add_metric(topn.precision)
+    rla.add_metric(topn.recall)
+    rla.add_metric(topn.ndcg)
+
+    recs = pd.DataFrame({
+        'data': 'a',
+        'user': ['a', 'a', 'a', 'b', 'b'],
+        'item': [2, 3, 1, 4, 5],
+        'rank': [1, 2, 3, 1, 2],
+        'wombat': np.random.randn(5)
     })
     truth = pd.DataFrame({
         'user': ['a', 'a', 'a', 'b', 'b', 'b'],

--- a/tests/test_topn_mrr.py
+++ b/tests/test_topn_mrr.py
@@ -3,45 +3,51 @@ import pandas as pd
 
 from pytest import approx
 
-import lenskit.metrics.topn as lm
+from lenskit.topn import recip_rank
+
+
+def _test_rr(items, rel):
+    recs = pd.DataFrame({'item': items})
+    truth = pd.DataFrame({'item': rel}).set_index('item')
+    return recip_rank(recs, truth)
 
 
 def test_mrr_empty_zero():
-    rr = lm.recip_rank([], [1, 3])
+    rr = _test_rr([], [1, 3])
     assert rr == approx(0)
 
 
 def test_mrr_norel_zero():
     "no relevant items -> zero"
-    rr = lm.recip_rank([1, 2, 3], [4, 5])
+    rr = _test_rr([1, 2, 3], [4, 5])
     assert rr == approx(0)
 
 
 def test_mrr_first_one():
     "first relevant -> one"
-    rr = lm.recip_rank([1, 2, 3], [1, 4])
+    rr = _test_rr([1, 2, 3], [1, 4])
     assert rr == approx(1.0)
 
 
 def test_mrr_second_one_half():
     "second relevant -> 0.5"
-    rr = lm.recip_rank([1, 2, 3], [5, 2, 3])
+    rr = _test_rr([1, 2, 3], [5, 2, 3])
     assert rr == approx(0.5)
 
 
 def test_mrr_series():
     "second relevant -> 0.5 in pd series"
-    rr = lm.recip_rank(pd.Series([1, 2, 3]), pd.Series([5, 2, 3]))
+    rr = _test_rr(pd.Series([1, 2, 3]), pd.Series([5, 2, 3]))
     assert rr == approx(0.5)
 
 
 def test_mrr_series_idx():
     "second relevant -> 0.5 in pd series w/ index"
-    rr = lm.recip_rank(pd.Series([1, 2, 3]), pd.Index([5, 2, 3]))
+    rr = _test_rr(pd.Series([1, 2, 3]), pd.Index([5, 2, 3]))
     assert rr == approx(0.5)
 
 
 def test_mrr_array_late():
     "deep -> 0.1"
-    rr = lm.recip_rank(np.arange(1, 21, 1, 'u4'), [20, 10])
+    rr = _test_rr(np.arange(1, 21, 1, 'u4'), [20, 10])
     assert rr == approx(0.1)

--- a/tests/test_topn_ndcg.py
+++ b/tests/test_topn_ndcg.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from pytest import approx
 
-from lenskit.topn import _dcg, ndcg
+from lenskit.metrics.topn import _dcg, ndcg
 import lk_test_utils as lktu
 
 

--- a/tests/test_topn_ndcg.py
+++ b/tests/test_topn_ndcg.py
@@ -3,73 +3,91 @@ import pandas as pd
 
 from pytest import approx
 
-import lenskit.metrics.topn as lm
+from lenskit.topn import _dcg, ndcg
 import lk_test_utils as lktu
 
 
 def test_dcg_empty():
     "empty should be zero"
-    assert lm._dcg(np.array([])) == approx(0)
+    assert _dcg(np.array([])) == approx(0)
 
 
 def test_dcg_zeros():
-    assert lm._dcg(np.zeros(10)) == approx(0)
+    assert _dcg(np.zeros(10)) == approx(0)
 
 
 def test_dcg_single():
     "a single element should be scored at the right place"
-    assert lm._dcg(np.array([0.5])) == approx(0.5)
-    assert lm._dcg(np.array([0, 0.5])) == approx(0.5)
-    assert lm._dcg(np.array([0, 0, 0.5])) == approx(0.5 / np.log2(3))
-    assert lm._dcg(np.array([0, 0, 0.5, 0])) == approx(0.5 / np.log2(3))
+    assert _dcg(np.array([0.5])) == approx(0.5)
+    assert _dcg(np.array([0, 0.5])) == approx(0.5)
+    assert _dcg(np.array([0, 0, 0.5])) == approx(0.5 / np.log2(3))
+    assert _dcg(np.array([0, 0, 0.5, 0])) == approx(0.5 / np.log2(3))
 
 
 def test_dcg_mult():
     "multiple elements should score correctly"
-    assert lm._dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)
-    assert lm._dcg(np.array([np.e, 0, 0, np.pi])) == approx(np.e + np.pi / np.log2(4))
+    assert _dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)
+    assert _dcg(np.array([np.e, 0, 0, np.pi])) == approx(np.e + np.pi / np.log2(4))
 
 
 def test_dcg_empty2():
     "empty should be zero"
-    assert lm.dcg(np.array([])) == approx(0)
+    assert _dcg(np.array([])) == approx(0)
 
 
 def test_dcg_zeros2():
-    assert lm.dcg(np.zeros(10)) == approx(0)
+    assert _dcg(np.zeros(10)) == approx(0)
 
 
 def test_dcg_single2():
     "a single element should be scored at the right place"
-    assert lm.dcg(np.array([0.5])) == approx(0.5)
-    assert lm.dcg(np.array([0, 0.5])) == approx(0.5)
-    assert lm.dcg(np.array([0, 0, 0.5])) == approx(0.5 / np.log2(3))
-    assert lm.dcg(np.array([0, 0, 0.5, 0])) == approx(0.5 / np.log2(3))
+    assert _dcg(np.array([0.5])) == approx(0.5)
+    assert _dcg(np.array([0, 0.5])) == approx(0.5)
+    assert _dcg(np.array([0, 0, 0.5])) == approx(0.5 / np.log2(3))
+    assert _dcg(np.array([0, 0, 0.5, 0])) == approx(0.5 / np.log2(3))
 
 
 def test_dcg_nan():
     "NANs should be 0"
-    assert lm.dcg(np.array([np.nan, 0.5])) == approx(0.5)
+    assert _dcg(np.array([np.nan, 0.5])) == approx(0.5)
 
 
 def test_dcg_series():
     "The DCG function should work on a series"
-    assert lm.dcg(pd.Series([np.e, 0, 0, np.pi])) == \
+    assert _dcg(pd.Series([np.e, 0, 0, np.pi])) == \
         approx((np.e + np.pi / np.log2(4)))
 
 
 def test_dcg_mult2():
     "multiple elements should score correctly"
-    assert lm.dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)
-    assert lm.dcg(np.array([np.e, 0, 0, np.pi])) == \
+    assert _dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)
+    assert _dcg(np.array([np.e, 0, 0, np.pi])) == \
         approx((np.e + np.pi / np.log2(4)))
 
 
-def test_ideal_dcg():
-    ratings = lktu.ml_pandas.renamed.ratings
-    ratings = ratings.loc[:, ['user', 'item', 'rating']]
+def test_ndcg_empty():
+    recs = pd.DataFrame({'item': []})
+    truth = pd.DataFrame({'item': [1, 2, 3], 'rating': [3.0, 5.0, 4.0]})
+    truth = truth.set_index('item')
+    assert ndcg(recs, truth) == approx(0.0)
 
-    ml_dcg = lm.compute_ideal_dcgs(ratings)
-    assert len(ml_dcg) < len(ratings)
-    assert 'ideal_dcg' in ml_dcg.columns
-    assert all(ml_dcg.ideal_dcg > 1)
+
+def test_ndcg_no_match():
+    recs = pd.DataFrame({'item': [4]})
+    truth = pd.DataFrame({'item': [1, 2, 3], 'rating': [3.0, 5.0, 4.0]})
+    truth = truth.set_index('item')
+    assert ndcg(recs, truth) == approx(0.0)
+
+
+def test_ndcg_perfect():
+    recs = pd.DataFrame({'item': [2, 3, 1]})
+    truth = pd.DataFrame({'item': [1, 2, 3], 'rating': [3.0, 5.0, 4.0]})
+    truth = truth.set_index('item')
+    assert ndcg(recs, truth) == approx(1.0)
+
+
+def test_ndcg_wrong():
+    recs = pd.DataFrame({'item': [1, 2]})
+    truth = pd.DataFrame({'item': [1, 2, 3], 'rating': [3.0, 5.0, 4.0]})
+    truth = truth.set_index('item')
+    assert ndcg(recs, truth) == approx(_dcg([3.0, 5.0] / _dcg([5.0, 4.0, 3.0])))

--- a/tests/test_topn_ndcg.py
+++ b/tests/test_topn_ndcg.py
@@ -47,6 +47,17 @@ def test_dcg_single2():
     assert lm.dcg(np.array([0, 0, 0.5, 0])) == approx(0.5 / np.log2(3))
 
 
+def test_dcg_nan():
+    "NANs should be 0"
+    assert lm.dcg(np.array([np.nan, 0.5])) == approx(0.5)
+
+
+def test_dcg_series():
+    "The DCG function should work on a series"
+    assert lm.dcg(pd.Series([np.e, 0, 0, np.pi])) == \
+        approx((np.e + np.pi / np.log2(4)))
+
+
 def test_dcg_mult2():
     "multiple elements should score correctly"
     assert lm.dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)

--- a/tests/test_topn_precision.py
+++ b/tests/test_topn_precision.py
@@ -3,81 +3,87 @@ import pandas as pd
 
 from pytest import approx
 
-import lenskit.metrics.topn as lm
+from lenskit.topn import precision
+
+
+def _test_prec(items, rel):
+    recs = pd.DataFrame({'item': items})
+    truth = pd.DataFrame({'item': rel}).set_index('item')
+    return precision(recs, truth)
 
 
 def test_precision_empty_none():
-    prec = lm.precision([], [1, 3])
+    prec = _test_prec([], [1, 3])
     assert prec is None
 
 
 def test_precision_simple_cases():
-    prec = lm.precision([1, 3], [1, 3])
+    prec = _test_prec([1, 3], [1, 3])
     assert prec == approx(1.0)
 
-    prec = lm.precision([1], [1, 3])
+    prec = _test_prec([1], [1, 3])
     assert prec == approx(1.0)
 
-    prec = lm.precision([1, 2, 3, 4], [1, 3])
+    prec = _test_prec([1, 2, 3, 4], [1, 3])
     assert prec == approx(0.5)
 
-    prec = lm.precision([1, 2, 3, 4], [1, 3, 5])
+    prec = _test_prec([1, 2, 3, 4], [1, 3, 5])
     assert prec == approx(0.5)
 
-    prec = lm.precision([1, 2, 3, 4], range(5, 10))
+    prec = _test_prec([1, 2, 3, 4], range(5, 10))
     assert prec == approx(0.0)
 
-    prec = lm.precision([1, 2, 3, 4], range(4, 10))
+    prec = _test_prec([1, 2, 3, 4], range(4, 10))
     assert prec == approx(0.25)
 
 
 def test_precision_series():
-    prec = lm.precision(pd.Series([1, 3]), pd.Series([1, 3]))
+    prec = _test_prec(pd.Series([1, 3]), pd.Series([1, 3]))
     assert prec == approx(1.0)
 
-    prec = lm.precision(pd.Series([1, 2, 3, 4]), pd.Series([1, 3, 5]))
+    prec = _test_prec(pd.Series([1, 2, 3, 4]), pd.Series([1, 3, 5]))
     assert prec == approx(0.5)
 
-    prec = lm.precision(pd.Series([1, 2, 3, 4]), pd.Series(range(4, 10)))
+    prec = _test_prec(pd.Series([1, 2, 3, 4]), pd.Series(range(4, 10)))
     assert prec == approx(0.25)
 
 
 def test_precision_series_set():
-    prec = lm.precision(pd.Series([1, 2, 3, 4]), [1, 3, 5])
+    prec = _test_prec(pd.Series([1, 2, 3, 4]), [1, 3, 5])
     assert prec == approx(0.5)
 
-    prec = lm.precision(pd.Series([1, 2, 3, 4]), range(4, 10))
+    prec = _test_prec(pd.Series([1, 2, 3, 4]), range(4, 10))
     assert prec == approx(0.25)
 
 
 def test_precision_series_index():
-    prec = lm.precision(pd.Series([1, 3]), pd.Index([1, 3]))
+    prec = _test_prec(pd.Series([1, 3]), pd.Index([1, 3]))
     assert prec == approx(1.0)
 
-    prec = lm.precision(pd.Series([1, 2, 3, 4]), pd.Index([1, 3, 5]))
+    prec = _test_prec(pd.Series([1, 2, 3, 4]), pd.Index([1, 3, 5]))
     assert prec == approx(0.5)
 
-    prec = lm.precision(pd.Series([1, 2, 3, 4]), pd.Index(range(4, 10)))
+    prec = _test_prec(pd.Series([1, 2, 3, 4]), pd.Index(range(4, 10)))
     assert prec == approx(0.25)
 
 
 def test_precision_series_array():
-    prec = lm.precision(pd.Series([1, 3]), np.array([1, 3]))
+    prec = _test_prec(pd.Series([1, 3]), np.array([1, 3]))
     assert prec == approx(1.0)
 
-    prec = lm.precision(pd.Series([1, 2, 3, 4]), np.array([1, 3, 5]))
+    prec = _test_prec(pd.Series([1, 2, 3, 4]), np.array([1, 3, 5]))
     assert prec == approx(0.5)
 
-    prec = lm.precision(pd.Series([1, 2, 3, 4]), np.arange(4, 10, 1, 'u4'))
+    prec = _test_prec(pd.Series([1, 2, 3, 4]), np.arange(4, 10, 1, 'u4'))
     assert prec == approx(0.25)
 
 
 def test_precision_array():
-    prec = lm.precision(np.array([1, 3]), np.array([1, 3]))
+    prec = _test_prec(np.array([1, 3]), np.array([1, 3]))
     assert prec == approx(1.0)
 
-    prec = lm.precision(np.array([1, 2, 3, 4]), np.array([1, 3, 5]))
+    prec = _test_prec(np.array([1, 2, 3, 4]), np.array([1, 3, 5]))
     assert prec == approx(0.5)
 
-    prec = lm.precision(np.array([1, 2, 3, 4]), np.arange(4, 10, 1, 'u4'))
+    prec = _test_prec(np.array([1, 2, 3, 4]), np.arange(4, 10, 1, 'u4'))
     assert prec == approx(0.25)

--- a/tests/test_topn_recall.py
+++ b/tests/test_topn_recall.py
@@ -3,86 +3,92 @@ import pandas as pd
 
 from pytest import approx
 
-import lenskit.metrics.topn as lm
+from lenskit.topn import recall
+
+
+def _test_recall(items, rel):
+    recs = pd.DataFrame({'item': items})
+    truth = pd.DataFrame({'item': rel}).set_index('item')
+    return recall(recs, truth)
 
 
 def test_recall_empty_zero():
-    prec = lm.recall([], [1, 3])
+    prec = _test_recall([], [1, 3])
     assert prec == approx(0)
 
 
 def test_recall_norel_na():
-    prec = lm.recall([1, 3], [])
-    assert np.isnan(prec)
+    prec = _test_recall([1, 3], [])
+    assert prec is None
 
 
 def test_recall_simple_cases():
-    prec = lm.recall([1, 3], [1, 3])
+    prec = _test_recall([1, 3], [1, 3])
     assert prec == approx(1.0)
 
-    prec = lm.recall([1], [1, 3])
+    prec = _test_recall([1], [1, 3])
     assert prec == approx(0.5)
 
-    prec = lm.recall([1, 2, 3, 4], [1, 3])
+    prec = _test_recall([1, 2, 3, 4], [1, 3])
     assert prec == approx(1.0)
 
-    prec = lm.recall([1, 2, 3, 4], [1, 3, 5])
+    prec = _test_recall([1, 2, 3, 4], [1, 3, 5])
     assert prec == approx(2.0 / 3)
 
-    prec = lm.recall([1, 2, 3, 4], range(5, 10))
+    prec = _test_recall([1, 2, 3, 4], range(5, 10))
     assert prec == approx(0.0)
 
-    prec = lm.recall([1, 2, 3, 4], range(4, 9))
+    prec = _test_recall([1, 2, 3, 4], range(4, 9))
     assert prec == approx(0.2)
 
 
 def test_recall_series():
-    prec = lm.recall(pd.Series([1, 3]), pd.Series([1, 3]))
+    prec = _test_recall(pd.Series([1, 3]), pd.Series([1, 3]))
     assert prec == approx(1.0)
 
-    prec = lm.recall(pd.Series([1, 2, 3]), pd.Series([1, 3, 5, 7]))
+    prec = _test_recall(pd.Series([1, 2, 3]), pd.Series([1, 3, 5, 7]))
     assert prec == approx(0.5)
 
-    prec = lm.recall(pd.Series([1, 2, 3, 4]), pd.Series(range(4, 9)))
+    prec = _test_recall(pd.Series([1, 2, 3, 4]), pd.Series(range(4, 9)))
     assert prec == approx(0.2)
 
 
 def test_recall_series_set():
-    prec = lm.recall(pd.Series([1, 2, 3, 4]), [1, 3, 5, 7])
+    prec = _test_recall(pd.Series([1, 2, 3, 4]), [1, 3, 5, 7])
     assert prec == approx(0.5)
 
-    prec = lm.recall(pd.Series([1, 2, 3, 4]), range(4, 9))
+    prec = _test_recall(pd.Series([1, 2, 3, 4]), range(4, 9))
     assert prec == approx(0.2)
 
 
 def test_recall_series_index():
-    prec = lm.recall(pd.Series([1, 3]), pd.Index([1, 3]))
+    prec = _test_recall(pd.Series([1, 3]), pd.Index([1, 3]))
     assert prec == approx(1.0)
 
-    prec = lm.recall(pd.Series([1, 2, 3, 4]), pd.Index([1, 3, 5, 7]))
+    prec = _test_recall(pd.Series([1, 2, 3, 4]), pd.Index([1, 3, 5, 7]))
     assert prec == approx(0.5)
 
-    prec = lm.recall(pd.Series([1, 2, 3, 4]), pd.Index(range(4, 9)))
+    prec = _test_recall(pd.Series([1, 2, 3, 4]), pd.Index(range(4, 9)))
     assert prec == approx(0.2)
 
 
 def test_recall_series_array():
-    prec = lm.recall(pd.Series([1, 3]), np.array([1, 3]))
+    prec = _test_recall(pd.Series([1, 3]), np.array([1, 3]))
     assert prec == approx(1.0)
 
-    prec = lm.recall(pd.Series([1, 2, 3, 4]), np.array([1, 3, 5, 7]))
+    prec = _test_recall(pd.Series([1, 2, 3, 4]), np.array([1, 3, 5, 7]))
     assert prec == approx(0.5)
 
-    prec = lm.recall(pd.Series([1, 2, 3, 4]), np.arange(4, 9, 1, 'u4'))
+    prec = _test_recall(pd.Series([1, 2, 3, 4]), np.arange(4, 9, 1, 'u4'))
     assert prec == approx(0.2)
 
 
 def test_recall_array():
-    prec = lm.recall(np.array([1, 3]), np.array([1, 3]))
+    prec = _test_recall(np.array([1, 3]), np.array([1, 3]))
     assert prec == approx(1.0)
 
-    prec = lm.recall(np.array([1, 2, 3, 4]), np.array([1, 3, 5, 7]))
+    prec = _test_recall(np.array([1, 2, 3, 4]), np.array([1, 3, 5, 7]))
     assert prec == approx(0.5)
 
-    prec = lm.recall(np.array([1, 2, 3, 4]), np.arange(4, 9, 1, 'u4'))
+    prec = _test_recall(np.array([1, 2, 3, 4]), np.arange(4, 9, 1, 'u4'))
     assert prec == approx(0.2)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -184,6 +184,7 @@ def test_fspath():
 
 
 def test_write_parquet(tmp_path):
+    assert tmp_path.exists()
     fn = tmp_path / 'out.parquet'
     frame = pd.DataFrame({'n': np.arange(10), 'x': np.random.randn(10) + 5})
     lku.write_parquet(fn, frame)


### PR DESCRIPTION
This completely rewrites how we do top-N metrics, so that it is easier to both use and implement correct top-N evaluations.