### PR TITLE
Add model stores for batch multiprocessing

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -17,6 +17,7 @@ dependencies:
 - cffi
 - pyarrow
 - joblib
+- pickle5
 - coverage 
 - pytest>=3.9
 - pytest-cov

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -187,5 +187,5 @@ intersphinx_mapping = {
     'implicit': ('https://implicit.readthedocs.io/en/latest/', None),
     'scikit': ('https://scikit-learn.org/stable/', None),
     'tqdm': ('https://tqdm.github.io/', None),
-    'joblib': ('https://joblib.readthedocs.io/en/', None)
+    'joblib': ('https://joblib.readthedocs.io/en/latest/', None)
 }

--- a/doc/sharing.rst
+++ b/doc/sharing.rst
@@ -49,18 +49,18 @@ Model Store Implementations
 
 We provide several model store implementations.
 
-Joblib-based
-~~~~~~~~~~~~
+Memory Mapping
+~~~~~~~~~~~~~~
 
-.. py:module:: lenskit.sharing.joblib
+.. py:module:: lenskit.sharing.file
 
-The :joblib-based store works on any supported platform and Python version.  It uses
-Joblib's memory-mapped Pickle extension to store models on disk and use their storage to back
-memory-mapped views of major data structures.
+The memory-mapped-file store works on any supported platform and Python version.  It uses
+Joblib's memory-mapped Pickle extension to store models on disk and use their storage
+to back memory-mapped views of major data structures.
 
-.. autoclass:: JoblibModelStore
+.. autoclass:: FileModelStore
     :show-inheritance:
-.. autoclass:: JoblibModelClient
+.. autoclass:: File
     :show-inheritance:
 
 Shared Memory

--- a/doc/sharing.rst
+++ b/doc/sharing.rst
@@ -16,16 +16,16 @@ exclude intermediate data structures, such as caches or inverse indexes, from th
 representation of an algorithm, and reconstruct them when the model is loaded.
 
 However, LensKit's multi-process sharing *also* uses pickling to capture the object state
-while using shared memory for :py:cls:`numpy.ndarray` objects.  In these cases, the structures
+while using shared memory for :py:class:`numpy.ndarray` objects.  In these cases, the structures
 should be pickled, so they can be shared between model instances.
 
 To support this, we have the concept of *sharing mode*.  Code that excludes objects when
 pickling should call :py:func:`in_share_context` to determine if that exclusion should
 actually happen.
 
-.. autofunc:: in_share_context
+.. autofunction:: in_share_context
 
-.. autofunc:: sharing_mode
+.. autofunction:: sharing_mode
 
 
 Model Store API
@@ -37,9 +37,18 @@ making objects available to other classes.
 .. autofunction:: get_store
 
 .. autoclass:: BaseModelStore
+    :members:
+    :show-inheritance:
+
 .. autoclass:: BaseModelClient
+    :members:
+    :show-inheritance:
 
 Model Store Implementations
 ---------------------------
 
 .. autoclass:: JoblibModelStore
+    :show-inheritance:
+
+.. autoclass:: SHMModelStore
+    :show-inheritance:

--- a/doc/sharing.rst
+++ b/doc/sharing.rst
@@ -1,0 +1,42 @@
+Model Sharing
+=============
+
+.. py:module:: lenskit.sharing
+
+The :py:mod:`lenskit.sharing` module provides utilities for managing models and sharing them
+between processes, particularly for the  multiprocessing in :py:mod:`lenskit.batch`.
+
+
+Sharing Mode
+-------------
+
+The only piece **algorithm developers** usually need to directly handle is the concept of
+'sharing mode' when implementing custom pickling logic.  To save space, it is reasonable to
+exclude intermediate data structures, such as caches or inverse indexes, from the pickled
+representation of an algorithm, and reconstruct them when the model is loaded.
+
+However, LensKit's multi-process sharing *also* uses pickling to capture the object state
+while using shared memory for :py:cls:`numpy.ndarray` objects.  In these cases, the structures
+should be pickled, so they can be shared between model instances.
+
+To support this, we have the concept of *sharing mode*.  Code that excludes objects when
+pickling should call :py:func:`in_share_context` to determine if that exclusion should
+actually happen.
+
+.. autofunc:: in_share_context
+
+.. autofunc:: sharing_mode
+
+
+Model Store API
+---------------
+
+Model stores handle persisting models into shared memory, cleaning up shared memory, and
+making objects available to other classes.
+
+.. autoclass:: BaseModelStore
+
+Model Store Implementations
+---------------------------
+
+.. autoclass:: JoblibModelStore

