### PR TITLE
Remove BiasedMFPredictor in favor of Bias

### DIFF
--- a/doc/mf.rst
+++ b/doc/mf.rst
@@ -12,15 +12,11 @@ Common Support
 .. module:: lenskit.algorithms.mf_common
 
 The :py:mod:`mf_common` module contains common support code for matrix factorization
-algorithms.  These classes, :py:class:`MFPredictor` and :py:class:`BiasMFPredictor`,
-define the parameters that are estimated during the :py:meth:`.Algorithm.fit` 
+algorithms.  This class, :py:class:`MFPredictor`,
+defines the parameters that are estimated during the :py:meth:`.Algorithm.fit` 
 process on common matrix factorization algorithms.
 
 .. autoclass:: MFPredictor
-   :show-inheritance:
-   :members:
-
-.. autoclass:: BiasMFPredictor
    :show-inheritance:
    :members:
 

--- a/lenskit/algorithms/als.py
+++ b/lenskit/algorithms/als.py
@@ -294,7 +294,7 @@ class BiasedMF(MFPredictor):
         A direct implementation of the original ALS concept [ZWSP2008]_ using LU-decomposition
         to solve for the optimized matrices.
 
-    See the base class :class:`.BiasMFPredictor` for documentation on
+    See the base class :class:`.MFPredictor` for documentation on
     the estimated parameters you can extract from a trained model.
 
     .. [ZWSP2008] Yunhong Zhou, Dennis Wilkinson, Robert Schreiber, and Rong Pan. 2008.

--- a/lenskit/algorithms/als.py
+++ b/lenskit/algorithms/als.py
@@ -5,7 +5,7 @@ import numpy as np
 from numba import njit, prange
 
 from .bias import Bias
-from .mf_common import BiasMFPredictor, MFPredictor
+from .mf_common import MFPredictor
 from ..matrix import sparse_ratings
 from .. import util
 from ..math.solve import _dposv

--- a/lenskit/algorithms/funksvd.py
+++ b/lenskit/algorithms/funksvd.py
@@ -196,7 +196,7 @@ class FunkSVD(MFPredictor):
     biased matrix factorization technique trained with featurewise stochastic gradient
     descent.
 
-    See the base class :class:`.BiasMFPredictor` for documentation on the estimated parameters
+    See the base class :class:`.MFPredictor` for documentation on the estimated parameters
     you can extract from a trained model.
 
     Args:

--- a/lenskit/algorithms/funksvd.py
+++ b/lenskit/algorithms/funksvd.py
@@ -245,7 +245,7 @@ class FunkSVD(MFPredictor):
 
         if self.bias:
             _logger.info('[%s] fitting bias model', timer)
-            ratings = self.bias.fit_transform(ratings)
+            self.bias.fit(ratings)
 
         _logger.info('[%s] preparing rating data for %d samples', timer, len(ratings))
         _logger.debug('shuffling rating data')

--- a/lenskit/algorithms/funksvd.py
+++ b/lenskit/algorithms/funksvd.py
@@ -8,6 +8,7 @@ import time
 import pandas as pd
 import numpy as np
 import numba as n
+from pandas.core.series import Series
 try:
     from numba.experimental import jitclass
 except ImportError:
@@ -222,6 +223,8 @@ class FunkSVD(MFPredictor):
         self.reg = reg
         self.damping = damping
         self.range = range
+        if not bias:
+            bias = None
         if bias is True:
             self.bias = Bias(damping=damping)
         else:
@@ -292,7 +295,8 @@ class FunkSVD(MFPredictor):
         # look up user index
         # look up user index
         preds = self.score_by_ids(user, items)
-        preds = self.bias.inverse_transform_user(user, preds)
+        if self.bias is not None:
+            preds = self.bias.inverse_transform_user(user, preds)
 
         # clamp if suitable
         if self.range is not None:

