### PR TITLE
Add 'persist' API to sharing

### DIFF
--- a/doc/sharing.rst
+++ b/doc/sharing.rst
@@ -61,8 +61,8 @@ Memory Mapping
 .. py:module:: lenskit.sharing.file
 
 The memory-mapped-file store works on any supported platform and Python version.  It uses
-Joblib's memory-mapped Pickle extension to store models on disk and use their storage
-to back memory-mapped views of major data structures.
+BinPickle's memory-mapped file support extension to store models on disk and use their
+storage to back memory-mapped views of major data structures.
 
 .. autoclass:: FileModelStore
     :show-inheritance:

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -62,7 +62,7 @@ def get_store(reuse=True, *, in_process=False):
     1. The currently-active store, if ``reuse=True``
     2. A no-op store, if ``in_process=True``
     3. :class:`SHMModelStore`, if on Python 3.8
-    4. :class:`JoblibModelStore`
+    4. :class:`FileModelStore`
 
     Args:
         reuse(bool):

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -107,7 +107,13 @@ def persist(model):
     Returns:
         PersistedModel: The persisted object.
     """
-    pass
+    lk_tmp = os.environ.get('LK_TEMP_DIR', None)
+    if lk_tmp is not None:
+        return persist_binpickle(model, lk_tmp)
+    elif shm is not None:
+        return persist_shm(model)
+    else:
+        return persist_binpickle(model)
 
 
 def persist_binpickle(model, dir=None):

--- a/lenskit/sharing/__init__.py
+++ b/lenskit/sharing/__init__.py
@@ -124,6 +124,7 @@ def persist_binpickle(model, dir=None):
     fd, path = tempfile.mkstemp(suffix='.bpk', prefix='lkpy-', dir=dir)
     os.close(fd)
     path = pathlib.Path(path)
+    _log.info('persisting %s to %s', model, path)
     with binpickle.BinPickler.mappable(path) as bp, sharing_mode():
         bp.dump(model)
     return BPKPersisted(path)
@@ -164,6 +165,84 @@ class BPKPersisted(PersistedModel):
 
     def __del___(self):
         self.close(False)
+
+
+def persist_shm(model, dir=None):
+    """
+    Persist a model using binpickle.
+
+    Args:
+        model: The model to persist.
+        dir: The temporary directory for persisting the model object.
+
+    Returns:
+        PersistedModel: The persisted object.
+    """
+    if shm is None:
+        raise ImportError('multiprocessing.shared_memory')
+
+    buffers = []
+    buf_keys = []
+
+    def buf_cb(buf):
+        ba = buf.raw()
+        block = shm.SharedMemory(create=True, size=ba.nbytes)
+        _log.debug('serializing %d bytes to %s', ba.nbytes, block.name)
+        # blit the buffer into shared memory
+        block.buf[:ba.nbytes] = ba
+        buffers.append(block)
+        buf_keys.append((block.name, ba.nbytes))
+
+    with sharing_mode():
+        data = pickle.dumps(model, protocol=5, buffer_callback=buf_cb)
+        shm_bytes = sum(b.size for b in buffers)
+        _log.info('serialized %s to %d pickle bytes with %d buffers of %d bytes',
+                  model, len(data), len(buffers), shm_bytes)
+
+    return SHMPersisted(data, buf_keys, buffers)
+
+
+class SHMPersisted(PersistedModel):
+    buffers = []
+    _model = None
+
+    def __init__(self, data, buf_specs, buffers):
+        self.pickle_data = data
+        self.buffer_specs = buf_specs
+        self.buffers = buffers
+        self.is_owner = True
+
+    def get(self):
+        if self._model is None:
+            buffers = []
+            shm_bufs = []
+            for bn, bs in self.buffer_specs:
+                # funny business with buffer sizes
+                block = shm.SharedMemory(name=bn)
+                _log.debug('%s: %d bytes (%d used)', block.name, bs, block.size)
+                buffers.append(block.buf[:bs])
+                shm_bufs.append(block)
+
+            self.buffers = shm_bufs
+            self._model = pickle.loads(self.pickle_data, buffers=buffers)
+
+        return self._model
+
+    def close(self, unlink=True):
+        self._model = None
+        if self.is_owner:
+            for buf in self.buffers:
+                buf.close()
+                buf.unlink()
+            del self.buffers
+            self.is_owner = False
+
+    def __getstate__(self):
+        return {
+            'pickle_data': self.pickle_data,
+            'buffer_specs': self.buffer_specs,
+            'is_owner': False
+        }
 
 
 def get_store(reuse=True, *, in_process=False):

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -41,6 +41,19 @@ def test_persist_bpk():
         share.close()
 
 
+@mark.skipif(lks.shm is None, reason='shared_memory not available')
+def test_persist_shm():
+    matrix = np.random.randn(1000, 100)
+    share = lks.persist_shm(matrix)
+    try:
+        m2 = share.get()
+        assert m2 is not matrix
+        assert np.all(m2 == matrix)
+        del m2
+    finally:
+        share.close()
+
+
 @store_param
 def test_store_init(store_cls):
     "Test that a store initializes and shuts down."

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -1,3 +1,5 @@
+import os
+
 import pickle
 import numpy as np
 
@@ -45,6 +47,38 @@ def test_persist_bpk():
 def test_persist_shm():
     matrix = np.random.randn(1000, 100)
     share = lks.persist_shm(matrix)
+    try:
+        m2 = share.get()
+        assert m2 is not matrix
+        assert np.all(m2 == matrix)
+        del m2
+    finally:
+        share.close()
+
+
+def test_persist():
+    "Test default persistence"
+    matrix = np.random.randn(1000, 100)
+    share = lks.persist(matrix)
+    try:
+        m2 = share.get()
+        assert m2 is not matrix
+        assert np.all(m2 == matrix)
+        del m2
+    finally:
+        share.close()
+
+
+def test_persist_dir(tmp_path):
+    "Test persistence with a configured directory"
+    matrix = np.random.randn(1000, 100)
+    os.environ['LK_TEMP_DIR'] = os.fspath(tmp_path)
+    try:
+        share = lks.persist(matrix)
+        assert isinstance(share, lks.BPKPersisted)
+    finally:
+        del os.environ['LK_TEMP_DIR']
+
     try:
         m2 = share.get()
         assert m2 is not matrix

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -28,6 +28,19 @@ def test_sharing_mode():
     assert not lks.in_share_context()
 
 
+def test_persist_bpk():
+    matrix = np.random.randn(1000, 100)
+    share = lks.persist_binpickle(matrix)
+    try:
+        assert share.path.exists()
+        m2 = share.get()
+        assert m2 is not matrix
+        assert np.all(m2 == matrix)
+        del m2
+    finally:
+        share.close()
+
+
 @store_param
 def test_store_init(store_cls):
     "Test that a store initializes and shuts down."


### PR DESCRIPTION
This adds new APIs to the `sharing` module for function-based persistence of model objects. It is a prerequisite for #150.