--- a/doc/sharing.rst
+++ b/doc/sharing.rst
@@ -37,6 +37,7 @@ making objects available to other classes.
 .. autofunction:: get_store
 
 .. autoclass:: BaseModelStore
+.. autoclass:: BaseModelClient
 
 Model Store Implementations
 ---------------------------

--- a/doc/sharing.rst
+++ b/doc/sharing.rst
@@ -47,8 +47,31 @@ making objects available to other classes.
 Model Store Implementations
 ---------------------------
 
+We provide several model store implementations.
+
+Joblib-based
+~~~~~~~~~~~~
+
+.. py:module:: lenskit.sharing.joblib
+
+The :joblib-based store works on any supported platform and Python version.  It uses
+Joblib's memory-mapped Pickle extension to store models on disk and use their storage to back
+memory-mapped views of major data structures.
+
 .. autoclass:: JoblibModelStore
     :show-inheritance:
+.. autoclass:: JoblibModelClient
+    :show-inheritance:
+
+Shared Memory
+~~~~~~~~~~~~~
+
+.. py:module:: lenskit.sharing.sharedmem
+
+This store uses Python 3.8's :py:mod:`multiprocessing.shared_memory` module, along with out-of-band
+buffer support in Pickle Protcol 5, to pass model data through shared memory.
 
 .. autoclass:: SHMModelStore
+    :show-inheritance:
+.. autoclass:: SHMClient
     :show-inheritance:

--- a/doc/sharing.rst
+++ b/doc/sharing.rst
@@ -34,6 +34,8 @@ Model Store API
 Model stores handle persisting models into shared memory, cleaning up shared memory, and
 making objects available to other classes.
 
+.. autofunction:: get_store
+
 .. autoclass:: BaseModelStore
 
 Model Store Implementations

--- a/doc/util.rst
+++ b/doc/util.rst
@@ -4,6 +4,7 @@ Utility Functions
 .. toctree::
     matrix
     math
+    sharing
 
 Miscellaneous
 -------------

--- a/lenskit/algorithms/basic.py
+++ b/lenskit/algorithms/basic.py
@@ -161,6 +161,10 @@ class Popular(Recommender):
         selector(CandidateSelector):
             The candidate selector to use. If ``None``, uses a new
             :class:`UnratedItemCandidateSelector`.
+
+    Attributes:
+        item_pop_(pandas.Series):
+            Item rating counts (popularity)
     """
 
     def __init__(self, selector=None):

--- a/lenskit/sharing.py
+++ b/lenskit/sharing.py
@@ -43,6 +43,13 @@ def in_share_context():
     return __save_mode == 'share'
 
 
+def create_store():
+    """
+    Create a new model store, using the best available on the current platform.
+    """
+    return JoblibModelStore()
+
+
 class BaseModelStore(AbstractContextManager):
     """
     Base class for storing models for access across processes.

--- a/lenskit/sharing.py
+++ b/lenskit/sharing.py
@@ -2,7 +2,19 @@
 Support for sharing and saving models and data structures.
 """
 
-from contextlib import contextmanager
+import os
+from abc import ABCMeta, abstractmethod
+from contextlib import contextmanager, AbstractContextManager
+import logging
+import pickle
+import tempfile
+from pathlib import Path
+
+import joblib
+
+from .util import scratch_dir
+
+_log = logging.getLogger(__name__)
 
 __save_mode = 'save'
 
@@ -29,3 +41,136 @@ def in_share_context():
     cross-process sharing.
     """
     return __save_mode == 'share'
