### PR TITLE
Skip predictions when no ratings to predict

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pytest --cov=lenskit --cov-report=xml tests
+          python -m pytest --cov=lenskit --cov-report=xml
       
       - name: Upload coverage
         uses: codecov/codecov-action@v1
@@ -137,7 +137,7 @@ jobs:
         
       - name: Run tests
         run: |
-          python -m tox -e minimal -- tests --cov=lenskit --cov-report=xml
+          python -m tox -e minimal -- --cov=lenskit --cov-report=xml
         
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/lenskit/_mkl_ops.py
+++ b/lenskit/_mkl_ops.py
@@ -29,7 +29,7 @@ ffi.cdef(__mkl_defs.replace('EXPORT ', ''))
 try:
     clib = ffi.dlopen(os.fspath(_mkl_so))
 except OSError:
-    raise ImportError('_mkl_ops cannot load helper')
+    clib = None
 
 _lk_mkl_spcreate = clib.lk_mkl_spcreate
 _lk_mkl_spsubset = clib.lk_mkl_spsubset

--- a/lenskit/_mkl_ops.py
+++ b/lenskit/_mkl_ops.py
@@ -28,29 +28,29 @@ ffi = cffi.FFI()
 ffi.cdef(__mkl_defs.replace('EXPORT ', ''))
 try:
     clib = ffi.dlopen(os.fspath(_mkl_so))
+
+    _lk_mkl_spcreate = clib.lk_mkl_spcreate
+    _lk_mkl_spsubset = clib.lk_mkl_spsubset
+    _lk_mkl_spfree = clib.lk_mkl_spfree
+    _lk_mkl_sporder = clib.lk_mkl_sporder
+    _lk_mkl_spopt = clib.lk_mkl_spopt
+    _lk_mkl_spmv = clib.lk_mkl_spmv
+    _lk_mkl_spmab = clib.lk_mkl_spmab
+    _lk_mkl_spmabt = clib.lk_mkl_spmabt
+    _lk_mkl_spexport = clib.lk_mkl_spexport
+    _lk_mkl_spsyrk = clib.lk_mkl_spsyrk
+
+    # silly pointer interface
+    _lk_mkl_spexport_p = clib.lk_mkl_spexport_p
+    _lk_mkl_spe_free = clib.lk_mkl_spe_free
+    _lk_mkl_spe_nrows = clib.lk_mkl_spe_nrows
+    _lk_mkl_spe_ncols = clib.lk_mkl_spe_ncols
+    _lk_mkl_spe_row_sp = clib.lk_mkl_spe_row_sp
+    _lk_mkl_spe_row_ep = clib.lk_mkl_spe_row_ep
+    _lk_mkl_spe_colinds = clib.lk_mkl_spe_colinds
+    _lk_mkl_spe_values = clib.lk_mkl_spe_values
 except OSError:
     clib = None
-
-_lk_mkl_spcreate = clib.lk_mkl_spcreate
-_lk_mkl_spsubset = clib.lk_mkl_spsubset
-_lk_mkl_spfree = clib.lk_mkl_spfree
-_lk_mkl_sporder = clib.lk_mkl_sporder
-_lk_mkl_spopt = clib.lk_mkl_spopt
-_lk_mkl_spmv = clib.lk_mkl_spmv
-_lk_mkl_spmab = clib.lk_mkl_spmab
-_lk_mkl_spmabt = clib.lk_mkl_spmabt
-_lk_mkl_spexport = clib.lk_mkl_spexport
-_lk_mkl_spsyrk = clib.lk_mkl_spsyrk
-
-# silly pointer interface
-_lk_mkl_spexport_p = clib.lk_mkl_spexport_p
-_lk_mkl_spe_free = clib.lk_mkl_spe_free
-_lk_mkl_spe_nrows = clib.lk_mkl_spe_nrows
-_lk_mkl_spe_ncols = clib.lk_mkl_spe_ncols
-_lk_mkl_spe_row_sp = clib.lk_mkl_spe_row_sp
-_lk_mkl_spe_row_ep = clib.lk_mkl_spe_row_ep
-_lk_mkl_spe_colinds = clib.lk_mkl_spe_colinds
-_lk_mkl_spe_values = clib.lk_mkl_spe_values
 
 # support intptr_t
 if cffi_utils is not None:

--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -333,6 +333,9 @@ class MultiEval:
             return None, None
         if not isinstance(algo, Predictor):
             return None, None
+        if 'rating' not in test.columns:
+            _logger.info('test data has no ratings, skipping prediction')
+            return None, None
 
         watch = util.Stopwatch()
         _logger.info('generating %d predictions for %s', len(test), algo)

--- a/lenskit/sharing/file.py
+++ b/lenskit/sharing/file.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 import logging
 import tempfile
 import gc
@@ -27,12 +28,15 @@ class BPKObject(SharedObject):
 
     def release(self):
         self.count -= 1
-        if self.count <= 0 and hasattr(self, 'object'):
+        if self.count == 0:
             _log.debug('releasing %s', str(self.object))
             del self.object
             gc.collect()
             self.bp_file.close()
             del self.bp_file
+        elif self.count < 0:
+            warnings.warn('over-released BPK', ResourceWarning, stacklevel=2)
+            assert not hasattr(self, 'object')
 
     def __del__(self):
         if hasattr(self, 'object'):

--- a/lenskit/sharing/file.py
+++ b/lenskit/sharing/file.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import tempfile
+import gc
 from pathlib import Path
 
 import binpickle
@@ -29,13 +30,15 @@ class BPKObject(SharedObject):
         if self.count <= 0:
             _log.debug('releasing %s', str(self.object))
             del self.object
+            gc.collect()
             self.bp_file.close()
             del self.bp_file
 
     def __del__(self):
-        _log.debug('releasing %s', str(self.object))
-        del self.object
-        del self.bp_file
+        if hasattr(self, 'object'):
+            _log.debug('releasing %s', str(self.object))
+            del self.object
+            del self.bp_file
 
 
 class FileClient(BaseModelClient):

--- a/lenskit/sharing/file.py
+++ b/lenskit/sharing/file.py
@@ -27,7 +27,7 @@ class BPKObject(SharedObject):
 
     def release(self):
         self.count -= 1
-        if self.count <= 0:
+        if self.count <= 0 and hasattr(self, 'object'):
             _log.debug('releasing %s', str(self.object))
             del self.object
             gc.collect()

--- a/tests/test_batch_sweep.py
+++ b/tests/test_batch_sweep.py
@@ -20,7 +20,7 @@ from pytest import mark
 @mark.parametrize('ncpus', [None, 2])
 def test_sweep_bias(tmp_path, ncpus):
     work = pathlib.Path(tmp_path)
-    sweep = batch.MultiEval(tmp_path, n_jobs=ncpus)
+    sweep = batch.MultiEval(tmp_path, eval_n_jobs=ncpus)
 
     ratings = ml_test.ratings
     folds = xf.partition_users(ratings, 5, xf.SampleN(5))
@@ -98,7 +98,7 @@ def test_sweep_norecs(tmp_path):
 @mark.slow
 def test_sweep_nopreds(tmp_path):
     work = pathlib.Path(tmp_path)
-    sweep = batch.MultiEval(tmp_path, n_jobs=2)
+    sweep = batch.MultiEval(tmp_path, eval_n_jobs=2)
 
     ratings = ml_test.ratings
     folds = [(train, test.drop(columns=['rating']))


### PR DESCRIPTION
This updates the MultiEval class to skip predictions entirely when there are no ratings in the test data to predict (closes #123).