### PR TITLE
ALS: Refactor common matrix & fix tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,17 +3,26 @@ from pytest import fixture
 
 import numpy as np
 
+from lenskit import util
+
 logging.getLogger('numba').setLevel(logging.INFO)
 
 _log = logging.getLogger('lenskit.tests')
 
 
-@fixture(scope='session')
+@fixture
 def rng():
-    if hasattr(np.random, 'default_rng'):
-        return np.random.default_rng()
-    else:
-        return np.random.RandomState()
+    return util.rng(42)
+
+
+@fixture
+def legacy_rng():
+    return util.rng(42, legacy_rng=True)
+
+
+@fixture(autouse=True)
+def init_rng(request):
+    util.init_rng(42)
 
 
 @fixture(autouse=True)

--- a/tests/test_als_implicit.py
+++ b/tests/test_als_implicit.py
@@ -47,6 +47,7 @@ def test_als_predict_basic():
     assert preds.loc[3] >= -0.1
     assert preds.loc[3] <= 5
 
+
 def test_als_predict_basic_for_new_ratings():
     """ Test ImplicitMF ability to support new ratings """
     algo = als.ImplicitMF(20, iterations=10)
@@ -60,6 +61,7 @@ def test_als_predict_basic_for_new_ratings():
     assert preds.index[0] == 3
     assert preds.loc[3] >= -0.1
     assert preds.loc[3] <= 5
+
 
 def test_als_predict_basic_for_new_user_with_new_ratings():
     """
@@ -79,6 +81,7 @@ def test_als_predict_basic_for_new_user_with_new_ratings():
 
     new_preds = algo.predict_for_user(new_u_id, [i], new_ratings)
     assert abs(preds.loc[i] - new_preds.loc[i]) <= 0.1
+
 
 def test_als_predict_for_new_users_with_new_ratings():
     """
@@ -117,6 +120,7 @@ def test_als_predict_for_new_users_with_new_ratings():
         diffs = abs(preds.values - new_preds.values)
         assert all(i <= 0.1 for i in diffs) == True
 
+
 def test_als_recs_topn_for_new_users_with_new_ratings():
     """
         Test if ImplicitMF topn recommendations using the same ratings for a new user
@@ -152,6 +156,7 @@ def test_als_recs_topn_for_new_users_with_new_ratings():
 
         tau = stats.kendalltau(recs.item.to_numpy(), new_recs.item.to_numpy())
         assert tau.correlation > 0
+
 
 def test_als_predict_bad_item():
     algo = als.ImplicitMF(20, iterations=10)

--- a/tests/test_als_implicit.py
+++ b/tests/test_als_implicit.py
@@ -15,6 +15,9 @@ import lenskit.util.test as lktu
 from lenskit.algorithms import Recommender
 from lenskit.util import Stopwatch
 
+from hypothesis import given
+from hypothesis.strategies import randoms
+
 _log = logging.getLogger(__name__)
 
 simple_df = pd.DataFrame({'item': [1, 1, 2, 3],
@@ -53,7 +56,7 @@ def test_als_predict_basic_for_new_ratings():
     algo = als.ImplicitMF(20, iterations=10)
     algo.fit(simple_df)
 
-    new_ratings = pd.Series([4.0, 5.0], index=[1, 2]) # items as index and ratings as values
+    new_ratings = pd.Series([4.0, 5.0], index=[1, 2])  # items as index and ratings as values
 
     preds = algo.predict_for_user(15, [3], new_ratings)
 
@@ -65,8 +68,8 @@ def test_als_predict_basic_for_new_ratings():
 
 def test_als_predict_basic_for_new_user_with_new_ratings():
     """
-        Test if ImplicitMF predictions using the same ratings for a new user
-        is the same as a user in the current simple_df dataset.
+    Test if ImplicitMF predictions using the same ratings for a new user
+    is the same as a user in the current simple_df dataset.
     """
     u = 10
     i = 3
@@ -77,7 +80,7 @@ def test_als_predict_basic_for_new_user_with_new_ratings():
     preds = algo.predict_for_user(u, [i])
 
     new_u_id = 1
-    new_ratings = pd.Series([4.0, 5.0], index=[1, 2]) # items as index and ratings as values
+    new_ratings = pd.Series([4.0, 5.0], index=[1, 2])  # items as index and ratings as values
 
     new_preds = algo.predict_for_user(new_u_id, [i], new_ratings)
     assert abs(preds.loc[i] - new_preds.loc[i]) <= 0.1
@@ -85,9 +88,9 @@ def test_als_predict_basic_for_new_user_with_new_ratings():
 
 def test_als_predict_for_new_users_with_new_ratings():
     """