+
+
+class BaseModelStore(AbstractContextManager):
+    """
+    Base class for storing models for access across processes.
+
+    Stores are also context managers that initalize themselves and clean themselves
+    up.
+    """
+
+    @abstractmethod
+    def put_model(self, model):
+        """
+        Store a model in the model store.
+
+        Args:
+            model(object): the model to store.
+
+        Returns:
+            a key to retrieve the model with :meth:`get_model`
+        """
+        pass
+
+    @abstractmethod
+    def get_model(self, key):
+        """
+        Get a model from the  model store.
+
+        Args:
+            key: the model key to retrieve.
+
+        Returns:
+            The model, previously stored with :meth:`put_model`.
+        """
+
+    def put_serialized(self, path):
+        """
+        Deserialize a model and load it into the store.
+
+        The base class method unpickles ``path`` and calls :meth:`store`.
+        """
+        with open(path, 'rb') as mf:
+            return self.put_model(pickle.load(mf))
+
+    def init(self):
+        "Initialize the store."
+
+    def shutdown(self):
+        "Shut down the store"
+
+    def __enter__(self):
+        self.init()
+        return self
+
+    def __exit__(self, *args):
+        self.shutdown()
+        return None
+
+
+class JoblibModelStore(BaseModelStore):
+    """
+    Model store using JobLib's memory-mapping pickle support.
+
+    Args:
+        path:
+            the path to use; otherwise uses a new temp directory under
+            :func:`util.scratch_dir`.
+        reserialize:
+            if ``True`` (the default), models passed to :meth:`put_serialized` are
+            re-serialized in the JobLib storage.
+    """
+
+    path: Path
+    reserialize: bool
+
+    def __init__(self, *, path=None, reserialize=True):
+        self.path = path
+        self.reserialize = reserialize
+
+    def init(self):
+        if self.path is None:
+            self._path = Path(tempfile.mkdtemp(prefix='lk-share', dir=scratch_dir()))
+            self._rmdir = True
+        else:
+            self._path = self.path
+            self._rmdir = False
+
+        self._files = []
+
+    def shutdown(self, *args):
+        failed = 0
+        # delete files
+        for f in self._files:
+            try:
+                _log.debug('removing %s', f)
+                f.unlink()
+            except PermissionError:
+                failed += 1
+                _log.warn('could not unlink %s', f)
+
+        # clean up directory
+        if failed:
+            _log.warn('failed to delete %d temporary files from %s', failed, self.path)
+        elif self._rmdir:
+            try:
+                self._path.rmdir()
+            except IOError as e:
+                _log.warn('could not delete %s: %s', self._path, e)
+
+        # and clean up internal data structures
+        del self._files
+        del self._path
+        del self._rmdir
+
+    def put_model(self, model):
+        fd, fn = tempfile.mkstemp('.model', 'lk-joblib', self._path)
+        fpath = Path(fn)
+        os.close(fd)
+
+        with sharing_mode():
+            joblib.dump(model, fn)
+        self._files.append(fpath)
+        return fpath
+
+    def get_model(self, key):
+        model = joblib.load(key, mmap_mode='r')
+        return model
+
+    def put_serialized(self, path):
+        if self.reserialize:
+            return super().put_serialized(path)
+        else:
+            return path

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -2,17 +2,10 @@
 Support for sharing and saving models and data structures.
 """
 
-import os
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 from contextlib import contextmanager, AbstractContextManager
 import logging
 import pickle
-import tempfile
-from pathlib import Path
-
-import joblib
-
-from .util import scratch_dir
 
 _log = logging.getLogger(__name__)
 
@@ -44,7 +37,7 @@ def in_share_context():
     return __save_mode == 'share'
 
 
-def get_store(reuse=True):
+def get_store(reuse=True, *, in_process=False):
     """
     Get a model store, using the best available on the current platform.  The
     resulting store should be used as a context manager, as in:
@@ -52,18 +45,46 @@ def get_store(reuse=True):
     >>> with get_store() as store:
     >>>     pass
 
+    .. note:: This is not thread-safe.
+
     Args:
         reuse(bool):
             If a store is active (with a ``with`` block), use that store instead
             of creating a new one.
+        in_process(bool):
+            If ``True``, then create a no-op store for use without multiprocessing.
+
+    Returns:
+        BaseModelStore: the model store.
     """
     if reuse and _active_stores:
         return _active_stores[-1]
+    elif in_process:
+        return NoopModelStore()
     else:
         return JoblibModelStore()
 
 
-class BaseModelStore(AbstractContextManager):
+class BaseModelClient:
+    """
+    Model store client to get models given keys.  Clients must be able to be cheaply
+    pickled and de-pickled to enable worker processes to access them.
+    """
+
+    @abstractmethod
+    def get_model(self, key):
+        """
+        Get a model from the  model store.
+
+        Args:
+            key: the model key to retrieve.
+
+        Returns:
+            The model, previously stored with :meth:`put_model`.
+        """
+
+
+class BaseModelStore(BaseModelClient):
     """
     Base class for storing models for access across processes.
 
@@ -87,18 +108,6 @@ class BaseModelStore(AbstractContextManager):
         """
         pass
 
-    @abstractmethod
-    def get_model(self, key):
-        """
-        Get a model from the  model store.
-
-        Args:
-            key: the model key to retrieve.
-
-        Returns:
-            The model, previously stored with :meth:`put_model`.
-        """
-
     def put_serialized(self, path):
         """
         Deserialize a model and load it into the store.