--- a/lenskit/algorithms/mf_common.py
+++ b/lenskit/algorithms/mf_common.py
@@ -2,13 +2,11 @@
 Common utilities & implementations for matrix factorization.
 """
 
-import pathlib
 import logging
 
 import numpy as np
 import pandas as pd
 
-from .. import util
 from . import Predictor
 
 _logger = logging.getLogger(__name__)
@@ -114,44 +112,3 @@ class MFPredictor(Predictor):
         res = pd.Series(rv, index=good_items)
         res = res.reindex(items)
         return res
-
-
-class BiasMFPredictor(MFPredictor):
-    """
-    Common model for biased matrix factorization.
-
-    Attributes:
-        user_index_(pandas.Index): Users in the model (length=:math:`m`).
-        item_index_(pandas.Index): Items in the model (length=:math:`n`).
-        global_bias_(double): The global bias term.
-        user_bias_(numpy.ndarray): The user bias terms.
-        item_bias_(numpy.ndarray): The item bias terms.
-        user_features_(numpy.ndarray): The :math:`m \\times k` user-feature matrix.
-        item_features_(numpy.ndarray): The :math:`n \\times k` item-feature matrix.
-    """
-
-    def score(self, user, items, u_features=None, raw=False):
-        """
-        Score a set of items for a user. User and item parameters must be indices
-        into the matrices.
-
-        Args:
-            user(int): the user index
-            items(array-like of int): the item indices
-            raw(bool): if ``True``, do return raw scores without biases added back.
-
-        Returns:
-            numpy.ndarray: the scores for the items.
-        """
-
-        rv = super().score(user, items, u_features)
-
-        if not raw and u_features is None:
-            # add bias back in
-            rv = rv + self.global_bias_
-            if self.user_bias_ is not None and user is not None:
-                rv = rv + self.user_bias_[user]
-            if self.item_bias_ is not None:
-                rv = rv + self.item_bias_[items]
-
-        return rv

--- a/tests/test_als_explicit.py
+++ b/tests/test_als_explicit.py
@@ -315,9 +315,9 @@ def test_als_batch_accuracy():
     _log.info('diff summary:\n%s', preds.abs_diff.describe())
 
     lu_mae = pm.mae(preds.lu_pred, preds.rating)
-    assert lu_mae == approx(0.73, abs=0.04)
+    assert lu_mae == approx(0.73, abs=0.045)
     cd_mae = pm.mae(preds.cd_pred, preds.rating)
-    assert cd_mae == approx(0.73, abs=0.04)
+    assert cd_mae == approx(0.73, abs=0.045)
 
     user_rmse = preds.groupby('user').apply(lambda df: pm.rmse(df.lu_pred, df.rating))
     assert user_rmse.mean() == approx(0.94, abs=0.05)

--- a/tests/test_funksvd.py
+++ b/tests/test_funksvd.py
@@ -60,6 +60,7 @@ def test_fsvd_predict_clamp():
     assert algo.user_features_.shape == (3, 20)
 
     preds = algo.predict_for_user(10, [3])
+    assert isinstance(preds, pd.Series)
     assert len(preds) == 1
     assert preds.index[0] == 3
     assert preds.loc[3] >= 1
@@ -155,7 +156,7 @@ def test_fsvd_train_binary():
     original = svd.FunkSVD(20, iterations=20, bias=False)
     original.fit(ratings)
 
-    assert original.bias.mean_ == 0
+    assert original.bias is None
     assert original.item_features_.shape == (ratings.item.nunique(), 20)
     assert original.user_features_.shape == (ratings.user.nunique(), 20)
 

--- a/tests/test_funksvd.py
+++ b/tests/test_funksvd.py
@@ -22,7 +22,7 @@ def test_fsvd_basic_build():
     algo = svd.FunkSVD(20, iterations=20)
     algo.fit(simple_df)
 
-    assert algo.global_bias_ == approx(simple_df.rating.mean())
+    assert algo.bias.mean_ == approx(simple_df.rating.mean())
     assert algo.item_features_.shape == (3, 20)
     assert algo.user_features_.shape == (3, 20)
 
@@ -31,7 +31,7 @@ def test_fsvd_clamp_build():
     algo = svd.FunkSVD(20, iterations=20, range=(1, 5))
     algo.fit(simple_df)
 
-    assert algo.global_bias_ == approx(simple_df.rating.mean())
+    assert algo.bias.mean_ == approx(simple_df.rating.mean())
     assert algo.item_features_.shape == (3, 20)
     assert algo.user_features_.shape == (3, 20)
 
@@ -40,7 +40,7 @@ def test_fsvd_predict_basic():
     algo = svd.FunkSVD(20, iterations=20)
     algo.fit(simple_df)
 
-    assert algo.global_bias_ == approx(simple_df.rating.mean())
+    assert algo.bias.mean_ == approx(simple_df.rating.mean())
     assert algo.item_features_.shape == (3, 20)
     assert algo.user_features_.shape == (3, 20)
 
@@ -55,7 +55,7 @@ def test_fsvd_predict_clamp():
     algo = svd.FunkSVD(20, iterations=20, range=(1, 5))
     algo.fit(simple_df)
 
-    assert algo.global_bias_ == approx(simple_df.rating.mean())
+    assert algo.bias.mean_ == approx(simple_df.rating.mean())
     assert algo.item_features_.shape == (3, 20)
     assert algo.user_features_.shape == (3, 20)
 
@@ -70,9 +70,7 @@ def test_fsvd_no_bias():
     algo = svd.FunkSVD(20, iterations=20, bias=None)
     algo.fit(simple_df)
 
-    assert algo.global_bias_ == 0
-    assert algo.item_bias_ is None
-    assert algo.user_bias_ is None
+    assert algo.bias is None
     assert algo.item_features_.shape == (3, 20)
     assert algo.user_features_.shape == (3, 20)
 
@@ -86,7 +84,7 @@ def test_fsvd_predict_bad_item():
     algo = svd.FunkSVD(20, iterations=20)
     algo.fit(simple_df)
 
-    assert algo.global_bias_ == approx(simple_df.rating.mean())
+    assert algo.bias.mean_ == approx(simple_df.rating.mean())
     assert algo.item_features_.shape == (3, 20)
     assert algo.user_features_.shape == (3, 20)
 
@@ -100,7 +98,7 @@ def test_fsvd_predict_bad_item_clamp():
     algo = svd.FunkSVD(20, iterations=20, range=(1, 5))
     algo.fit(simple_df)
 
-    assert algo.global_bias_ == approx(simple_df.rating.mean())
+    assert algo.bias.mean_ == approx(simple_df.rating.mean())
     assert algo.item_features_.shape == (3, 20)
     assert algo.user_features_.shape == (3, 20)
 
@@ -114,7 +112,7 @@ def test_fsvd_predict_bad_user():
     algo = svd.FunkSVD(20, iterations=20)
     algo.fit(simple_df)
 
-    assert algo.global_bias_ == approx(simple_df.rating.mean())
+    assert algo.bias.mean_ == approx(simple_df.rating.mean())
     assert algo.item_features_.shape == (3, 20)
     assert algo.user_features_.shape == (3, 20)
 
@@ -132,7 +130,7 @@ def test_fsvd_save_load():
     original = svd.FunkSVD(20, iterations=20)
     original.fit(ratings)
 
-    assert original.global_bias_ == approx(ratings.rating.mean())
+    assert original.bias.mean_ == approx(ratings.rating.mean())
     assert original.item_features_.shape == (ratings.item.nunique(), 20)
     assert original.user_features_.shape == (ratings.user.nunique(), 20)
 
@@ -140,9 +138,9 @@ def test_fsvd_save_load():
     _log.info('serialized to %d bytes', len(mod))
     algo = pickle.loads(mod)
 
-    assert algo.global_bias_ == original.global_bias_
-    assert np.all(algo.user_bias_ == original.user_bias_)
-    assert np.all(algo.item_bias_ == original.item_bias_)
+    assert algo.bias.mean_ == original.bias.mean_
+    assert np.all(algo.bias.user_offsets_ == original.bias.user_offsets_)
+    assert np.all(algo.bias.item_offsets_ == original.bias.item_offsets_)
     assert np.all(algo.user_features_ == original.user_features_)
     assert np.all(algo.item_features_ == original.item_features_)
     assert np.all(algo.item_index_ == original.item_index_)
@@ -157,7 +155,7 @@ def test_fsvd_train_binary():
     original = svd.FunkSVD(20, iterations=20, bias=False)
     original.fit(ratings)
 
-    assert original.global_bias_ == 0
+    assert original.bias.mean_ == 0
     assert original.item_features_.shape == (ratings.item.nunique(), 20)
     assert original.user_features_.shape == (ratings.user.nunique(), 20)
 


### PR DESCRIPTION
This removes the remaining uses of `BiasedMFPredictor` in favor of using the `Bias` class directly.