-        Test if ImplicitMF predictions using the same ratings for a new user
-        is the same as a user in ml-latest-small dataset.
-        The test is run for more than one user.
+    Test if ImplicitMF predictions using the same ratings for a new user
+    is the same as a user in ml-latest-small dataset.
+    The test is run for more than one user.
     """
     n_users = 3
     n_items = 2
@@ -105,57 +108,70 @@ def test_als_predict_for_new_users_with_new_ratings():
     for u in users:
         _log.debug(f"user: {u}")
         preds = algo.predict_for_user(u, items)
+        upos = algo.user_index_.get_loc(u)
 
         user_data = ratings[ratings.user == u]
 
-        _log.debug("user_features from fit: " + str(algo.user_features_[algo.user_index_.get_loc(u), :]))
+        _log.debug("user_features from fit: " + str(algo.user_features_[upos, :]))
 
-        new_ratings = pd.Series(user_data.rating.to_numpy(), index=user_data.item) # items as index and ratings as values
+        # get the user's rating series
+        new_ratings = user_data.set_index('item')['rating'].copy()
         new_preds = algo.predict_for_user(new_u_id, items, new_ratings)
 
         _log.debug("preds: " + str(preds.values))
         _log.debug("new_preds: " + str(new_preds.values))
         _log.debug("------------")
 
-        diffs = abs(preds.values - new_preds.values)
-        assert all(i <= 0.1 for i in diffs) == True
+        diffs = np.abs(preds.values - new_preds.values)
+        assert all(diffs <= 0.1)
 
 
-def test_als_recs_topn_for_new_users_with_new_ratings():
+def test_als_recs_topn_for_new_users_with_new_ratings(rng):
     """
-        Test if ImplicitMF topn recommendations using the same ratings for a new user
-        is the same as a user in ml-latest-small dataset.
-        The test is run for more than one user.
+    Test if ImplicitMF topn recommendations using the same ratings for a new user
+    is the same as a user in ml-latest-small dataset.
+    The test is run for more than one user.
     """
     from lenskit.algorithms import basic
     import scipy.stats as stats
 
-    n_users = 3
-    n_items = 10
+    n_users = 10
     new_u_id = -1
     ratings = lktu.ml_test.ratings
 
-    np.random.seed(45)
-    users = np.random.choice(ratings.user.unique(), n_users)
-    items = np.random.choice(ratings.item.unique(), n_items)
+    users = rng.choice(np.unique(ratings.user), n_users)
 
     algo = als.ImplicitMF(20, iterations=10, method="lu")
     rec_algo = basic.TopN(algo)
     rec_algo.fit(ratings)
-    _log.debug("Items: " + str(items))
+    # _log.debug("Items: " + str(items))
 
+    correlations = pd.Series(np.nan, index=users)
     for u in users:
-        _log.debug(f"user: {u}")
-        recs = rec_algo.recommend(u, 10, candidates=items)
+        recs = rec_algo.recommend(u, 10)
         user_data = ratings[ratings.user == u]
+        upos = algo.user_index_.get_loc(u)
+        _log.info('user %s: %s ratings', u, len(user_data))
 
-        _log.debug("user_features from fit: " + str(algo.user_features_[algo.user_index_.get_loc(u), :]))
+        _log.debug("user_features from fit: " + str(algo.user_features_[upos, :]))
 
-        new_ratings = pd.Series(user_data.rating.to_numpy(), index=user_data.item) # items as index and ratings as values
-        new_recs = rec_algo.recommend(new_u_id, 10, candidates=items, ratings=new_ratings)
+        # get the user's rating series
+        new_ratings = user_data.set_index('item')['rating'].copy()
+        new_recs = rec_algo.recommend(new_u_id, 10, ratings=new_ratings)
 
-        tau = stats.kendalltau(recs.item.to_numpy(), new_recs.item.to_numpy())
-        assert tau.correlation > 0
+        # merge new & old recs
+        all_recs = pd.merge(recs.rename(columns={'score': 'old_score'}),
+                            new_recs.rename(columns={'score': 'new_score'}),
+                            how='outer').fillna(-np.inf)
+
+        tau = stats.kendalltau(all_recs.old_score, all_recs.new_score)
+        _log.info('correlation for user %s: %f', u, tau.correlation)
+        correlations.loc[u] = tau.correlation
+
+    _log.debug('correlations: %s', correlations)
+
+    assert not(any(correlations.isnull()))
+    assert all(correlations >= 0.5)
 
 
 def test_als_predict_bad_item():


### PR DESCRIPTION
This does a littler ALS cleanup:

- [x] refactor the computation of `OtOr` in ImplicitALS into a function
- [x] correct Kendall *τ* computation