@@ -107,6 +116,17 @@ class BaseModelStore(AbstractContextManager):
         """
         with open(path, 'rb') as mf:
             return self.put_model(pickle.load(mf))
+
+    @abstractmethod
+    def client(self):
+        """
+        Get a client for the model store.  Clients are cheap to pass to
+        child processes for multiprocessing.
+
+        Returns:
+            BaseModelClient: the model client.
+        """
+        pass
 
     def init(self):
         "Initialize the store."
@@ -129,78 +149,28 @@ class BaseModelStore(AbstractContextManager):
         _active_stores.pop()
         return None
 
+    def __getstate__(self):
+        raise RuntimeError('stores cannot be pickled, do you want to use the client?')
 
-class JoblibModelStore(BaseModelStore):
+
+class NoopModelStore(BaseModelStore):
     """
-    Model store using JobLib's memory-mapping pickle support.
-
-    Args:
-        path:
-            the path to use; otherwise uses a new temp directory under
-            :func:`util.scratch_dir`.
-        reserialize:
-            if ``True`` (the default), models passed to :meth:`put_serialized` are
-            re-serialized in the JobLib storage.
+    Model store that does nothing - models are their own keys.  Only useful in
+    single-threaded computations.
     """
-
-    path: Path
-    reserialize: bool
-
-    def __init__(self, *, path=None, reserialize=True):
-        self.path = path
-        self.reserialize = reserialize
-
-    def init(self):
-        if self.path is None:
-            self._path = Path(tempfile.mkdtemp(prefix='lk-share', dir=scratch_dir()))
-            self._rmdir = True
-        else:
-            self._path = self.path
-            self._rmdir = False
-
-        self._files = []
-
-    def shutdown(self, *args):
-        failed = 0
-        # delete files
-        for f in self._files:
-            try:
-                _log.debug('removing %s', f)
-                f.unlink()
-            except PermissionError:
-                failed += 1
-                _log.warning('could not unlink %s', f)
-
-        # clean up directory
-        if failed:
-            _log.warning('failed to delete %d temporary files from %s', failed, self.path)
-        elif self._rmdir:
-            try:
-                self._path.rmdir()
-            except IOError as e:
-                _log.warning('could not delete %s: %s', self._path, e)
-
-        # and clean up internal data structures
-        del self._files
-        del self._path
-        del self._rmdir
-
-    def put_model(self, model):
-        fd, fn = tempfile.mkstemp('.model', 'lk-joblib', self._path)
-        fpath = Path(fn)
-        os.close(fd)
-
-        with sharing_mode():
-            joblib.dump(model, fn)
-        self._files.append(fpath)
-        return fpath
 
     def get_model(self, key):
-        model = joblib.load(key, mmap_mode='r')
+        return key
+
+    def put_model(self, model):
         return model
 
-    def put_serialized(self, path):
-        if self.reserialize:
-            return super().put_serialized(path)
-        else:
-            return path
+    def client(self):
+        return self  # since we're only single-threaded, we are the client
+
+    def __str__(self):
+        return 'NoopModelStore'
+
+
+## more imports
+from .joblib import JoblibModelStore

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -97,7 +97,7 @@ class BaseModelClient:
             key: the model key to retrieve.
 
         Returns:
-            The model, previously stored with :meth:`put_model`.
+            The model, previously stored with :meth:`BaseModelStore.put_model`.
         """
 
 
@@ -121,7 +121,7 @@ class BaseModelStore(BaseModelClient):
             model(object): the model to store.
 
         Returns:
-            a key to retrieve the model with :meth:`get_model`
+            a key to retrieve the model with :meth:`BaseModelClient.get_model`
         """
         pass
 
@@ -129,7 +129,7 @@ class BaseModelStore(BaseModelClient):
         """
         Deserialize a model and load it into the store.
 
-        The base class method unpickles ``path`` and calls :meth:`store`.
+        The base class method unpickles ``path`` and calls :meth:`put_model`.
         """
         with open(path, 'rb') as mf:
             return self.put_model(pickle.load(mf))

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -61,6 +61,8 @@ def get_store(reuse=True, *, in_process=False):
         return _active_stores[-1]
     elif in_process:
         return NoopModelStore()
+    elif 'SHMModelStore' in globals():
+        return SHMModelStore()
     else:
         return JoblibModelStore()
 
@@ -174,3 +176,7 @@ class NoopModelStore(BaseModelStore):
 
 ## more imports
 from .joblib import JoblibModelStore
+try:
+    from .sharedmem import SHMModelStore
+except ImportError:
+    pass  # shared memory not available

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -79,7 +79,7 @@ def get_store(reuse=True, *, in_process=False):
     elif SHMModelStore.ENABLED:
         return SHMModelStore()
     else:
-        return JoblibModelStore()
+        return FileModelStore()
 
 
 class BaseModelClient:
@@ -190,5 +190,5 @@ class NoopModelStore(BaseModelStore):
 
 
 # more imports
-from .joblib import JoblibModelStore
+from .file import FileModelStore
 from .sharedmem import SHMModelStore

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -43,7 +43,7 @@ def get_store(reuse=True, *, in_process=False):
     resulting store should be used as a context manager, as in:
 
     >>> with get_store() as store:
-    >>>     pass
+    ...     pass
 
     .. note:: This is not thread-safe.
 

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -30,11 +30,11 @@ def sharing_mode():
     sharing, not model persistence.
     """
     old = _save_mode()
