### PR TITLE
Python version update: support 3.8 and drop 3.5

### DIFF
--- a/build-support/test-linux-conda.yml
+++ b/build-support/test-linux-conda.yml
@@ -8,6 +8,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/build-support/test-linux-vanilla.yml
+++ b/build-support/test-linux-vanilla.yml
@@ -10,8 +10,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-      Python38:
-        python.version: '3.8'
+      # Python38:
+      #   python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/build-support/test-linux-vanilla.yml
+++ b/build-support/test-linux-vanilla.yml
@@ -4,8 +4,6 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:

--- a/build-support/test-linux-vanilla.yml
+++ b/build-support/test-linux-vanilla.yml
@@ -10,6 +10,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/build-support/test-mac-conda.yml
+++ b/build-support/test-mac-conda.yml
@@ -8,6 +8,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/build-support/test-windows-conda.yml
+++ b/build-support/test-windows-conda.yml
@@ -8,6 +8,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/build-support/test-windows-vanilla.yml
+++ b/build-support/test-windows-vanilla.yml
@@ -6,8 +6,8 @@ jobs:
     matrix:
       Python37:
         python.version: '3.7'
-      Python38:
-        python.version: '3.8'
+      # Python38:
+      #   python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/build-support/test-windows-vanilla.yml
+++ b/build-support/test-windows-vanilla.yml
@@ -6,8 +6,9 @@ jobs:
     matrix:
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
-  condition: False
 
   steps:
   - task: UsePythonVersion@0

--- a/lenskit/_mkl_ops.py
+++ b/lenskit/_mkl_ops.py
@@ -14,10 +14,6 @@ from .matrix import CSR, _CSR
 _logger = logging.getLogger(__name__)
 __dir = pathlib.Path(__file__).parent
 
-
-if not hasattr(os, 'fspath'):
-    raise ImportError('_mkl_ops requires Python 3.6 or newer')
-
 __cc = ccompiler.new_compiler()
 _mkl_so = __dir / __cc.shared_object_filename('mkl_ops')
 __mkl_defs = (__dir / 'mkl_ops.h').read_text()

--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import pathlib
 import collections
@@ -304,7 +305,7 @@ class MultiEval:
         if not self.save_models:
             return
         elif self.save_models == 'gzip':
-            with gzip.open(util.fspath(base.with_suffix('.pkl.gz')), 'wb') as f:
+            with gzip.open(os.fspath(base.with_suffix('.pkl.gz')), 'wb') as f:
                 pickle.dump(algo, f)
         elif self.save_models == 'joblib':
             joblib.dump(algo, base.with_suffix('.jlpkl'))

--- a/lenskit/util/data.py
+++ b/lenskit/util/data.py
@@ -2,6 +2,7 @@
 Data utilities
 """
 
+import os
 import os.path
 import logging
 import pathlib
@@ -9,7 +10,6 @@ import warnings
 
 import pandas as pd
 
-from .files import fspath
 from ..datasets import MovieLens
 
 try:
@@ -49,7 +49,7 @@ def write_parquet(path, frame, append=False):
         frame(pandas.DataFrame): The data to write.
         append(bool): Whether to append to the file or overwrite it.
     """
-    fn = fspath(path)
+    fn = os.fspath(path)
     append = append and os.path.exists(fn)
     _log.debug('%s %d rows to Parquet file %s',
                'appending' if append else 'writing',

--- a/lenskit/util/files.py
+++ b/lenskit/util/files.py
@@ -8,7 +8,7 @@ import tempfile
 import logging
 import pathlib
 
-__all__ = ['delete_sometime', 'norm_path', 'scratch_dir']
+__all__ = ['delete_sometime', 'scratch_dir']
 
 _log = logging.getLogger(__name__)
 
@@ -60,17 +60,3 @@ def scratch_dir(default=True, joblib=False):
     if default and not path:
         path = tempfile.gettempdir()
     return path
-
-
-def norm_path(path):
-    """
-    Convert a path into a :cls:`pathlib.Path`, in a Python 3.5-compatible way.
-    """
-    if isinstance(path, pathlib.Path):
-        return path
-    elif hasattr(path, '__fspath__'):
-        return pathlib.Path(path.__fspath__())
-    elif isinstance(path, str):
-        return pathlib.Path(str)
-    else:
-        raise ValueError('invalid path: ' + repr(path))

--- a/lenskit/util/files.py
+++ b/lenskit/util/files.py
@@ -8,10 +8,9 @@ import tempfile
 import logging
 import pathlib
 
-__all__ = ['delete_sometime', 'fspath', 'norm_path', 'scratch_dir']
+__all__ = ['delete_sometime', 'norm_path', 'scratch_dir']
 
 _log = logging.getLogger(__name__)
-__os_fp = getattr(os, 'fspath', None)
 
 _removable_files = []
 
@@ -61,14 +60,6 @@ def scratch_dir(default=True, joblib=False):
     if default and not path:
         path = tempfile.gettempdir()
     return path
-
-
-def fspath(path):
-    "Backport of :py:func:`os.fspath` function for Python 3.5."
-    if __os_fp:
-        return __os_fp(path)
-    else:
-        return str(path)
 
 
 def norm_path(path):

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence"
     ],
 
