### PR TITLE
Unify configuration points

### DIFF
--- a/lenskit/batch/_predict.py
+++ b/lenskit/batch/_predict.py
@@ -73,9 +73,10 @@ def predict(algo, pairs, *, n_jobs=None, **kwargs):
             contains a ``rating`` column, it will be included in the result.
         n_jobs(int):
             The number of processes to use for parallel batch prediction.  Passed as
-            ``n_jobs`` to :cls:`joblib.Parallel`.  The default, ``None``, will make
+            ``n_jobs`` to :cls:`joblib.Parallel`.  The default, ``None``, will result
+            in a call to :func:`util.proc_count`(``None``), so the process will be
             the process sequential _unless_ called inside the :func:`joblib.parallel_backend`
-            context manager.
+            context manager or the ``LK_NUM_PROCS`` environment variable is set.
 
             .. note:: ``nprocs`` is accepted as a deprecated alias.
 
@@ -88,6 +89,9 @@ def predict(algo, pairs, *, n_jobs=None, **kwargs):
     if n_jobs is None and 'nprocs' in kwargs:
         n_jobs = kwargs['nprocs']
         warnings.warn('nprocs is deprecated, use n_jobs', DeprecationWarning)
+
+    if n_jobs is None:
+        n_jobs = util.proc_count(None)
 
     loop = Parallel(n_jobs=n_jobs)
 

--- a/lenskit/batch/_recommend.py
+++ b/lenskit/batch/_recommend.py
@@ -70,9 +70,10 @@ def recommend(algo, users, n, candidates=None, *, n_jobs=None, **kwargs):
             built-in candidate selector (usually recommended).
         n_jobs(int):
             The number of processes to use for parallel recommendations.  Passed as
-            ``n_jobs`` to :cls:`joblib.Parallel`.  The default, ``None``, will make
+            ``n_jobs`` to :cls:`joblib.Parallel`.  The default, ``None``, will result
+            in a call to :func:`util.proc_count`(``None``), so the process will be
             the process sequential _unless_ called inside the :func:`joblib.parallel_backend`
-            context manager.
+            context manager or the ``LK_NUM_PROCS`` environment variable is set.
 
             .. note:: ``nprocs`` is accepted as a deprecated alias.
 
@@ -84,6 +85,9 @@ def recommend(algo, users, n, candidates=None, *, n_jobs=None, **kwargs):
     if n_jobs is None and 'nprocs' in kwargs:
         n_jobs = kwargs['nprocs']
         warnings.warn('nprocs is deprecated, use n_jobs', DeprecationWarning)
+
+    if n_jobs is None:
+        n_jobs = util.proc_count(None)
 
     rec_algo = Recommender.adapt(algo)
     if candidates is None and rec_algo is not algo:

--- a/lenskit/util/__init__.py
+++ b/lenskit/util/__init__.py
@@ -101,7 +101,7 @@ def cur_memory():
         return 'unknown'
 
 
-def desired_job_count(core_div=2):
+def proc_count(core_div=2):
     """
     Get the number of desired jobs for multiprocessing operations.  This does not
     affect Numba or MKL multithreading.
@@ -109,12 +109,20 @@ def desired_job_count(core_div=2):
     This count can come from a number of sources:
     * The ``LK_NUM_PROCS`` environment variable
     * The number of CPUs, divided by ``core_div`` (default 2)
+
+    Args:
+        core_div(int or None):
+            The divisor to scale down the number of cores; ``None`` to turn off core-based
+            fallback.
+
+    Returns:
+        int: The number of jobs desired.
     """
 
     nprocs = os.environ.get('LK_NUM_PROCS')
     if nprocs is not None:
         nprocs = int(nprocs)
-    else:
+    elif core_div is not None:
         nprocs = max(mp.cpu_count() // core_div, 1)
 
     return nprocs

--- a/lenskit/util/__init__.py
+++ b/lenskit/util/__init__.py
@@ -2,8 +2,10 @@
 Miscellaneous utility functions.
 """
 
+import os
 import logging
 from copy import deepcopy
+import multiprocessing as mp
 
 from ..algorithms import Algorithm
 from .files import *
@@ -97,3 +99,22 @@ def cur_memory():
         return "%.1f MiB" % (res.ru_idrss,)
     else:
         return 'unknown'
+
+
+def desired_job_count(core_div=2):
+    """
+    Get the number of desired jobs for multiprocessing operations.  This does not
+    affect Numba or MKL multithreading.
+
+    This count can come from a number of sources:
+    * The ``LK_NUM_PROCS`` environment variable
+    * The number of CPUs, divided by ``core_div`` (default 2)
+    """
+
+    nprocs = os.environ.get('LK_NUM_PROCS')
+    if nprocs is not None:
+        nprocs = int(nprocs)
+    else:
+        nprocs = max(mp.cpu_count() // core_div, 1)
+
+    return nprocs

--- a/lenskit/util/files.py
+++ b/lenskit/util/files.py
@@ -46,7 +46,7 @@ def scratch_dir(default=True, joblib=False):
     Get the configured temporary directory.  Looks for configuration in the following
     places:
 
-    1. The environment variable ``LENSKIT_TEMP_DIR``.
+    1. The environment variable ``LK_TEMP_DIR``.
     2. If ``joblib`` is ``True``, the environment variable ``JOBLIB_TEMP_FOLDER``.
     3. If ``default`` is ``True``, the result of :fun:`tempfile.gettempdir`.
 
@@ -54,7 +54,11 @@ def scratch_dir(default=True, joblib=False):
         default(bool): whether to look in the Python default locations.
         joblib(bool): whether to consult the Joblib configuration directory.
     """
-    path = os.environ.get('LENSKIT_TEMP_DIR', None)
+    path = os.environ.get('LK_TEMP_DIR', None)
+    if joblib and not path:
+        path = os.environ.get('LENSKIT_TEMP_DIR', None)
+        if path is not None:
+            _log.warn('LENSKIT_TEMP_DIR is deprecated, use LK_TEMP_DIR instead')
     if joblib and not path:
         path = os.environ.get('JOBLIB_TEMP_FOLDER', None)
     if default and not path:


### PR DESCRIPTION
This unifies LensKit's environment variable use:

- `LK_TEMP_DIR` replaces `LENSKIT_TEMP_DIR`, so everything will start with `LK_`. The old environment variable is available as a deprecated alias.
- Add a `proc_count` function to read `LK_NUM_JOBS` and configure CPU counts.
- Use `proc_count` to set default in batch functions