-    _store_state.save_mode = 'share'
+    _store_state.mode = 'share'
     try:
         yield
     finally:
-        _store_state.save_mode = old
+        _store_state.mode = old
 
 
 def in_share_context():

--- a/lenskit/sharing/file.py
+++ b/lenskit/sharing/file.py
@@ -10,7 +10,7 @@ from . import BaseModelStore, BaseModelClient, sharing_mode
 _log = logging.getLogger(__name__)
 
 
-class JoblibModelClient(BaseModelClient):
+class FileClient(BaseModelClient):
     """
     Client using Joblib's memory-mapping pickle support.
     """
@@ -32,7 +32,7 @@ class JoblibModelClient(BaseModelClient):
             return {}  # nothing to pickle here
 
 
-class JoblibModelStore(BaseModelStore, JoblibModelClient):
+class FileModelStore(BaseModelStore, FileClient):
     """
     Model store using JobLib's memory-mapping pickle support.
 
@@ -88,7 +88,7 @@ class JoblibModelStore(BaseModelStore, JoblibModelClient):
         del self._rmdir
 
     def client(self):
-        return JoblibModelClient()
+        return FileClient()
 
     def put_model(self, model):
         fd, fn = tempfile.mkstemp('.model', 'lk-joblib', self._path)
@@ -109,6 +109,6 @@ class JoblibModelStore(BaseModelStore, JoblibModelClient):
 
     def __str__(self):
         if self.path is not None:
-            return f'JoblibModelStore({self.path})'
+            return f'FileModelStore({self.path})'
         else:
-            return 'JoblibModelStore()'
+            return 'FileModelStore()'

--- a/lenskit/sharing/joblib.py
+++ b/lenskit/sharing/joblib.py
@@ -15,10 +15,21 @@ class JoblibModelClient(BaseModelClient):
     Client using Joblib's memory-mapping pickle support.
     """
 
+    _last_key = None
+
     def get_model(self, key):
-        _log.debug('loading model from %s', key)
-        model = joblib.load(key, mmap_mode='r')
-        return model
+        if self._last_key == key:
+            _log.debug('reusing model %s', key)
+        else:
+            _log.debug('loading model from %s', key)
+            self._last_model = joblib.load(key, mmap_mode='r')
+        return self._last_model
+
+    def __getstate__(self):
+        if isinstance(self, BaseModelStore):
+            raise RuntimeError('stores cannot be pickled')
+        else:
+            return {}  # nothing to pickle here
 
 
 class JoblibModelStore(BaseModelStore, JoblibModelClient):

