### PR TITLE
Improve MP worker detection and disable item-item parallelism when run under MP

### DIFF
--- a/doc/performance.rst
+++ b/doc/performance.rst
@@ -52,9 +52,10 @@ and works as follows:
   of processes, and with 1 inner thread.
 * If ``LK_NUM_PROCS`` is a comma-separated pair of integers (e.g. ``8,4``), the batch
   functions will use the first number for the process count and the second number as
-  the inner thread count.
+  the inner thread count (but it will **not** override ``NUMBA_NUM_THREADS``).
 * If ``LK_NUM_PROCS`` is not set, the batch functions use half the number of cores as
-  the process count and 2 as the inner thread count.
+  the process count and 2 as the inner thread count (unless ``NUMBA_NUM_THREADS`` is
+  specified in the environment).
 
 .. _batch functions: batch.html
 

--- a/lenskit/util/parallel.py
+++ b/lenskit/util/parallel.py
@@ -103,7 +103,8 @@ def _initialize_mp_worker(mkey, func, threads, log_queue):
     _initialize_worker(log_queue)
     global __work_model, __work_func
 
-    if 'NUMBA_NUM_THREADS' not in os.environ:
+    nnt_env = os.environ.get('NUMBA_NUM_THREADS', None)
+    if nnt_env is None or int(nnt_env) > threads:
         _log.debug('configuring Numba thread count')
         import numba
         numba.config.NUMBA_NUM_THREADS = threads

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 log_level=DEBUG
-log_cli_format = [%(levelname)7s] %(asctime)s %(name)s %(message)s
-log_file_format = [%(levelname)7s] %(asctime)s %(name)s %(message)s
+log_format = [%(levelname)7s] [%(processName)s] %(name)s %(message)s
+log_cli_format = [%(levelname)7s] %(asctime)s [%(processName)s] %(name)s %(message)s
+log_file_format = [%(levelname)7s] %(asctime)s [%(processName)s] %(name)s %(message)s
 doctest_plus=enabled
 doctest_subpackage_requires =
     lenskit/algorithms/svd* = scikit-learn

--- a/tests/test_knn_item_item.py
+++ b/tests/test_knn_item_item.py
@@ -569,15 +569,13 @@ def test_ii_impl_match():
 @lktu.wantjit
 @mark.slow
 @mark.eval
+@mark.skipif(not lktu.ml100k.available, reason='ML100K not available')
 @mark.parametrize('ncpus', [1, 2])
 def test_ii_batch_recommend(ncpus):
     import lenskit.crossfold as xf
     from lenskit import batch, topn
 
-    if not os.path.exists('ml-100k/u.data'):
-        raise pytest.skip()
-
-    ratings = pd.read_csv('ml-100k/u.data', sep='\t', names=['user', 'item', 'rating', 'timestamp'])
+    ratings = lktu.ml100k.ratings
 
     def eval(train, test):
         _log.info('running training')
@@ -604,3 +602,4 @@ def test_ii_batch_recommend(ncpus):
     dcg = results.ndcg
     _log.info('nDCG for %d users is %f', len(dcg), dcg.mean())
     assert dcg.mean() > 0.03
+

--- a/tests/test_knn_item_item.py
+++ b/tests/test_knn_item_item.py
@@ -619,7 +619,8 @@ def _build_predict(ratings, fold):
 
 @lktu.wantjit
 @mark.slow
-def test_ii_multi_build():
+def test_ii_parallel_multi_build():
+    "Build multiple item-item models in parallel"
     ratings = lktu.ml_test.ratings
     ratings['partition'] = np.random.choice(4, len(ratings), replace=True)
 


### PR DESCRIPTION
Item-item CF's parallelism causes segfaults (reliably) when the item-item model build process is run *inside* a multiprocessing context. This PR adds more reliable detection for MP worker threads and entirely disables item-item's parallel building when running under a multiprocessing regime to build many models in parallel.