### PR TITLE
Drop deprecated CondaEnvironment task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -306,7 +306,7 @@ jobs:
 
   - script: |
       conda create -n lkpy -qy $(conda.deps)
-      conda install -n lkpy llvm-openmp
+      conda install -n lkpy -qy llvm-openmp
     displayName: Set up Conda environment
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -304,9 +304,8 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
 
-  - script: conda update -y conda
-
   - script: conda create -n lkpy -y $(conda.deps) llvm-openmp
+    displayName: Set up Conda environment
 
   - script: |
       if [ ! -r ~/ml-100k/u.data ]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
     displayName: Add conda to PATH
 
-  - script: conda create -n lkpy -y $(conda.deps)
+  - script: conda create -n lkpy -qy $(conda.deps)
     displayName: Create Anaconda environment
   
   - script: |
@@ -264,7 +264,7 @@ jobs:
   - script: conda update -y conda
     displayName: Update Conda
   
-  - script: conda create -n lkpy -y $(conda.deps)
+  - script: conda create -n lkpy -qy $(conda.deps)
     displayName: Create Conda environment
 
   - script: |
@@ -304,7 +304,9 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
 
-  - script: conda create -n lkpy -y $(conda.deps) llvm-openmp
+  - script: |
+      conda create -n lkpy -qy $(conda.deps)
+      conda install -n lkpy llvm-openmp
     displayName: Set up Conda environment
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,17 +24,19 @@ jobs:
     maxParallel: 4
 
   steps:
-  - task: CondaEnvironment@1
-    inputs:
-      createCustomEnvironment: true
-      environmentName: lkpy
-      packageSpecs: $(conda.deps)
+  - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
+    displayName: Add conda to PATH
+
+  - script: conda create -n lkpy -y $(conda.deps)
+    displayName: Create Anaconda environment
   
   - script: |
-        pip install $(pip.extras)
+      source activate lkpy
+      pip install $(pip.extras)
     displayName: 'Extra PyPI deps'
 
   - script: |
+      source activate lkpy
       numba -s
     displayName: 'Inspect Numba environment'
     
@@ -46,11 +48,13 @@ jobs:
     displayName: 'Download ML-100K'
 
   - script: |
+      source activate lkpy
       mkdir -p build
       python3 setup.py build
     displayName: 'Build LKPY'
 
   - script: |
+      source activate lkpy
       export NUMBA_THREADING_LAYER=omp # Tests don't work with TBB
       python3 -m pytest --junitxml=build/test-results.xml --verbose
     displayName: 'Test LKPY'
@@ -62,10 +66,12 @@ jobs:
       testRunTitle: 'Publish test results for Python $(python.version)'
 
   - script: |
+      source activate lkpy
       env NUMBA_DISABLE_JIT=1 python3 -m pytest --cov=lenskit --cov-report=xml --cov-report=html -m 'not eval'
     displayName: 'Run Tests with Coverage'
 
   - script: |
+      source activate lkpy
       echo "Fetching Codecov script"
       curl -o /tmp/codecov.sh https://codecov.io/bash
       
@@ -247,28 +253,33 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
+      Python37:
+        python.version: '3.7'
     maxParallel: 4
 
   steps:
-  - task: CondaEnvironment@1
-    inputs:
-      createCustomEnvironment: true
-      environmentName: lkpy
-      packageSpecs: $(conda.deps)
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Add conda to PATH
 
-  - script: conda update -y --all
-    displayName: 'Refresh Conda'
+  - script: conda update -y conda
+    displayName: Update Conda
+  
+  - script: conda create -n lkpy -y $(conda.deps)
+    displayName: Create Conda environment
 
   - script: |
+      call activate lkpy
       pip install $(pip.extras)
     displayName: 'Extra PyPI deps'
 
   - script: |
+      call activate lkpy
       python -V
       python setup.py build
     displayName: 'Build LKPY'
 
   - script: |
+      call activate lkpy
       python -m pytest --junitxml=build/test-results.xml
     displayName: 'Test LKPY'
   
@@ -290,15 +301,12 @@ jobs:
     maxParallel: 4
 
   steps:
-  - task: CondaEnvironment@1
-    inputs:
-      createCustomEnvironment: true
-      environmentName: lkpy
-      packageSpecs: $(conda.deps)
-      updateConda: false
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
 
-  - script: sudo conda install -y llvm-openmp
-    displayName: 'Install OpenMP'
+  - script: conda update -y conda
+
+  - script: conda create -n lkpy -y $(conda.deps) llvm-openmp
 
   - script: |
       if [ ! -r ~/ml-100k/u.data ]; then
@@ -308,10 +316,12 @@ jobs:
     displayName: 'Download ML-100K'
     
   - script: |
+      source activate lkpy
       python3 setup.py build
     displayName: 'Build LKPY'
 
   - script: |
+      source activate lkpy
       mkdir -p build
       python3 -m pytest --junitxml=build/test-results.xml
     displayName: 'Test LKPY'


### PR DESCRIPTION
The CondaEnvironment task is now deprecated (see Microsoft/azure-pipelines-tasks#9573); this uses the [Yaml script method](https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/anaconda?view=azure-devops).