--- a/lenskit/sharing/joblib.py
+++ b/lenskit/sharing/joblib.py
@@ -1,0 +1,103 @@
+import os
+import logging
+import tempfile
+from pathlib import Path
+
+import joblib
+from ..util import scratch_dir
+from . import BaseModelStore, BaseModelClient, sharing_mode
+
+_log = logging.getLogger(__name__)
+
+
+class JoblibModelClient(BaseModelClient):
+    """
+    Client using Joblib's memory-mapping pickle support.
+    """
+
+    def get_model(self, key):
+        _log.debug('loading model from %s', key)
+        model = joblib.load(key, mmap_mode='r')
+        return model
+
+
+class JoblibModelStore(BaseModelStore, JoblibModelClient):
+    """
+    Model store using JobLib's memory-mapping pickle support.
+
+    Args:
+        path:
+            the path to use; otherwise uses a new temp directory under
+            :func:`util.scratch_dir`.
+        reserialize:
+            if ``True`` (the default), models passed to :meth:`put_serialized` are
+            re-serialized in the JobLib storage.
+    """
+
+    path: Path
+    reserialize: bool
+
+    def __init__(self, *, path=None, reserialize=True):
+        self.path = path
+        self.reserialize = reserialize
+
+    def init(self):
+        if self.path is None:
+            self._path = Path(tempfile.mkdtemp(prefix='lk-share-', dir=scratch_dir()))
+            self._rmdir = True
+        else:
+            self._path = self.path
+            self._rmdir = False
+
+        self._files = []
+
+    def shutdown(self, *args):
+        failed = 0
+        # delete files
+        for f in self._files:
+            try:
+                _log.debug('removing %s', f)
+                f.unlink()
+            except PermissionError:
+                failed += 1
+                _log.warning('could not unlink %s', f)
+
+        # clean up directory
+        if failed:
+            _log.warning('failed to delete %d temporary files from %s', failed, self.path)
+        elif self._rmdir:
+            try:
+                self._path.rmdir()
+            except IOError as e:
+                _log.warning('could not delete %s: %s', self._path, e)
+
+        # and clean up internal data structures
+        del self._files
+        del self._path
+        del self._rmdir
+
+    def client(self):
+        return JoblibModelClient()
+
+    def put_model(self, model):
+        fd, fn = tempfile.mkstemp('.model', 'lk-joblib', self._path)
+        fpath = Path(fn)
+        _log.debug('saving model %s to %s', model, fpath)
+        os.close(fd)
+
+        with sharing_mode():
+            joblib.dump(model, fn)
+        self._files.append(fpath)
+        return fpath
+
+    def put_serialized(self, path):
+        if self.reserialize:
+            return super().put_serialized(path)
+        else:
+            return path
+
+    def __str__(self):
+        if self.path is not None:
+            return f'JoblibModelStore({self.path})'
+        else:
+            return 'JoblibModelStore()'

--- a/lenskit/sharing/sharedmem.py
+++ b/lenskit/sharing/sharedmem.py
@@ -1,0 +1,113 @@
+"""
+Sharing support using Python 3.8 shared memory.
+"""
+
+from typing import NamedTuple
+import logging
+import multiprocessing.shared_memory as shm
+import pickle
+import uuid
+
+import numpy as np
+
+from . import BaseModelClient, BaseModelStore, sharing_mode
+
+_log = logging.getLogger(__name__)
+
+
+class SHMKey(NamedTuple):
+    id: uuid.UUID
+    data: bytes
+    buffers: list
+
+    def __str__(self):
+        nbs = len(self.data)
+        return f'SHMKey({self.id}: {nbs} bytes)'
+
+
+class SHMClient(BaseModelClient):
+    _last_key = None
+    _last_model = None
+    _last_bufs = None
+
+    def get_model(self, key: SHMKey):
+        if self._last_key and self._last_key.id == key.id:
+            _log.debug('reusing model %s', key)
+        else:
+            self._last_model = None
+            self._last_bufs = None
+
+            _log.debug('loading model from %s', key)
+            buffers = []
+            shm_bufs = []
+            for bn, bs in key.buffers:
+                # funny business with buffer sizes
+                block = shm.SharedMemory(name=bn)
+                _log.debug('%s: %d bytes (%d used)', block.name, bs, block.size)
+                buffers.append(block.buf[:bs])
+                shm_bufs.append(block)
+            self._last_model = pickle.loads(key.data, buffers=buffers)
+            self._last_bufs = shm_bufs
+            self._last_key = key
+
+        return self._last_model
+
+    def __getstate__(self):
+        if isinstance(self, BaseModelStore):
+            raise RuntimeError('stores cannot be pickled')
+        else:
+            return {}  # nothing to pickle here
+
+
+class SHMModelStore(BaseModelStore, SHMClient):
+    """
+    Model store using shared memory and Pickle Protocol 5.
+
+    Args:
+        path:
+            the path to use; otherwise uses a new temp directory under
+            :func:`util.scratch_dir`.
+        reserialize:
+            if ``True`` (the default), models passed to :meth:`put_serialized` are
+            re-serialized in the SHM storage.
+    """
+
+    def init(self):
+        self.buffers = {}
+
+    def shutdown(self, *args):
+        for k, bs in self.buffers.items():
+            for buf in bs:
+                buf.close()
+                buf.unlink()
+        del self.buffers
+
+    def client(self):
+        return SHMClient()
+
+    def put_model(self, model):
+        buffers = []
+        buf_keys = []
+
+        def buf_cb(buf):
+            ba = buf.raw()
+            block = shm.SharedMemory(create=True, size=ba.nbytes)
+            _log.debug('serializing %d bytes to %s', ba.nbytes, block.name)
+            block.buf[:] = ba
+            buffers.append(block)
+            buf_keys.append((block.name, ba.nbytes))
+
+        id = uuid.uuid4()
+
+        with sharing_mode():
+            data = pickle.dumps(model, protocol=5, buffer_callback=buf_cb)
+            shm_bytes = sum(b.size for b in buffers)
+            _log.info('serialized %s to %s (%d pickle bytes and %d buffers of %d bytes)',
+                      model, id, len(data), len(buffers), shm_bytes)
+
+        self.buffers[id] = buffers
+
+        return SHMKey(id, data, buf_keys)
+
+    def __str__(self):
+        return 'SHMModelStore()'

