### PR TITLE
Improve k-NN performance

### DIFF
--- a/build-support/test-linux-conda.yml
+++ b/build-support/test-linux-conda.yml
@@ -59,8 +59,6 @@ jobs:
 
   - script: |
       source activate lkpy
-      conda install -n lkpy -qy ipykernel nbformat jupyter_client matplotlib
-      pip install nbval
       cp -r ml-100k doc
       cp -r ml-latest-small doc
       export PYTHONPATH="$PWD"

--- a/build-support/test-mac-conda.yml
+++ b/build-support/test-mac-conda.yml
@@ -37,7 +37,7 @@ jobs:
   - script: |
       source activate lkpy
       mkdir -p build
-      python3 -m pytest --junitxml=build/test-results.xml
+      python3 -m pytest --verbose --junitxml=build/test-results.xml
     displayName: 'Test LKPY'
 
   - task: PublishTestResults@2

--- a/build-support/test-mac-conda.yml
+++ b/build-support/test-mac-conda.yml
@@ -19,7 +19,7 @@ jobs:
       conda create -n lkpy -qy python=$(python.version)
       conda env update -n lkpy -q -f dev-environment.yml
       conda install -n lkpy -qy llvm-openmp
-      conda remove -n lkpy -qy hpfrec
+      conda remove -n lkpy -qy hpfrec tbb
     displayName: Set up Conda environment
 
   - script: |

--- a/build-support/test-mac-conda.yml
+++ b/build-support/test-mac-conda.yml
@@ -19,7 +19,7 @@ jobs:
       conda create -n lkpy -qy python=$(python.version)
       conda env update -n lkpy -q -f dev-environment.yml
       conda install -n lkpy -qy llvm-openmp
-      conda remove -n lkpy -qy hpfrec tbb
+      conda remove -n lkpy -qy hpfrec
     displayName: Set up Conda environment
 
   - script: |

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -28,6 +28,10 @@ dependencies:
 - nbformat
 - nbconvert
 - flake8
+- ipykernel
+- jupyter_client
+- matplotlib
 - pip:
   - nbsphinx
   - recommonmark
+  - nbval

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -12,7 +12,6 @@ dependencies:
 - python-snappy
 - numba>=0.38
 - cffi
-- tbb
 - pyarrow
 - joblib
 - coverage 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - python-snappy
 - numba>=0.38
 - cffi
+- tbb
 - pyarrow
 - joblib
 - coverage 

--- a/lenskit/_mkl_ops.py
+++ b/lenskit/_mkl_ops.py
@@ -78,6 +78,8 @@ class SparseM:
         vals = np.require(csr.values, np.float_, 'C')
 
         m = SparseM()
+        _logger.debug('creating MKL matrix 0x%08x from %dx%d CSR',
+                      id(m), csr.nrows, csr.ncols)
         _sp = _mkl_ffi.cast('int*', sp.ctypes.data)
         _ep = _mkl_ffi.cast('int*', ep.ctypes.data)
         _cols = _mkl_ffi.cast('int*', cols.ctypes.data)
@@ -94,7 +96,7 @@ class SparseM:
 
     def __del__(self):
         if self.h_ptr[0]:
-            _logger.debug('destroying MKL sparse matrix')
+            _logger.debug('destroying MKL sparse matrix 0x%08x', id(self))
             _mkl_lib.mkl_sparse_destroy(self.handle)
 
     def export(self):

--- a/lenskit/algorithms/basic.py
+++ b/lenskit/algorithms/basic.py
@@ -9,7 +9,7 @@ import pandas as pd
 import numpy as np
 
 from .. import check
-from ..matrix import CSR, sparse_ratings
+from ..matrix import sparse_ratings
 from . import Predictor, Recommender, CandidateSelector
 
 _logger = logging.getLogger(__name__)
@@ -306,9 +306,10 @@ class TopN(Recommender, Predictor):
 
         scores = self.predictor.predict_for_user(user, candidates, ratings)
         scores = scores[scores.notna()]
-        scores = scores.sort_values(ascending=False)
         if n is not None:
-            scores = scores.iloc[:n]
+            scores = scores.nlargest(n)
+        else:
+            scores = scores.sort_values(ascending=False)
         scores.name = 'score'
         scores.index.name = 'item'
         return scores.reset_index()

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -292,6 +292,7 @@ class ItemItem(Predictor):
         assert smat.ncols == nitems
 
         # Count possible neighbors
+        _logger.debug('counting neighbors')
         cv = _CountVisitor(nitems)
         _visit_nbrs(smat.N, cv, self.min_sim, triangular)
         possible = cv.counts
@@ -303,7 +304,8 @@ class ItemItem(Predictor):
         else:
             nnbrs = possible
         nsims = np.sum(nnbrs)
-        _logger.info('truncating %d neighbors to %d', smat.nnz, nsims)
+        _logger.info('[%s] truncating %d neighbors to %d (of %d possible)',
+                     self._timer, smat.nnz, nsims, np.sum(possible))
 
         # set up the target matrix
         trimmed = matrix.CSR.empty((nitems, nitems), nnbrs)
@@ -313,7 +315,7 @@ class ItemItem(Predictor):
         _visit_nbrs(smat.N, av, self.min_sim, triangular)
         assert np.all(av.pointers == trimmed.rowptrs[1:])
 
-        _logger.info('sorting neighborhoods')
+        _logger.info('[%s] sorting neighborhoods', self._timer)
         _sort_nbrs(trimmed.N)
 
         # and construct the new matrix

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -236,12 +236,13 @@ class ItemItem(Predictor):
 
         _logger.info('[%s] multiplying matrix with MKL', self._timer)
         smat = mkl.csr_syrk(rmat)
+        _logger.debug('extracting row indexes')
         rows = smat.rowinds()
         cols = smat.colinds
         vals = smat.values
 
         rows, cols, vals = self._filter_similarities(rows, cols, vals)
