### PR TITLE
Fix Python versions and conda environments in CI builds

### DIFF
--- a/.github/actions/conda-env/main.js
+++ b/.github/actions/conda-env/main.js
@@ -45,7 +45,7 @@ async function initialize(cfg) {
         core.info(`creating conda environment w/ Python ${cfg.py_version}`);
         await run(conda_bin, ['create', '-qy', '-n', cfg.name, `python=${cfg.py_version}`]);
         core.info(`updating conda environment from ${cfg.file}`);
-        await run(conda_bin, ['env', 'update', '-q', '-n', cfg.name, '-f', cfg.file]);
+        await run(conda_bin, ['env', 'update', '-n', cfg.name, '-f', cfg.file]);
     } else {
         core.info(`creating conda environment from ${cfg.file}`);
         await run(conda_bin, ['env', 'create', '-q', '-n', cfg.name, '-f', cfg.file]);
@@ -113,6 +113,8 @@ async function main() {
     } else {
         await exportUnix(cfg);
     }
+    core.info('built environment, listing packages')
+    await run(conda_bin, ['list', '-n', cfg.name])
 }
 
 main().catch((err) => {

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -115,7 +115,7 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           conda activate base
           conda config --set channel_priority strict
-          python setup.py dep_info --conda-env environment.yml -E dev,tf --python-version 3.8
+          python setup.py dep_info --conda-env environment.yml -E dev,tf --python-version 3.7
           cat environment.yml
           
       - uses: ./.github/actions/conda-env

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -36,7 +36,7 @@ jobs:
             echo "Using basic dev deps"
             e_opts="-E dev"
           fi
-          python setup.py dep_info --conda-env environment.yml $e_opts
+          python setup.py dep_info --conda-env environment.yml $e_opts --python-version $PYVER
           cat environment.yml
         env:
           RUNNER: ${{runner.os}}
@@ -46,7 +46,6 @@ jobs:
         with:
           name: lkpy
           env-file: environment.yml
-          python-version: ${{matrix.python}}
 
       - name: Inspect environment
         run: |
@@ -116,14 +115,13 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           conda activate base
           conda config --set channel_priority strict
-          python setup.py dep_info --conda-env environment.yml -E dev,tf
+          python setup.py dep_info --conda-env environment.yml -E dev,tf --python-version 3.8
           cat environment.yml
           
       - uses: ./.github/actions/conda-env
         with:
           name: lkpy
           env-file: environment.yml
-          python-version: 3.8
 
       - name: Download ML-100K
         shell: pwsh
@@ -157,14 +155,13 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           conda activate base
           conda config --set channel_priority strict
-          python setup.py dep_info --conda-env environment.yml -E dev,demo
+          python setup.py dep_info --conda-env environment.yml -E dev,demo --python-version 3.8
           cat environment.yml
           
       - uses: ./.github/actions/conda-env
         with:
           name: lkpy
           env-file: environment.yml
-          python-version: 3.8
 
       - name: Download ML-100K
         shell: pwsh

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ class DepInfo(Command):
         ('ignore-extras=', 'I', 'ignore an extra from all-extras'),
         ('conda-env=', 'c', 'write Conda environment file'),
         ('conda-requires=', None, 'extra Conda requirements (raw yaml)'),
-        ('conda-forge', None, 'use conda-forge channel')
+        ('conda-forge', None, 'use conda-forge channel'),
+        ('python-version=', None, 'use specified Python version')
     ]
     boolean_options = ['all-extras', 'conda-forge']
     MAIN_PACKAGE_MAP = {
@@ -84,6 +85,7 @@ class DepInfo(Command):
         self.conda_env = None
         self.conda_requires = None
         self.conda_forge = None
+        self.python_version = None
 
     def finalize_options(self):
         """Post-process options."""
@@ -114,7 +116,10 @@ class DepInfo(Command):
                 print(msg)
 
     def _write_conda(self, file):
-        pyver = self.distribution.python_requires
+        if self.python_version:
+            pyver = f'={self.python_version}'
+        else:
+            pyver = self.distribution.python_requires
         pip_deps = []
         dep_spec = {
             'name': 'lkpy-dev',


### PR DESCRIPTION
This fixes how we test Python versions, making `dep_info` capable of specifying a version, and makes other CI tweaks.