--- a/lenskit/util/test.py
+++ b/lenskit/util/test.py
@@ -17,7 +17,7 @@ from lenskit.datasets import MovieLens, ML100K
 _log = logging.getLogger(__name__)
 
 ml_test = MovieLens('ml-latest-small')
-ml100k = ML100K()
+ml100k = ML100K('ml-100k')
 
 
 def ml_sample():

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -10,7 +10,7 @@ from lenskit.algorithms.item_knn import ItemItem
 
 from pytest import mark
 
-stores = [lks.JoblibModelStore]
+stores = [lks.FileModelStore]
 if pickle.HIGHEST_PROTOCOL >= 5:
     # we have Python 3.8
     stores.append(lks.SHMModelStore)

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -118,24 +118,24 @@ def test_store_iknn(store_cls):
 
 def test_create_store():
     with lks.get_store() as store:
-        assert len(lks._active_stores) == 1
-        assert lks._active_stores[-1] is store
+        assert len(lks._active_stores()) == 1
+        assert lks._active_stores()[-1] is store
 
 
 def test_reuse_store():
     with lks.get_store() as outer:
         with lks.get_store() as inner:
             assert inner is outer
-            assert len(lks._active_stores) == 2
-            assert lks._active_stores[-1] is inner
-        assert len(lks._active_stores) == 1
+            assert len(lks._active_stores()) == 2
+            assert lks._active_stores()[-1] is inner
+        assert len(lks._active_stores()) == 1
 
 
 def test_new_store():
     with lks.get_store() as outer:
         with lks.get_store(False) as inner:
             assert inner is not outer
-            assert len(lks._active_stores) == 2
-            assert lks._active_stores[-1] is inner
-            assert lks._active_stores[0] is outer
-        assert len(lks._active_stores) == 1
+            assert len(lks._active_stores()) == 2
+            assert lks._active_stores()[-1] is inner
+            assert lks._active_stores()[0] is outer
+        assert len(lks._active_stores()) == 1

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -3,8 +3,10 @@ import numpy as np
 
 import lenskit.util.test as lktu
 from lenskit import sharing as lks
+from lenskit.algorithms import Recommender
 from lenskit.algorithms.basic import Popular
 from lenskit.algorithms.als import BiasedMF
+from lenskit.algorithms.item_knn import ItemItem
 
 from pytest import mark
 
@@ -96,6 +98,21 @@ def test_store_als(store_cls):
         assert np.all(a2.item_features_ == algo.item_features_)
         assert a2.user_features_ is not algo.user_features_
         assert np.all(a2.user_features_ == algo.user_features_)
+        del a2
+
+
+@store_param
+def test_store_iknn(store_cls):
+    algo = ItemItem(10)
+    algo = Recommender.adapt(algo)
+    algo.fit(lktu.ml_test.ratings)
+
+    with store_cls() as store:
+        k = store.put_model(algo)
+        client = store.client()
+
+        a2 = client.get_model(k)
+        assert a2 is not algo
         del a2
 
 

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -1,0 +1,38 @@
+import lenskit.util.test as lktu
+from lenskit import sharing as lks
+from lenskit.algorithms.basic import Popular
+
+from pytest import mark
+
+stores = [lks.JoblibModelStore]
+store_param = mark.parametrize('store_cls', stores)
+
+
+def test_sharing_mode():
+    "Ensure sharing mode decorator turns on sharing"
+    assert not lks.in_share_context()
+
+    with lks.sharing_mode():
+        assert lks.in_share_context()
+
+    assert not lks.in_share_context()
+
+
+@store_param
+def test_store_init(store_cls):
+    "Test that a store initializes and shuts down."
+    with store_cls():
+        pass
+
+
+@store_param
+def test_store_save(store_cls):
+    algo = Popular()
+    algo.fit(lktu.ml_test.ratings)
+
+    with store_cls() as store:
+        k = store.put_model(algo)
+        a2 = store.get_model(k)
+        assert a2 is not algo
+        assert a2.item_pop_ is not algo.item_pop_
+        assert all(a2.item_pop_ == algo.item_pop_)

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -83,6 +83,7 @@ def test_store_client_pickle(store_cls):
         del a2
 
 
