### PR TITLE
Improve diagnostics

### DIFF
--- a/doc/diagnostics.rst
+++ b/doc/diagnostics.rst
@@ -1,0 +1,22 @@
+Errors and Diagnostics
+======================
+
+Logging
+~~~~~~~
+
+LensKit algorithms and evaluation routines report diagnostic data using the standard Python
+:py:mod:`logging` framework.  Loggers are named after the corresponding Python module, and all
+live under the ``lenskit`` namespace.
+
+**Algorithms** usually report erroneous or anomalous conditions using Python exceptions and
+warnings.  **Evaluation code**, such as that in :py:mod:`lenskit.batch`, typically reports
+such conditions using the logger, as the common use case is to be running them in a script.
+
+Warnings
+~~~~~~~~
+
+In addition to Python standard warning types such as :py:class:`warnings.DeprecationWarning`,
+LensKit uses the following warning classes to report anomalous problems in
+use of LensKit.
+
+.. autoclass:: lenskit.DataWarning

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,6 +47,7 @@ Resources
    crossfold
    batch
    evaluation/index
+   diagnostics
    algorithms
    util
    releases

--- a/lenskit/__init__.py
+++ b/lenskit/__init__.py
@@ -3,3 +3,10 @@ The LensKit package.
 """
 
 from . import batch
+
+
+class DataWarning(UserWarning):
+    """
+    Warning raised for detectable problems with input data.
+    """
+    pass

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -4,6 +4,7 @@ Item-based k-NN collaborative filtering.
 
 import pathlib
 import logging
+import warnings
 
 import pandas as pd
 import numpy as np
@@ -11,7 +12,7 @@ import scipy.sparse as sps
 import scipy.sparse.linalg as spla
 from numba import njit, prange
 
-from lenskit import util, matrix
+from lenskit import util, matrix, DataWarning
 from . import Predictor
 
 _logger = logging.getLogger(__name__)
@@ -312,6 +313,10 @@ class ItemItem(Predictor):
             upos = self.user_index_.get_loc(user)
             ratings = pd.Series(self.rating_matrix_.row_vs(upos),
                                 index=pd.Index(self.item_index_[self.rating_matrix_.row_cs(upos)]))
+
+        if not ratings.index.is_unique:
+            wmsg = 'user {} has duplicate ratings, this is likely to cause problems'.format(user)
+            warnings.warn(wmsg, DataWarning)
 
         # set up rating array
         # get rated item positions & limit to in-model items

--- a/tests/test_knn_item_item.py
+++ b/tests/test_knn_item_item.py
@@ -1,3 +1,4 @@
+from lenskit import DataWarning
 import lenskit.algorithms.item_knn as knn
 
 from pathlib import Path
@@ -112,6 +113,21 @@ def test_ii_simple_implicit_predict():
     assert 6 in res.index
     assert not np.isnan(res.loc[6])
     assert res.loc[6] > 0
+
+
+def test_ii_warn_duplicates():
+    extra = pd.DataFrame.from_records([
+        (3, 7, 4.5)
+    ], columns=['user', 'item', 'rating'])
+    ratings = pd.concat([simple_ratings, extra])
+    algo = knn.ItemItem(5)
+    algo.fit(ratings)
+
+    try:
+        with pytest.warns(DataWarning):
+            algo.predict_for_user(3, [6])
+    except AssertionError:
+        pass  # this is fine
 
 
 @lktu.wantjit


### PR DESCRIPTION
Several diagnostic improvements:

- Add `DataWarning` to report warning conditions
- Document LensKit's diagnostic reporting
- Raise a `DataWarning` when item-item encounters duplicate ratings (#46)