### PR TITLE
first stab at fixing recs size errors

### DIFF
--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -291,7 +291,7 @@ class MultiEval:
         return preds, watch.elapsed()
 
     def _recommend(self, rid, algo, test, candidates):
-        if not self.recommend: #if recommend is any false-y val (0, None, False), turn off recs
+        if not self.recommend:  #if recommend is any false-y val (0, None, False), turn off recs
             return None, None
         elif self.recommend is True:  # special value True means unlimited
             nrecs = None

--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -291,16 +291,17 @@ class MultiEval:
         return preds, watch.elapsed()
 
     def _recommend(self, rid, algo, test, candidates):
-        if self.recommend is None or self.recommend is False or self.recommend is 0:
+        if not self.recommend: #if recommend is any false-y val (0, None, False), turn off recs
             return None, None
-
-        if self.recommend is True:
-            self.recommend = None
+        elif self.recommend is True:  # special value True means unlimited
+            nrecs = None
+        else:  # recommend has rec size
+            nrecs = self.recommend
 
         watch = util.Stopwatch()
         users = test.user.unique()
         _logger.info('generating recommendations for %d users for %s', len(users), algo)
-        recs = recommend(algo, users, self.recommend, candidates,
+        recs = recommend(algo, users, nrecs, candidates,
                          nprocs=self.nprocs)
         watch.stop()
         _logger.info('generated recommendations in %s', watch)

--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -291,7 +291,7 @@ class MultiEval:
         return preds, watch.elapsed()
 
     def _recommend(self, rid, algo, test, candidates):
-        if not self.recommend:  #if recommend is any false-y val (0, None, False), turn off recs
+        if not self.recommend:  # if recommend is any false-y val (0, None, False), turn off recs
             return None, None
         elif self.recommend is True:  # special value True means unlimited
             nrecs = None

--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -291,8 +291,11 @@ class MultiEval:
         return preds, watch.elapsed()
 
     def _recommend(self, rid, algo, test, candidates):
-        if self.recommend is None:
+        if self.recommend is None or self.recommend is False or self.recommend is 0:
             return None, None
+
+        if self.recommend is True:
+            self.recommend = None
 
         watch = util.Stopwatch()
         users = test.user.unique()

--- a/tests/test_batch_sweep.py
+++ b/tests/test_batch_sweep.py
@@ -93,42 +93,6 @@ def test_sweep_norecs(tmp_path):
     preds = pd.read_parquet(work / 'predictions.parquet')
     assert all(preds.RunId.isin(bias_runs.RunId))
 
-    ## again, but with recommend=False
-
-    tmp_path = norm_path(tmp_path)
-    work = pathlib.Path(tmp_path)
-    sweep = batch.MultiEval(tmp_path, recommend=False)
-
-    ratings = ml_pandas.renamed.ratings
-    folds = xf.partition_users(ratings, 5, xf.SampleN(5))
-    sweep.add_datasets(folds, DataSet='ml-small')
-    sweep.add_algorithms([Bias(damping=0), Bias(damping=5), Bias(damping=10)],
-                         attrs=['damping'])
-    sweep.add_algorithms(Popular())
-
-    try:
-        sweep.run()
-    finally:
-        if (work / 'runs.csv').exists():
-            runs = pd.read_csv(work / 'runs.csv')
-            print(runs)
-
-    assert (work / 'runs.csv').exists()
-    assert (work / 'runs.parquet').exists()
-    assert (work / 'predictions.parquet').exists()
-    assert not (work / 'recommendations.parquet').exists()
-
-    runs = pd.read_parquet(work / 'runs.parquet')
-    # 4 algorithms by 5 partitions
-    assert len(runs) == 20
-    assert all(np.sort(runs.AlgoClass.unique()) == ['Bias', 'Popular'])
-    bias_runs = runs[runs.AlgoClass == 'Bias']
-    assert all(bias_runs.damping.notna())
-    pop_runs = runs[runs.AlgoClass == 'Popular']
-    assert all(pop_runs.damping.isna())
-
-    preds = pd.read_parquet(work / 'predictions.parquet')
-    assert all(preds.RunId.isin(bias_runs.RunId))
 
 @mark.slow
 def test_sweep_allrecs(tmp_path):

--- a/tests/test_batch_sweep.py
+++ b/tests/test_batch_sweep.py
@@ -57,6 +57,121 @@ def test_sweep_bias(tmp_path, ncpus):
 
 
 @mark.slow
+def test_sweep_norecs(tmp_path):
+    tmp_path = norm_path(tmp_path)
+    work = pathlib.Path(tmp_path)
+    sweep = batch.MultiEval(tmp_path, recommend=None)
+
+    ratings = ml_pandas.renamed.ratings
+    folds = xf.partition_users(ratings, 5, xf.SampleN(5))
+    sweep.add_datasets(folds, DataSet='ml-small')
+    sweep.add_algorithms([Bias(damping=0), Bias(damping=5), Bias(damping=10)],
+                         attrs=['damping'])
+    sweep.add_algorithms(Popular())
+
+    try:
+        sweep.run()
+    finally:
+        if (work / 'runs.csv').exists():
+            runs = pd.read_csv(work / 'runs.csv')
+            print(runs)
+
+    assert (work / 'runs.csv').exists()
+    assert (work / 'runs.parquet').exists()
+    assert (work / 'predictions.parquet').exists()
+    assert not (work / 'recommendations.parquet').exists()
+
+    runs = pd.read_parquet(work / 'runs.parquet')
+    # 4 algorithms by 5 partitions
+    assert len(runs) == 20
+    assert all(np.sort(runs.AlgoClass.unique()) == ['Bias', 'Popular'])
+    bias_runs = runs[runs.AlgoClass == 'Bias']
+    assert all(bias_runs.damping.notna())
+    pop_runs = runs[runs.AlgoClass == 'Popular']
+    assert all(pop_runs.damping.isna())
+
+    preds = pd.read_parquet(work / 'predictions.parquet')
+    assert all(preds.RunId.isin(bias_runs.RunId))
+
+    ## again, but with recommend=False
+
+    tmp_path = norm_path(tmp_path)
+    work = pathlib.Path(tmp_path)
+    sweep = batch.MultiEval(tmp_path, recommend=False)
+
+    ratings = ml_pandas.renamed.ratings
+    folds = xf.partition_users(ratings, 5, xf.SampleN(5))
+    sweep.add_datasets(folds, DataSet='ml-small')
+    sweep.add_algorithms([Bias(damping=0), Bias(damping=5), Bias(damping=10)],
+                         attrs=['damping'])
+    sweep.add_algorithms(Popular())
+
+    try:
+        sweep.run()
+    finally:
+        if (work / 'runs.csv').exists():
+            runs = pd.read_csv(work / 'runs.csv')
+            print(runs)
+
+    assert (work / 'runs.csv').exists()
+    assert (work / 'runs.parquet').exists()
+    assert (work / 'predictions.parquet').exists()
+    assert not (work / 'recommendations.parquet').exists()
+
+    runs = pd.read_parquet(work / 'runs.parquet')
+    # 4 algorithms by 5 partitions
+    assert len(runs) == 20
+    assert all(np.sort(runs.AlgoClass.unique()) == ['Bias', 'Popular'])
+    bias_runs = runs[runs.AlgoClass == 'Bias']
+    assert all(bias_runs.damping.notna())
+    pop_runs = runs[runs.AlgoClass == 'Popular']
+    assert all(pop_runs.damping.isna())
+
+    preds = pd.read_parquet(work / 'predictions.parquet')
+    assert all(preds.RunId.isin(bias_runs.RunId))
+
+@mark.slow
+def test_sweep_allrecs(tmp_path):
+    tmp_path = norm_path(tmp_path)
+    work = pathlib.Path(tmp_path)
+    sweep = batch.MultiEval(tmp_path, recommend=True)
+
+    ratings = ml_pandas.renamed.ratings
+    folds = xf.partition_users(ratings, 5, xf.SampleN(5))
+    sweep.add_datasets(folds, DataSet='ml-small')
+    sweep.add_algorithms([Bias(damping=0), Bias(damping=5), Bias(damping=10)],
+                             attrs=['damping'])
+    sweep.add_algorithms(Popular())
+
+    try:
+        sweep.run()
+    finally:
+        if (work / 'runs.csv').exists():
+            runs = pd.read_csv(work / 'runs.csv')
+            print(runs)
+
+    assert (work / 'runs.csv').exists()
+    assert (work / 'runs.parquet').exists()
+    assert (work / 'predictions.parquet').exists()
+    assert (work / 'recommendations.parquet').exists()
+
+    runs = pd.read_parquet(work / 'runs.parquet')
+    # 4 algorithms by 5 partitions
+    assert len(runs) == 20
+    assert all(np.sort(runs.AlgoClass.unique()) == ['Bias', 'Popular'])
+    bias_runs = runs[runs.AlgoClass == 'Bias']
+    assert all(bias_runs.damping.notna())
+    pop_runs = runs[runs.AlgoClass == 'Popular']
+    assert all(pop_runs.damping.isna())
+
+    preds = pd.read_parquet(work / 'predictions.parquet')
+    assert all(preds.RunId.isin(bias_runs.RunId))
+
+    recs = pd.read_parquet(work / 'recommendations.parquet')
+    assert all(recs.RunId.isin(runs.RunId))
+
+
+@mark.slow
 def test_sweep_filenames(tmp_path):
     tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)


### PR DESCRIPTION
I expect to get some substantial 'fix this' feedback on this push.

The fix itself seems simple enough - just expand the checks to turn off recommendations to also include `0` and `False` (in addition to the previously checked `None`), and then after that, set `recommend=None` if `True` is passed in. 

I feel a bit out of my depth currently with the test classes when they get this complex. I copied the pattern from other tests that utilized `MultiEval`. 

`test_sweep_norecs` creates a `MultiEval` with `recommend = None` and makes sure no `recommendations.parquet` file is created. It then *repeats* the process with `recommend = False`. I wasn't sure if you'd want this or if it's overkill (especially given how slow these tests are). I could have also added one for `recommend = 0`, but didn't.

There's a bunch of additional `assert` lines that aren't really needed to test this - but I figured I'd leave them in during the first submission in case you'd prefer to check them regardless. 

`test_sweep_allrecs` simply makes sure a `recommendations.parquet` file is created when `recommend=True` is passed. **However it does not check if full recommendations are generated**. I wasn't sure how I would check this - I imagine it would work with an ``assert len(recs) == X`` check, but I'm not sure exactly what that size would be. (I have some confusion about ``ml_pandas.renamed.ratings`` and where exactly it is coming from).