+@lktu.wantjit
 @store_param
 def test_store_als(store_cls):
     algo = BiasedMF(10)
@@ -101,6 +102,7 @@ def test_store_als(store_cls):
         del a2
 
 
+@lktu.wantjit
 @store_param
 def test_store_iknn(store_cls):
     algo = ItemItem(10)

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -1,12 +1,18 @@
 import pickle
+import numpy as np
 
 import lenskit.util.test as lktu
 from lenskit import sharing as lks
 from lenskit.algorithms.basic import Popular
+from lenskit.algorithms.als import BiasedMF
 
 from pytest import mark
 
 stores = [lks.JoblibModelStore]
+if pickle.HIGHEST_PROTOCOL >= 5:
+    # we have Python 3.8
+    stores.append(lks.SHMModelStore)
+
 store_param = mark.parametrize('store_cls', stores)
 
 
@@ -72,6 +78,24 @@ def test_store_client_pickle(store_cls):
         assert a2 is not algo
         assert a2.item_pop_ is not algo.item_pop_
         assert all(a2.item_pop_ == algo.item_pop_)
+        del a2
+
+
+@store_param
+def test_store_als(store_cls):
+    algo = BiasedMF(10)
+    algo.fit(lktu.ml_test.ratings)
+
+    with store_cls() as store:
+        k = store.put_model(algo)
+        client = store.client()
+
+        a2 = client.get_model(k)
+        assert a2 is not algo
+        assert a2.item_features_ is not algo.item_features_
+        assert np.all(a2.item_features_ == algo.item_features_)
+        assert a2.user_features_ is not algo.user_features_
+        assert np.all(a2.user_features_ == algo.user_features_)
         del a2
 
 

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -1,3 +1,5 @@
+import pickle
+
 import lenskit.util.test as lktu
 from lenskit import sharing as lks
 from lenskit.algorithms.basic import Popular
@@ -33,6 +35,40 @@ def test_store_save(store_cls):
     with store_cls() as store:
         k = store.put_model(algo)
         a2 = store.get_model(k)
+        assert a2 is not algo
+        assert a2.item_pop_ is not algo.item_pop_
+        assert all(a2.item_pop_ == algo.item_pop_)
+        del a2
+
+
+@store_param
+def test_store_client(store_cls):
+    algo = Popular()
+    algo.fit(lktu.ml_test.ratings)
+
+    with store_cls() as store:
+        k = store.put_model(algo)
+        client = store.client()
+
+        a2 = client.get_model(k)
+        assert a2 is not algo
+        assert a2.item_pop_ is not algo.item_pop_
+        assert all(a2.item_pop_ == algo.item_pop_)
+        del a2
+
+
+@store_param
+def test_store_client_pickle(store_cls):
+    algo = Popular()
+    algo.fit(lktu.ml_test.ratings)
+
+    with store_cls() as store:
+        k = store.put_model(algo)
+        client = store.client()
+        client = pickle.loads(pickle.dumps(client))
+        k = pickle.loads(pickle.dumps(k))
+
+        a2 = client.get_model(k)
         assert a2 is not algo
         assert a2.item_pop_ is not algo.item_pop_
         assert all(a2.item_pop_ == algo.item_pop_)

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -36,3 +36,29 @@ def test_store_save(store_cls):
         assert a2 is not algo
         assert a2.item_pop_ is not algo.item_pop_
         assert all(a2.item_pop_ == algo.item_pop_)
+        del a2
+
+
+def test_create_store():
+    with lks.get_store() as store:
+        assert len(lks._active_stores) == 1
+        assert lks._active_stores[-1] is store
+
+
+def test_reuse_store():
+    with lks.get_store() as outer:
+        with lks.get_store() as inner:
+            assert inner is outer
+            assert len(lks._active_stores) == 2
+            assert lks._active_stores[-1] is inner
+        assert len(lks._active_stores) == 1
+
+
+def test_new_store():
+    with lks.get_store() as outer:
+        with lks.get_store(False) as inner:
+            assert inner is not outer
+            assert len(lks._active_stores) == 2
+            assert lks._active_stores[-1] is inner
+            assert lks._active_stores[0] is outer
+        assert len(lks._active_stores) == 1


### PR DESCRIPTION
This adds the concept of a *model store*, which can be used for efficient shared-memory sharing of a model between processes.  Three implementations are provided:

* No-op, for sequential or multithreaded processing
* Joblib, using Joblib's memory-mapped pickling and supported on all supported platforms
* Shared memory, using Pickle Protocol 5 and `multiprocessing.shared_memory` on Python 3.8

Future work could consider adding a Plasma store.