-    python_requires='>= 3.5',
+    python_requires='>= 3.6',
     setup_requires=[
         'pytest-runner'
     ],

--- a/tests/test_batch_sweep.py
+++ b/tests/test_batch_sweep.py
@@ -8,7 +8,6 @@ import pandas as pd
 import numpy as np
 import joblib
 
-from lenskit.util import norm_path
 from lenskit.util.test import ml_test
 from lenskit import batch, crossfold as xf
 from lenskit.algorithms import Predictor
@@ -20,7 +19,6 @@ from pytest import mark
 @mark.slow
 @mark.parametrize('ncpus', [None, 2])
 def test_sweep_bias(tmp_path, ncpus):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path, nprocs=ncpus)
 
@@ -62,7 +60,6 @@ def test_sweep_bias(tmp_path, ncpus):
 
 @mark.slow
 def test_sweep_norecs(tmp_path):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path, recommend=None)
 
@@ -100,7 +97,6 @@ def test_sweep_norecs(tmp_path):
 
 @mark.slow
 def test_sweep_allrecs(tmp_path):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path, recommend=True)
 
@@ -141,7 +137,6 @@ def test_sweep_allrecs(tmp_path):
 
 @mark.slow
 def test_sweep_filenames(tmp_path):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path)
 
@@ -182,7 +177,6 @@ def test_sweep_filenames(tmp_path):
 
 @mark.slow
 def test_sweep_persist(tmp_path):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path)
 
@@ -223,7 +217,6 @@ def test_sweep_persist(tmp_path):
 
 @mark.slow
 def test_sweep_oneshot(tmp_path):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path, combine=False)
 
@@ -254,7 +247,6 @@ def test_sweep_oneshot(tmp_path):
 
 @mark.slow
 def test_sweep_save(tmp_path):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path)
 
@@ -289,7 +281,6 @@ def test_sweep_save(tmp_path):
 
 @mark.slow
 def test_sweep_combine(tmp_path):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path, combine=False)
 
@@ -347,7 +338,6 @@ def test_sweep_combine(tmp_path):
 @mark.slow
 @mark.parametrize("format", [True, 'gzip', 'joblib'])
 def test_save_models(tmp_path, format):
-    tmp_path = norm_path(tmp_path)
     work = pathlib.Path(tmp_path)
     sweep = batch.MultiEval(tmp_path, save_models=format)
 

--- a/tests/test_batch_sweep.py
+++ b/tests/test_batch_sweep.py
@@ -1,3 +1,4 @@
+from os import fspath
 import pathlib
 import json
 import pickle
@@ -7,7 +8,7 @@ import pandas as pd
 import numpy as np
 import joblib
 
-from lenskit.util import norm_path, fspath
+from lenskit.util import norm_path
 from lenskit.util.test import ml_test
 from lenskit import batch, crossfold as xf
 from lenskit.algorithms import Predictor

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -75,12 +75,6 @@ def test_last_memo():
     assert len(history) == 2
 
 
-def test_fspath():
-    path = pathlib.Path('lenskit')
-    fn = lku.fspath(path)
-    assert fn == 'lenskit'
-
-
 def test_write_parquet(tmp_path):
     assert tmp_path.exists()
     fn = tmp_path / 'out.parquet'


### PR DESCRIPTION
This commit makes two important changes to our Python version support:

- Add Python 3.8 to test matrix (no code changes required)
- Drop Python 3.5 from test matrix

We also clean up compatibility code:

- Drop Python 3.5 compatibility shims (`fspath` implementation, `norm_path`)

Python 3.8 Vanilla tests are not yet enabled, because key dependencies (`llvmlite` and `pyarrow`) do not yet ship Python 3.8 binary wheels, and source builds in the CI environment are too time-consuming.