-        del smat
+        del smat  # free a little memory
         nnz = len(rows)
 
         _logger.info('[%s] making matrix symmetric (%d -> %d nnz)',
@@ -273,7 +274,13 @@ class ItemItem(Predictor):
 
         _logger.info('[%s] filter keeps %d of %d entries', self._timer, np.sum(mask), len(rows))
 
-        return rows[mask], cols[mask], vals[mask]
+        rows = rows[mask]
+        _logger.debug('shrunk rows: %s', rows)
+        cols = cols[mask]
+        _logger.debug('shrunk cols: %s', rows)
+        vals = vals[mask]
+        _logger.debug('shrunk vals: %s', rows)
+        return rows, cols, vals
 
     def _select_similarities(self, nitems, rows, cols, vals):
         _logger.info('[%s] ordering similarities', self._timer)

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -243,7 +243,8 @@ class ItemItem(Predictor):
         del smat
         nnz = len(rows)
 
-        _logger.info('[%s] making matrix symmetric (%d nnz)', self._timer, nnz)
+        _logger.info('[%s] making matrix symmetric (%d -> %d nnz)',
+                     self._timer, nnz, nnz * 2)
         rows = np.resize(rows, nnz * 2)
         cols = np.resize(cols, nnz * 2)
         vals = np.resize(vals, nnz * 2)

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -40,7 +40,7 @@ def _count_nbrs(smat: matrix._CSR, thresh: float, triangular: bool):
 @njit(nogil=True)
 def _copy_nbrs(smat: matrix._CSR, out: matrix._CSR, limits, thresh: float, triangular: bool):
     "Count the number of neighbors passing the threshold for each row."
-    ptrs = smat.rowptrs[:-1].copy()
+    ptrs = out.rowptrs[:-1].copy()
     scs = smat.colinds
     svs = smat.values
     orps = out.rowptrs

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -250,11 +250,13 @@ class ItemItem(Predictor):
         _logger.debug('collecting garbage')
         gc.collect()
         _logger.debug('resizing %d-byte row array', rows.nbytes)
-        rows = np.resize(rows, nnz * 2)
-        _logger.debug('resizing %d-byte col array', rows.nbytes)
-        cols = np.resize(cols, nnz * 2)
-        _logger.debug('resizing %d-byte val array', rows.nbytes)
-        vals = np.resize(vals, nnz * 2)
+        rows.resize(nnz * 2)
+        _logger.debug('resizing %d-byte col array', cols.nbytes)
+        cols.resize(nnz * 2)
+        _logger.debug('resizing %d-byte val array', vals.nbytes)
+        vals.resize(nnz * 2)
+
+        _logger.debug('copying data into back half of the arrays')
         rows[nnz:] = cols[:nnz]
         cols[nnz:] = rows[:nnz]
         vals[nnz:] = vals[:nnz]
@@ -275,11 +277,8 @@ class ItemItem(Predictor):
         _logger.info('[%s] filter keeps %d of %d entries', self._timer, np.sum(mask), len(rows))
 
         rows = rows[mask]
-        _logger.debug('shrunk rows: %s', (rows.shape, rows.dtype, rows.flags))
         cols = cols[mask]
-        _logger.debug('shrunk cols: %s', (cols.shape, cols.dtype, cols.flags))
         vals = vals[mask]
-        _logger.debug('shrunk vals: %s', (vals.shape, vals.dtype, vals.flags))
         return rows, cols, vals
 
     def _select_similarities(self, nitems, rows, cols, vals):

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -275,11 +275,11 @@ class ItemItem(Predictor):
         _logger.info('[%s] filter keeps %d of %d entries', self._timer, np.sum(mask), len(rows))
 
         rows = rows[mask]
-        _logger.debug('shrunk rows: %s', rows)
+        _logger.debug('shrunk rows: %s', (rows.shape, rows.dtype, rows.flags))
         cols = cols[mask]
-        _logger.debug('shrunk cols: %s', rows)
+        _logger.debug('shrunk cols: %s', (cols.shape, cols.dtype, cols.flags))
         vals = vals[mask]
-        _logger.debug('shrunk vals: %s', rows)
+        _logger.debug('shrunk vals: %s', (vals.shape, vals.dtype, vals.flags))
         return rows, cols, vals
 
     def _select_similarities(self, nitems, rows, cols, vals):

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -290,9 +290,9 @@ class ItemItem(Predictor):
         possible = cv.counts
 
         # Count neighbors to use neighbors
-        min_nbrs = self.min_nbrs
-        if min_nbrs is not None and min_nbrs > 0:
-            nnbrs = np.maximum(possible, min_nbrs, dtype=np.int32)
+        save_nbrs = self.save_nbrs
+        if save_nbrs is not None and save_nbrs > 0:
+            nnbrs = np.minimum(possible, save_nbrs, dtype=np.int32)
         else:
             nnbrs = possible
         nsims = np.sum(nnbrs)

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -39,11 +39,11 @@ def _count_nbrs(mat: matrix._CSR, thresh: float, triangular: bool):
 
 
 @njit
-def _insert(drps, dcs, dvs, used, limits, i, c, v):
+def _insert(dst, used, limits, i, c, v):
     "Insert one item into a heap"
-    sp = drps[i]
+    sp = dst.rowptrs[i]
     ep = sp + used[i]
-    ep = kvp_minheap_insert(sp, ep, limits[i], c, v, dcs, dvs)
+    ep = kvp_minheap_insert(sp, ep, limits[i], c, v, dst.colinds, dst.values)
     used[i] = ep - sp
 
 
@@ -58,10 +58,6 @@ def _copy_nbrs(src: matrix._CSR, dst: matrix._CSR, limits, thresh: float, triang
     used = np.zeros(dst.nrows, dtype=np.int32)
 
     for p in prange(4):
-        drps = dst.rowptrs
-        dcs = dst.colinds
-        dvs = dst.values
-
         for i in range(src.nrows):
             sp, ep = src.row_extent(i)
 
@@ -70,9 +66,9 @@ def _copy_nbrs(src: matrix._CSR, dst: matrix._CSR, limits, thresh: float, triang
                 v = src.values[j]
                 if c != i and v >= thresh:
                     if _mine(p, i):
-                        _insert(drps, dcs, dvs, used, limits, i, c, v)
+                        _insert(dst, used, limits, i, c, v)
                     if triangular and _mine(p, c):
-                        _insert(drps, dcs, dvs, used, limits, c, i, v)
+                        _insert(dst, used, limits, c, i, v)
 
     return used
 

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -5,6 +5,7 @@ Item-based k-NN collaborative filtering.
 import pathlib
 import logging
 import warnings
+import gc
 
 import pandas as pd
 import numpy as np
@@ -245,8 +246,13 @@ class ItemItem(Predictor):
 
         _logger.info('[%s] making matrix symmetric (%d -> %d nnz)',
                      self._timer, nnz, nnz * 2)
+        _logger.debug('collecting garbage')
+        gc.collect()
+        _logger.debug('resizing %d-byte row array', rows.nbytes)
         rows = np.resize(rows, nnz * 2)
+        _logger.debug('resizing %d-byte col array', rows.nbytes)
         cols = np.resize(cols, nnz * 2)
+        _logger.debug('resizing %d-byte val array', rows.nbytes)
         vals = np.resize(vals, nnz * 2)
         rows[nnz:] = cols[:nnz]
         cols[nnz:] = rows[:nnz]

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -160,6 +160,20 @@ class ItemItem(Predictor):
     is not terribly configurable; it hard-codes design decisions found to work well in the previous
     Java-based LensKit code.
 
+    Args:
+        nnbrs(int):
+            the maximum number of neighbors for scoring each item (``None`` for unlimited)
+        min_nbrs(int): the minimum number of neighbors for scoring each item
+        min_sim(double): minimum similarity threshold for considering a neighbor
+        save_nbrs(double):
+            the number of neighbors to save per item in the trained model
+            (``None`` for unlimited)
+        center(bool):
+            whether to normalize (mean-center) rating vectors.  Turn this off when working
+            with unary data and other data types that don't respond well to centering.
+        aggregate:
+            the type of aggregation to do. Can be ``weighted-average`` or ``sum``.
+
     Attributes:
         item_index_(pandas.Index): the index of item IDs.
         item_means_(numpy.ndarray): the mean rating for each known item.
@@ -171,21 +185,6 @@ class ItemItem(Predictor):
 
     def __init__(self, nnbrs, min_nbrs=1, min_sim=1.0e-6, save_nbrs=None,
                  center=True, aggregate='weighted-average'):
-        """
-        Args:
-            nnbrs(int):
-                the maximum number of neighbors for scoring each item (``None`` for unlimited)
-            min_nbrs(int): the minimum number of neighbors for scoring each item
-            min_sim(double): minimum similarity threshold for considering a neighbor
-            save_nbrs(double):
-                the number of neighbors to save per item in the trained model
-                (``None`` for unlimited)
-            center(bool):
-                whether to normalize (mean-center) rating vectors.  Turn this off when working
-                with unary data and other data types that don't respond well to centering.
-            aggregate:
-                the type of aggregation to do. Can be ``weighted-average`` or ``sum``.
-        """
         self.nnbrs = nnbrs
         if self.nnbrs is not None and self.nnbrs < 1:
             self.nnbrs = -1

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -19,9 +19,7 @@ from . import Predictor
 _logger = logging.getLogger(__name__)
 
 
-@njit(n.int32[:](matrix._CSR.class_type.instance_type,
-                 n.float64, n.bool_),
-      nogil=True)
+@njit(nogil=True)
 def _count_nbrs(mat: matrix._CSR, thresh: float, triangular: bool):
     "Count the number of neighbors passing the threshold for each row."
     counts = np.zeros(mat.nrows, dtype=np.int32)
@@ -54,10 +52,7 @@ def _mine(part, val):
     return (val & 0xC) >> 2 == part
 
 
-@njit(n.int32[:](matrix._CSR.class_type.instance_type,
-                 matrix._CSR.class_type.instance_type,
-                 n.int32[:], n.float64, n.bool_),
-      nogil=True, parallel=True)
+@njit(nogil=True, parallel=True)
 def _copy_nbrs(src: matrix._CSR, dst: matrix._CSR, limits, thresh: float, triangular: bool):
     "Copy neighbors into the output matrix."
     used = np.zeros(dst.nrows, dtype=np.int32)
@@ -78,8 +73,7 @@ def _copy_nbrs(src: matrix._CSR, dst: matrix._CSR, limits, thresh: float, triang
     return used
 
 
-@njit(n.void(matrix._CSR.class_type.instance_type),
-      nogil=True, parallel=True)
+@njit(nogil=True, parallel=True)
 def _sort_nbrs(smat):
     for i in prange(smat.nrows):
         sp, ep = smat.row_extent(i)

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -49,7 +49,7 @@ def _copy_nbrs(smat: matrix._CSR, out: matrix._CSR, limits, thresh: float, trian
             if c != i and v >= thresh:
                 sp = out.rowptrs[i]
                 ep = ptrs[i]
-                ep = kvp_minheap_insert(sp, ep, limits[i], j, v, out.colinds, out.values)
+                ep = kvp_minheap_insert(sp, ep, limits[i], c, v, out.colinds, out.values)
                 ptrs[i] = ep
                 if triangular:
                     sp = out.rowptrs[c]

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -7,7 +7,6 @@ import logging
 
 import pandas as pd
 import numpy as np
-from scipy import stats
 
 from numba import njit
 

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -3,17 +3,88 @@ User-based k-NN collaborative filtering.
 """
 
 from sys import intern
-import pathlib
 import logging
 
 import pandas as pd
 import numpy as np
 from scipy import stats
 
+from numba import njit
+
 from .. import util, matrix
 from . import Predictor
+from ..util.accum import kvp_minheap_insert
 
 _logger = logging.getLogger(__name__)
+
+
+@njit
+def _agg_weighted_avg(iur, item, sims, use):
+    """
+    Weighted-average aggregate.
+
+    Args:
+        iur(matrix._CSR): the item-user ratings matrix
+        item(int): the item index in ``iur``
+        sims(numpy.ndarray): the similarities for the users who have rated ``item``
+        use(numpy.ndarray): positions in sims and the rating row to actually use
+    """
+    rates = iur.row_vs(item)
+    num = 0.0
+    den = 0.0
+    for j in use:
+        num += rates[j] * sims[j]
+        den += np.abs(sims[j])
+    return num / den
+
+
+@njit
+def _agg_sum(iur, item, sims, use):
+    """
+    Sum aggregate
+
+    Args:
+        iur(matrix._CSR): the item-user ratings matrix
+        item(int): the item index in ``iur``
+        sims(numpy.ndarray): the similarities for the users who have rated ``item``
+        use(numpy.ndarray): positions in sims and the rating row to actually use
+    """
+    x = 0.0
+    for j in use:
+        x += sims[j]
+    return x
+
+
+@njit
+def _score(items, results, iur, sims, nnbrs, min_sim, min_nbrs, agg):
+    h_ks = np.empty(nnbrs, dtype=np.int32)
+    h_vs = np.empty(nnbrs)
+
+    for i in range(len(results)):
+        item = items[i]
+        if item < 0:
+            continue
+
+        h_ep = 0
+
+        # who has rated this item?
+        i_users = iur.row_cs(item)
+
+        # what are their similarities to our target user?
+        i_sims = sims[i_users]
+
+        # which of these neighbors do we really want to use?
+        for j, s in enumerate(i_sims):
+            if np.abs(s) < 1.0e-10:
+                break
+            if min_sim is not None and s < min_sim:
+                break
+            h_ep = kvp_minheap_insert(0, h_ep, nnbrs, j, s, h_ks, h_vs)
+
+        if h_ep < min_nbrs:
+            continue
+
+        results[i] = agg(iur, item, i_sims, h_ks[:h_ep])
 
 
 class UserUser(Predictor):
@@ -130,38 +201,16 @@ class UserUser(Predictor):
 
         results = np.full(len(items), np.nan, dtype=np.float_)
         ri_pos = self.item_index_.get_indexer(items.values)
-        for i in range(len(results)):
-            ipos = ri_pos[i]
-            if ipos < 0:
-                continue
+        if self.aggregate == self.AGG_WA:
+            agg = _agg_weighted_avg
+        elif self.aggregate == self.AGG_SUM:
+            agg = _agg_sum
+        else:
+            raise ValueError('invalid aggregate ' + self.aggregate)
 
-            # get the item's users & ratings
-            i_users = self.transpose_matrix_.row_cs(ipos)
-
-            # find and limit the neighbors
-            i_sims = nsims[i_users]
-            mask = np.abs(i_sims >= 1.0e-10)
-
-            if self.nnbrs is not None and self.nnbrs > 0:
-                rank = stats.rankdata(-i_sims, 'ordinal')
-                mask = np.logical_and(mask, rank <= self.nnbrs)
-            if self.min_sim is not None:
-                mask = np.logical_and(mask, i_sims >= self.min_sim)
-
-            if np.sum(mask) < self.min_nbrs:
-                continue
-
-            # now we have picked weights, take a dot product
-            ism = i_sims[mask]
-            if self.aggregate == self.AGG_WA:
-                i_rates = self.transpose_matrix_.row_vs(ipos)
-                v = np.dot(i_rates[mask], ism)
-                v = v / np.sum(ism)
-            elif self.aggregate == self.AGG_SUM:
-                v = np.sum(ism)
-            else:
-                raise ValueError('invalid aggregate ' + self.aggregate)
-            results[i] = v + umean
+        _score(ri_pos, results, self.transpose_matrix_.N, nsims,
+               self.nnbrs, self.min_sim, self.min_nbrs, agg)
+        results += umean
 
         results = pd.Series(results, index=items, name='prediction')
 

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -22,6 +22,17 @@ class UserUser(Predictor):
     is not terribly configurable; it hard-codes design decisions found to work well in the previous
     Java-based LensKit code.
 
+    Args:
+        nnbrs(int):
+            the maximum number of neighbors for scoring each item (``None`` for unlimited)
+        min_nbrs(int): the minimum number of neighbors for scoring each item
+        min_sim(double): minimum similarity threshold for considering a neighbor
+        center(bool):
+            whether to normalize (mean-center) rating vectors.  Turn this off when working
+            with unary data and other data types that don't respond well to centering.
+        aggregate:
+            the type of aggregation to do. Can be ``weighted-average`` or ``sum``.
+
     Attributes:
         user_index_(pandas.Index): User index.
         item_index_(pandas.Index): Item index.
@@ -33,18 +44,6 @@ class UserUser(Predictor):
     AGG_WA = intern('weighted-average')
 
     def __init__(self, nnbrs, min_nbrs=1, min_sim=0, center=True, aggregate='weighted-average'):
-        """
-        Args:
-            nnbrs(int):
-                the maximum number of neighbors for scoring each item (``None`` for unlimited)
-            min_nbrs(int): the minimum number of neighbors for scoring each item
-            min_sim(double): minimum similarity threshold for considering a neighbor
-            center(bool):
-                whether to normalize (mean-center) rating vectors.  Turn this off when working
-                with unary data and other data types that don't respond well to centering.
-            aggregate:
-                the type of aggregation to do. Can be ``weighted-average`` or ``sum``.
-        """
         self.nnbrs = nnbrs
         self.min_nbrs = min_nbrs
         self.min_sim = min_sim

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -67,27 +67,17 @@ class UserUser(Predictor):
 
         # mean-center ratings
         if self.center:
-            umeans = np.zeros(len(users))
-            for u in range(uir.nrows):
-                sp, ep = uir.row_extent(u)
-                v = uir.values[sp:ep]
-                umeans[u] = m = v.mean()
-                uir.values[sp:ep] -= m
+            umeans = uir.normalize_rows('center')
         else:
             umeans = None
 
         # compute centered transpose
         iur = uir.transpose()
 
-        # L2-normalize ratings
+        # L2-normalize ratings so dot product is cosine
         if uir.values is None:
             uir.values = np.full(uir.nnz, 1.0)
-        for u in range(uir.nrows):
-            sp, ep = uir.row_extent(u)
-            v = uir.values[sp:ep]
-            n = np.linalg.norm(v)
-            if n > 0:
-                uir.values[sp:ep] /= n
+        uir.normalize_rows('unit')
 
         mkl = matrix.mkl_ops()
         mkl_m = mkl.SparseM.from_csr(uir) if mkl else None

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -59,6 +59,7 @@ def _agg_sum(iur, item, sims, use):
 def _score(items, results, iur, sims, nnbrs, min_sim, min_nbrs, agg):
     h_ks = np.empty(nnbrs, dtype=np.int32)
     h_vs = np.empty(nnbrs)
+    used = np.zeros(len(results), dtype=np.int32)
 
     for i in range(len(results)):
         item = items[i]
@@ -76,15 +77,18 @@ def _score(items, results, iur, sims, nnbrs, min_sim, min_nbrs, agg):
         # which of these neighbors do we really want to use?
         for j, s in enumerate(i_sims):
             if np.abs(s) < 1.0e-10:
-                break
+                continue
             if min_sim is not None and s < min_sim:
-                break
+                continue
             h_ep = kvp_minheap_insert(0, h_ep, nnbrs, j, s, h_ks, h_vs)
 
         if h_ep < min_nbrs:
             continue
 
         results[i] = agg(iur, item, i_sims, h_ks[:h_ep])
+        used[i] = h_ep
+
+    return used
 
 
 class UserUser(Predictor):

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -50,7 +50,7 @@ def _csr_delegate(name):
 @jitclass({
     'nrows': n.int32,
     'ncols': n.int32,
-    'nnz': n.int32,
+    'nnz': n.int64,
     'rowptrs': n.int32[:],
     'colinds': n.int32[:],
     'values': n.optional(n.float64[:])

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -101,6 +101,13 @@ class _CSR:
         else:
             return self.values[sp:ep]
 
+    def rowinds(self):
+        ris = np.zeros(self.nnz, np.int32)
+        for i in range(self.nrows):
+            sp, ep = self.row_extent(i)
+            ris[sp:ep] = i
+        return ris
+
 
 class CSR:
     """
@@ -241,7 +248,7 @@ class CSR:
 
         .. note:: This method is not available from Numba.
         """
-        return np.repeat(np.arange(self.nrows, dtype=np.int32), np.diff(self.rowptrs))
+        return self.N.rowinds()
 
     def row(self, row):
         """

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -418,6 +418,8 @@ def _center_rows(csr: _CSR):
     means = np.zeros(csr.nrows)
     for i in range(csr.nrows):
         sp, ep = csr.row_extent(i)
+        if sp == ep:
+            continue  # empty row
         vs = csr.row_vs(i)
         m = np.mean(vs)
         means[i] = m
@@ -431,6 +433,8 @@ def _unit_rows(csr: _CSR):
     norms = np.zeros(csr.nrows)
     for i in range(csr.nrows):
         sp, ep = csr.row_extent(i)
+        if sp == ep:
+            continue  # empty row
         vs = csr.row_vs(i)
         m = np.linalg.norm(vs)
         norms[i] = m

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -147,6 +147,27 @@ class CSR:
             self.N = _CSR(nrows, ncols, nnz, ptrs, inds, vals)
 
     @classmethod
+    def empty(cls, shape, row_nnzs):
+        """
+        Create an empty CSR matrix.
+
+        Args:
+            shape(tuple): the array shape (rows,cols)
+            row_nnzs(array-like): the number of nonzero entries for each row
+        """
+        nrows, ncols = shape
+        assert len(row_nnzs) == nrows
+        nnz = np.sum(row_nnzs)
+
+        rowptrs = np.zeros(nrows + 1, dtype=np.int32)
+        rowptrs[1:] = np.cumsum(row_nnzs)
+
+        colinds = np.full(nnz, -1, dtype=np.int32)
+        values = np.full(nnz, np.nan)
+
+        return cls(nrows, ncols, nnz, rowptrs, colinds, values)
+
+    @classmethod
     def from_coo(cls, rows, cols, vals, shape=None):
         """
         Create a CSR matrix from data in COO format.

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -50,7 +50,7 @@ def _csr_delegate(name):
 @jitclass({
     'nrows': n.int32,
     'ncols': n.int32,
-    'nnz': n.int64,
+    'nnz': n.int32,
     'rowptrs': n.int32[:],
     'colinds': n.int32[:],
     'values': n.optional(n.float64[:])
@@ -225,7 +225,8 @@ class CSR:
 
     def to_scipy(self):
         """
-        Convert a CSR matrix to a SciPy :py:class:`scipy.sparse.csr_matrix`.
+        Convert a CSR matrix to a SciPy :py:class:`scipy.sparse.csr_matrix`.  Avoids copying
+        if possible.
 
         Args:
             self(CSR): A CSR matrix.

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -438,7 +438,7 @@ def _unit_rows(csr: _CSR):
     return norms
 
 
-@njit
+@njit(nogil=True)
 def _csr_align(rowinds, nrows, rowptrs, align):
     rcts = np.zeros(nrows, dtype=np.int32)
     for r in rowinds:

--- a/lenskit/matrix.py
+++ b/lenskit/matrix.py
@@ -51,9 +51,9 @@ def _csr_delegate(name):
     'nrows': n.int32,
     'ncols': n.int32,
     'nnz': n.int32,
-    'rowptrs': n.int32[:],
-    'colinds': n.int32[:],
-    'values': n.optional(n.float64[:])
+    'rowptrs': n.int32[::1],
+    'colinds': n.int32[::1],
+    'values': n.optional(n.float64[::1])
 })
 class _CSR:
     """

--- a/lenskit/util/accum.py
+++ b/lenskit/util/accum.py
@@ -13,7 +13,7 @@ def _swap(a, i, j):
     a[j] = t
 
 
-@njit(nogil=True)
+@njit
 def _ind_downheap(pos: int, size, keys, values):
     min = pos
     left = 2*pos + 1

--- a/lenskit/util/accum.py
+++ b/lenskit/util/accum.py
@@ -96,7 +96,7 @@ class Accumulator:
             parent = (current - 1) // 2
 
 
-@njit
+@njit(nogil=True)
 def _pair_downheap(pos: int, sp, limit, ks, vs):
     min = pos
     left = 2*pos + 1
@@ -112,7 +112,7 @@ def _pair_downheap(pos: int, sp, limit, ks, vs):
         _pair_downheap(min, sp, limit, ks, vs)
 
 
-@njit
+@njit(nogil=True)
 def _pair_upheap(pos, sp, ks, vs):
     parent = (pos - 1) // 2
     while pos > 0 and vs[sp + parent] > vs[sp + pos]:
@@ -122,14 +122,14 @@ def _pair_upheap(pos, sp, ks, vs):
         parent = (pos - 1) // 2
 
 
-@njit
-def kvp_insert(sp, ep, limit, k, v, keys, vals):
+@njit(nogil=True)
+def kvp_minheap_insert(sp, ep, limit, k, v, keys, vals):
     """
-    Insert a value (with key) into a heap, only keeping the top values.
+    Insert a value (with key) into a heap-organized array subset, only keeping the top values.
 
     Args:
-        sp(int): the start of the heap
-        ep(int): the current end of the heap
+        sp(int): the start of the heap (inclusive)
+        ep(int): the current end of the heap (exclusive)
         limit(int): the maximum size of the heap
         k: the key
         v: the value (used for sorting)
@@ -159,3 +159,21 @@ def kvp_insert(sp, ep, limit, k, v, keys, vals):
     else:
         # heap is full and new value doesn't belong
         return ep
+
+
+@njit(nogil=True)
+def kvp_minheap_sort(sp, ep, keys, vals):
+    """
+    Sort a heap-organized array subset by decreasing values.
+
+    Args:
+        sp(int): the start of the heap (inclusive).
+        ep(int): the end of the heap (exclusive).
+        keys: the key array
+        vals: the value array
+    """
+
+    for i in range(ep-1, sp, -1):
+        _swap(keys, i, sp)
+        _swap(vals, i, sp)
+        _pair_downheap(0, sp, i-sp, keys, vals)

--- a/lenskit/util/accum.py
+++ b/lenskit/util/accum.py
@@ -98,18 +98,22 @@ class Accumulator:
 
 @njit(nogil=True)
 def _pair_downheap(pos: int, sp, limit, ks, vs):
-    min = pos
-    left = 2*pos + 1
-    right = 2*pos + 2
-    if left < limit and vs[sp + left] < vs[sp + min]:
-        min = left
-    if right < limit and vs[sp + right] < vs[sp + min]:
-        min = right
-    if min != pos:
-        # we want to swap!
-        _swap(vs, sp + pos, sp + min)
-        _swap(ks, sp + pos, sp + min)
-        _pair_downheap(min, sp, limit, ks, vs)
+    finished = False
+    while not finished:
+        min = pos
+        left = 2*pos + 1
+        right = 2*pos + 2
+        if left < limit and vs[sp + left] < vs[sp + min]:
+            min = left
+        if right < limit and vs[sp + right] < vs[sp + min]:
+            min = right
+        if min != pos:
+            # we want to swap!
+            _swap(vs, sp + pos, sp + min)
+            _swap(ks, sp + pos, sp + min)
+            pos = min
+        else:
+            finished = True
 
 
 @njit(nogil=True)

--- a/lenskit/util/accum.py
+++ b/lenskit/util/accum.py
@@ -6,7 +6,7 @@ import numpy as np
 from numba import njit, jitclass, int32, double
 
 
-@njit(nogil=True)
+@njit
 def _swap(a, i, j):
     t = a[i]
     a[i] = a[j]
@@ -96,7 +96,7 @@ class Accumulator:
             parent = (current - 1) // 2
 
 
-@njit(nogil=True)
+@njit
 def _pair_downheap(pos: int, sp, limit, ks, vs):
     finished = False
     while not finished:
@@ -116,7 +116,7 @@ def _pair_downheap(pos: int, sp, limit, ks, vs):
             finished = True
 
 
-@njit(nogil=True)
+@njit
 def _pair_upheap(pos, sp, ks, vs):
     parent = (pos - 1) // 2
     while pos > 0 and vs[sp + parent] > vs[sp + pos]:
@@ -126,7 +126,7 @@ def _pair_upheap(pos, sp, ks, vs):
         parent = (pos - 1) // 2
 
 
-@njit('int64(int64,int64,int64,int32,float64,int32[:],float64[:])', nogil=True)
+@njit('int64(int64,int64,int64,int32,float64,int32[:],float64[:])')
 def kvp_minheap_insert(sp, ep, limit, k, v, keys, vals):
     """
     Insert a value (with key) into a heap-organized array subset, only keeping the top values.
@@ -165,7 +165,7 @@ def kvp_minheap_insert(sp, ep, limit, k, v, keys, vals):
         return ep
 
 
-@njit('void(int64,int64,int32[:],float64[:])', nogil=True)
+@njit('void(int64,int64,int32[:],float64[:])')
 def kvp_minheap_sort(sp, ep, keys, vals):
     """
     Sort a heap-organized array subset by decreasing values.

--- a/lenskit/util/accum.py
+++ b/lenskit/util/accum.py
@@ -6,14 +6,14 @@ import numpy as np
 from numba import njit, jitclass, int32, double
 
 
-@njit
+@njit(nogil=True)
 def _swap(a, i, j):
     t = a[i]
     a[i] = a[j]
     a[j] = t
 
 
-@njit
+@njit(nogil=True)
 def _ind_downheap(pos: int, size, keys, values):
     min = pos
     left = 2*pos + 1
@@ -122,7 +122,7 @@ def _pair_upheap(pos, sp, ks, vs):
         parent = (pos - 1) // 2
 
 
-@njit(nogil=True)
+@njit('int64(int64,int64,int64,int32,float64,int32[:],float64[:])', nogil=True)
 def kvp_minheap_insert(sp, ep, limit, k, v, keys, vals):
     """
     Insert a value (with key) into a heap-organized array subset, only keeping the top values.
@@ -161,7 +161,7 @@ def kvp_minheap_insert(sp, ep, limit, k, v, keys, vals):
         return ep
 
 
-@njit(nogil=True)
+@njit('void(int64,int64,int32[:],float64[:])', nogil=True)
 def kvp_minheap_sort(sp, ep, keys, vals):
     """
     Sort a heap-organized array subset by decreasing values.

--- a/lenskit/util/test.py
+++ b/lenskit/util/test.py
@@ -6,6 +6,9 @@ import os
 import os.path
 import logging
 
+import numpy as np
+from .. import matrix
+
 import pytest
 
 from lenskit.datasets import MovieLens, ML100K
@@ -24,6 +27,18 @@ def ml_sample():
     top_rates = ratings.loc[top.index, :]
     _log.info('top 500 items yield %d of %d ratings', len(top_rates), len(ratings))
     return top_rates.reset_index()
+
+
+def rand_csr(nrows=100, ncols=50, nnz=1000, values=True):
+    "Generate a random CSR for testing."
+    coords = np.random.choice(np.arange(ncols * nrows, dtype=np.int32), nnz, False)
+    rows = np.mod(coords, nrows, dtype=np.int32)
+    cols = np.floor_divide(coords, nrows, dtype=np.int32)
+    if values:
+        vals = np.random.randn(nnz)
+    else:
+        vals = None
+    return matrix.CSR.from_coo(rows, cols, vals, (nrows, ncols))
 
 
 wantjit = pytest.mark.skipif('NUMBA_DISABLE_JIT' in os.environ,

--- a/tests/test_knn_user_user.py
+++ b/tests/test_knn_user_user.py
@@ -189,19 +189,26 @@ def test_uu_known_preds():
     _log.info('reading known predictions from %s', pred_file)
     known_preds = pd.read_csv(str(pred_file))
     pairs = known_preds.loc[:, ['user', 'item']]
+    _log.info('generating %d known predictions', len(pairs))
 
     preds = batch.predict(algo, pairs)
     merged = pd.merge(known_preds.rename(columns={'prediction': 'expected'}), preds)
     assert len(merged) == len(preds)
     merged['error'] = merged.expected - merged.prediction
-    assert not any(merged.prediction.isna() & merged.expected.notna())
+    try:
+        assert not any(merged.prediction.isna() & merged.expected.notna())
+    except AssertionError as e:
+        bad = merged[merged.prediction.isna() & merged.expected.notna()]
+        _log.error('%d missing predictions:\n%s', len(bad), bad)
+        raise e
+
     err = merged.error
     err = err[err.notna()]
     try:
         assert all(err.abs() < 0.01)
     except AssertionError as e:
         bad = merged[merged.error.notna() & (merged.error.abs() >= 0.01)]
-        _log.error('erroneous predictions:\n%s', bad)
+        _log.error('%d erroneous predictions:\n%s', len(bad), bad)
         raise e
 
 

--- a/tests/test_knn_user_user.py
+++ b/tests/test_knn_user_user.py
@@ -6,7 +6,7 @@ import pickle
 
 import pandas as pd
 import numpy as np
-from scipy import sparse as sps
+from scipy.sparse import linalg as spla
 
 from pytest import approx, mark
 
@@ -145,7 +145,7 @@ def test_uu_implicit():
     assert algo.user_means_ is None
 
     mat = algo.rating_matrix_.to_scipy()
-    norms = sps.linalg.norm(mat, 2, 1)
+    norms = spla.norm(mat, 2, 1)
     assert norms == approx(1.0)
 
     preds = algo.predict_for_user(50, [1, 2, 42])

--- a/tests/test_matrix_csr.py
+++ b/tests/test_matrix_csr.py
@@ -198,6 +198,24 @@ def test_csr_transpose_coords():
         assert row[r] == 1
 
 
+def test_csr_transpose_many():
+    for i in range(50):
+        mat = np.random.randn(100, 50)
+        mat[mat <= 0] = 0
+        smat = sps.csr_matrix(mat)
+
+        csr = lm.CSR.from_scipy(smat)
+        csrt = csr.transpose()
+        assert csrt.nrows == 50
+        assert csrt.ncols == 100
+
+        s2 = csrt.to_scipy()
+        smat = smat.T.tocsr()
+        assert all(smat.indptr == csrt.rowptrs)
+
+        assert np.all(s2.toarray() == smat.toarray())
+
+
 def test_csr_row_nnzs():
     # initialize sparse matrix
     mat = np.random.randn(10, 5)

--- a/tests/test_matrix_csr.py
+++ b/tests/test_matrix_csr.py
@@ -324,8 +324,9 @@ def test_mean_center():
 
         for i in range(csr.nrows):
             vs = csr.row_vs(i)
-            assert np.mean(vs) == approx(0.0)
-            assert vs + m2[i] == approx(spm.getrow(i).toarray()[0, csr.row_cs(i)])
+            if len(vs) > 0:
+                assert np.mean(vs) == approx(0.0)
+                assert vs + m2[i] == approx(spm.getrow(i).toarray()[0, csr.row_cs(i)])
 
 
 def test_unit_norm():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -40,6 +40,7 @@ def test_stopwatch_long_str():
     s = str(w)
     assert s.endswith('s')
 
+
 def test_stopwatch_minutes():
     w = lku.Stopwatch()
     w.stop()
@@ -47,6 +48,7 @@ def test_stopwatch_minutes():
     s = str(w)
     p = re.compile(r'1m2.\d\ds')
     assert p.match(s)
+
 
 def test_stopwatch_hours():
     w = lku.Stopwatch()
@@ -57,113 +59,9 @@ def test_stopwatch_hours():
     assert p.match(s)
 
 
-def test_accum_init_empty():
-    values = np.empty(0)
-    acc = lku.Accumulator(values, 10)
-
-    assert acc is not None
-    assert acc.size == 0
-    assert acc.peek() < 0
-    assert acc.remove() < 0
-    assert len(acc.top_keys()) == 0
-
-
-def test_accum_add_get():
-    values = np.array([1.5])
-    acc = lku.Accumulator(values, 10)
-
-    assert acc is not None
-    assert acc.size == 0
-    assert acc.peek() < 0
-    assert acc.remove() < 0
-
-    acc.add(0)
-    assert acc.size == 1
-    assert acc.peek() == 0
-    assert acc.remove() == 0
-    assert acc.size == 0
-    assert acc.peek() == -1
-
-
-def test_accum_add_a_few():
-    values = np.array([1.5, 2, -1])
-    acc = lku.Accumulator(values, 10)
-
-    assert acc is not None
-    assert acc.size == 0
-
-    acc.add(1)
-    acc.add(0)
-    acc.add(2)
-
-    assert acc.size == 3
-    assert acc.peek() == 2
-    assert acc.remove() == 2
-    assert acc.size == 2
-    assert acc.remove() == 0
-    assert acc.remove() == 1
-    assert acc.size == 0
-
-
-def test_accum_add_a_few_lim():
-    values = np.array([1.5, 2, -1])
-    acc = lku.Accumulator(values, 2)
-
-    assert acc is not None
-    assert acc.size == 0
-
-    acc.add(1)
-    acc.add(0)
-    acc.add(2)
-
-    assert acc.size == 2
-    assert acc.remove() == 0
-    assert acc.size == 1
-    assert acc.remove() == 1
-    assert acc.size == 0
-
-
-def test_accum_add_more_lim():
-    for run in range(10):
-        values = np.random.randn(100)
-        acc = lku.Accumulator(values, 10)
-
-        order = np.arange(len(values), dtype=np.int_)
-        np.random.shuffle(order)
-        for i in order:
-            acc.add(i)
-            assert acc.size <= 10
-
-        topn = []
-        # start with the smallest remaining one, grab!
-        while acc.size > 0:
-            topn.append(acc.remove())
-
-        topn = np.array(topn)
-        xs = np.argsort(values)
-        assert all(topn == xs[-10:])
-
-
-def test_accum_top_indices():
-    for run in range(10):
-        values = np.random.randn(100)
-        acc = lku.Accumulator(values, 10)
-
-        order = np.arange(len(values), dtype=np.int_)
-        np.random.shuffle(order)
-        for i in order:
-            acc.add(i)
-            assert acc.size <= 10
-
-        topn = acc.top_keys()
-
-        xs = np.argsort(values)
-        # should be top N values in decreasing order
-        assert all(topn == np.flip(xs[-10:], axis=0))
-
-
 def test_last_memo():
     history = []
+
     def func(foo):
         history.append(foo)
     cache = lku.LastMemo(func)

--- a/tests/test_util_accum.py
+++ b/tests/test_util_accum.py
@@ -1,0 +1,108 @@
+import numpy as np
+
+from lenskit.util import Accumulator
+
+
+def test_accum_init_empty():
+    values = np.empty(0)
+    acc = Accumulator(values, 10)
+
+    assert acc is not None
+    assert acc.size == 0
+    assert acc.peek() < 0
+    assert acc.remove() < 0
+    assert len(acc.top_keys()) == 0
+
+
+def test_accum_add_get():
+    values = np.array([1.5])
+    acc = Accumulator(values, 10)
+
+    assert acc is not None
+    assert acc.size == 0
+    assert acc.peek() < 0
+    assert acc.remove() < 0
+
+    acc.add(0)
+    assert acc.size == 1
+    assert acc.peek() == 0
+    assert acc.remove() == 0
+    assert acc.size == 0
+    assert acc.peek() == -1
+
+
+def test_accum_add_a_few():
+    values = np.array([1.5, 2, -1])
+    acc = Accumulator(values, 10)
+
+    assert acc is not None
+    assert acc.size == 0
+
+    acc.add(1)
+    acc.add(0)
+    acc.add(2)
+
+    assert acc.size == 3
+    assert acc.peek() == 2
+    assert acc.remove() == 2
+    assert acc.size == 2
+    assert acc.remove() == 0
+    assert acc.remove() == 1
+    assert acc.size == 0
+
+
+def test_accum_add_a_few_lim():
+    values = np.array([1.5, 2, -1])
+    acc = Accumulator(values, 2)
+
+    assert acc is not None
+    assert acc.size == 0
+
+    acc.add(1)
+    acc.add(0)
+    acc.add(2)
+
+    assert acc.size == 2
+    assert acc.remove() == 0
+    assert acc.size == 1
+    assert acc.remove() == 1
+    assert acc.size == 0
+
+
+def test_accum_add_more_lim():
+    for run in range(10):
+        values = np.random.randn(100)
+        acc = Accumulator(values, 10)
+
+        order = np.arange(len(values), dtype=np.int_)
+        np.random.shuffle(order)
+        for i in order:
+            acc.add(i)
+            assert acc.size <= 10
+
+        topn = []
+        # start with the smallest remaining one, grab!
+        while acc.size > 0:
+            topn.append(acc.remove())
+
+        topn = np.array(topn)
+        xs = np.argsort(values)
+        assert all(topn == xs[-10:])
+
+
+def test_accum_top_indices():
+    for run in range(10):
+        values = np.random.randn(100)
+        acc = Accumulator(values, 10)
+
+        order = np.arange(len(values), dtype=np.int_)
+        np.random.shuffle(order)
+        for i in order:
+            acc.add(i)
+            assert acc.size <= 10
+
+        topn = acc.top_keys()
+
+        xs = np.argsort(values)
+        # should be top N values in decreasing order
+        assert all(topn == np.flip(xs[-10:], axis=0))

--- a/tests/test_util_accum.py
+++ b/tests/test_util_accum.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from lenskit.util import Accumulator
+from lenskit.util.accum import kvp_insert
 
 
 def test_accum_init_empty():
@@ -106,3 +107,85 @@ def test_accum_top_indices():
         xs = np.argsort(values)
         # should be top N values in decreasing order
         assert all(topn == np.flip(xs[-10:], axis=0))
+
+
+def test_kvp_add_to_empty():
+    ks = np.empty(10, dtype=np.int32)
+    vs = np.empty(10)
+
+    # insert an item
+    n = kvp_insert(0, 0, 10, 5, 3.0, ks, vs)
+
+    # ep has moved
+    assert n == 1
+
+    # item is there
+    assert ks[0] == 5
+    assert vs[0] == 3.0
+
+
+def test_kvp_add_larger():
+    ks = np.empty(10, dtype=np.int32)
+    vs = np.empty(10)
+
+    # insert an item
+    n = kvp_insert(0, 0, 10, 5, 3.0, ks, vs)
+    n = kvp_insert(0, n, 10, 1, 6.0, ks, vs)
+
+    # ep has moved
+    assert n == 2
+
+    # data is there
+    assert all(ks[:2] == [5, 1])
+    assert all(vs[:2] == [3.0, 6.0])
+
+
+def test_kvp_add_smaller():
+    ks = np.empty(10, dtype=np.int32)
+    vs = np.empty(10)
+
+    # insert an item
+    n = kvp_insert(0, 0, 10, 5, 3.0, ks, vs)
+    n = kvp_insert(0, n, 10, 1, 1.0, ks, vs)
+
+    # ep has moved
+    assert n == 2
+
+    # data is there
+    assert all(ks[:2] == [1, 5])
+    assert all(vs[:2] == [1.0, 3.0])
+
+
+def test_kvp_add_several():
+    ks = np.full(10, -1, dtype=np.int32)
+    vs = np.zeros(10)
+
+    n = 0
+
+    for k in range(10):
+        v = np.random.randn()
+        n = kvp_insert(0, n, 10, k, v, ks, vs)
+
+    assert n == 10
+    # all the keys
+    assert all(ks >= 0)
+    assert all(np.sort(ks) == list(range(10)))
+    # value is the smallest
+    assert vs[0] == np.min(vs)
+
+    # it rejects a smaller value; -100 is extremely unlikely
+    n2 = kvp_insert(0, n, 10, 50, -100.0, ks, vs)
+
+    assert n2 == n
+    assert all(ks != 50)
+    assert all(vs > -100.0)
+
+    # it inserts a larger value; all positive is extremely unlikely
+    old_mk = ks[0]
+    old_mv = vs[0]
+    n2 = kvp_insert(0, n, 10, 50, 0.0, ks, vs)
+
+    assert n2 == n
+    assert all(ks != old_mk)
+    assert all(vs > old_mv)
+    assert np.count_nonzero(ks == 50) == 1

--- a/tests/test_util_accum.py
+++ b/tests/test_util_accum.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from lenskit.util import Accumulator
-from lenskit.util.accum import kvp_insert
+from lenskit.util.accum import kvp_minheap_insert, kvp_minheap_sort
 
 
 def test_accum_init_empty():
@@ -114,7 +114,7 @@ def test_kvp_add_to_empty():
     vs = np.empty(10)
 
     # insert an item
-    n = kvp_insert(0, 0, 10, 5, 3.0, ks, vs)
+    n = kvp_minheap_insert(0, 0, 10, 5, 3.0, ks, vs)
 
     # ep has moved
     assert n == 1
@@ -129,8 +129,8 @@ def test_kvp_add_larger():
     vs = np.empty(10)
 
     # insert an item
-    n = kvp_insert(0, 0, 10, 5, 3.0, ks, vs)
-    n = kvp_insert(0, n, 10, 1, 6.0, ks, vs)
+    n = kvp_minheap_insert(0, 0, 10, 5, 3.0, ks, vs)
+    n = kvp_minheap_insert(0, n, 10, 1, 6.0, ks, vs)
 
     # ep has moved
     assert n == 2
@@ -145,8 +145,8 @@ def test_kvp_add_smaller():
     vs = np.empty(10)
 
     # insert an item
-    n = kvp_insert(0, 0, 10, 5, 3.0, ks, vs)
-    n = kvp_insert(0, n, 10, 1, 1.0, ks, vs)
+    n = kvp_minheap_insert(0, 0, 10, 5, 3.0, ks, vs)
+    n = kvp_minheap_insert(0, n, 10, 1, 1.0, ks, vs)
 
     # ep has moved
     assert n == 2
@@ -164,7 +164,7 @@ def test_kvp_add_several():
 
     for k in range(10):
         v = np.random.randn()
-        n = kvp_insert(0, n, 10, k, v, ks, vs)
+        n = kvp_minheap_insert(0, n, 10, k, v, ks, vs)
 
     assert n == 10
     # all the keys
@@ -174,7 +174,7 @@ def test_kvp_add_several():
     assert vs[0] == np.min(vs)
 
     # it rejects a smaller value; -100 is extremely unlikely
-    n2 = kvp_insert(0, n, 10, 50, -100.0, ks, vs)
+    n2 = kvp_minheap_insert(0, n, 10, 50, -100.0, ks, vs)
 
     assert n2 == n
     assert all(ks != 50)
@@ -183,9 +183,33 @@ def test_kvp_add_several():
     # it inserts a larger value; all positive is extremely unlikely
     old_mk = ks[0]
     old_mv = vs[0]
-    n2 = kvp_insert(0, n, 10, 50, 0.0, ks, vs)
+    n2 = kvp_minheap_insert(0, n, 10, 50, 0.0, ks, vs)
 
     assert n2 == n
     assert all(ks != old_mk)
     assert all(vs > old_mv)
     assert np.count_nonzero(ks == 50) == 1
+
+
+def test_kvp_sort():
+    ks = np.full(10, -1, dtype=np.int32)
+    vs = np.zeros(10)
+
+    n = 0
+
+    for k in range(20):
+        v = np.random.randn()
+        n = kvp_minheap_insert(0, n, 10, k, v, ks, vs)
+
+    assert n == 10
+
+    ovs = vs.copy()
+    oks = ks.copy()
+    ord = np.argsort(ovs)
+    ord = ord[::-1]
+
+    kvp_minheap_sort(0, n, ks, vs)
+    assert vs[0] == np.max(ovs)
+    assert vs[-1] == np.min(ovs)
+    assert all(ks == oks[ord])
+    assert all(vs == ovs[ord])


### PR DESCRIPTION
This PR has a number of performance improvements, primarily to the k-NN recommenders:

- Decrease memory required for training item-item by accumulating final results directly into the final similarity matrix, using in-place heaps for top-N accumulation.
- Introduce light parallelism for this process (need more testing on the efficacy of this)
- Speed up user-user k-NN scoring by moving the score loop to Numba & using more compact data structures
- Use `nlargest` in `TopN` instead of `sort_values`
- Add supporting machinery (and tests) for the above