### PR TITLE
Allow scipy='coo' in sparse_ratings

### DIFF
--- a/lenskit/matrix/__init__.py
+++ b/lenskit/matrix/__init__.py
@@ -470,8 +470,8 @@ def sparse_ratings(ratings, scipy=False, *, users=None, items=None):
 
     Args:
         ratings(pandas.DataFrame): a data table of (user, item, rating) triples.
-        scipy: if ``True`` or ``"csr"``, return a SciPy csr matrix instead of
-        :py:class:`CSR`. if ``"coo"``, return a SciPy coo matrix.
+        scipy: if ``True`` or ``'csr'``, return a SciPy csr matrix instead of
+        :py:class:`CSR`. if ``'coo'``, return a SciPy coo matrix.
         users(pandas.Index): an index of user IDs.
         items(pandas.Index): an index of items IDs.
 
@@ -500,7 +500,7 @@ def sparse_ratings(ratings, scipy=False, *, users=None, items=None):
     else:
         vals = None
 
-    if scipy == "coo":
+    if scipy == 'coo':
         matrix = sps.coo_matrix(
             (vals, (row_ind, col_ind)), shape=(len(users), len(items))
         )

--- a/lenskit/matrix/__init__.py
+++ b/lenskit/matrix/__init__.py
@@ -11,7 +11,7 @@ import scipy.sparse as sps
 
 _logger = logging.getLogger(__name__)
 
-RatingMatrix = namedtuple("RatingMatrix", ["matrix", "users", "items"])
+RatingMatrix = namedtuple('RatingMatrix', ['matrix', 'users', 'items'])
 RatingMatrix.__doc__ = """
 A rating matrix with associated indices.
 
@@ -29,7 +29,6 @@ def _impl_mod():
     global __impl_mod
     if __impl_mod is None:
         from . import native
-
         __impl_mod = native
     return __impl_mod
 
@@ -40,14 +39,13 @@ def mkl_ops():
     """
     try:
         from . import _mkl_ops
-
         if _mkl_ops.clib:
             return _mkl_ops
         else:
-            _logger.debug("MKL imported but not available")
+            _logger.debug('MKL imported but not available')
             return None
     except ImportError as e:
-        _logger.debug("MKL not importable: %s", e)
+        _logger.debug('MKL not importable: %s', e)
         return None
 
 
@@ -60,7 +58,6 @@ class _CSR:
     Note that the ``values`` array is always present (unlike the Python shim), but is
     zero-length if no values are present.  This eases Numba type-checking.
     """
-
     def __init__(self, nrows, ncols, nnz, ptrs, inds, vals):
         self.nrows = nrows
         self.ncols = ncols
@@ -87,7 +84,7 @@ class _CSR:
 
     def row_extent(self, row):
         sp = self.rowptrs[row]
-        ep = self.rowptrs[row + 1]
+        ep = self.rowptrs[row+1]
         return (sp, ep)
 
     def row_cs(self, row):
@@ -149,12 +146,9 @@ class CSR:
         colinds(numpy.ndarray): the column indices.
         values(numpy.ndarray): the values
     """
+    __slots__ = ['_N']
 
-    __slots__ = ["_N"]
-
-    def __init__(
-        self, nrows=None, ncols=None, nnz=None, ptrs=None, inds=None, vals=None, N=None
-    ):
+    def __init__(self, nrows=None, ncols=None, nnz=None, ptrs=None, inds=None, vals=None, N=None):
         if N is not None:
             self._N = N
         else:
@@ -227,16 +221,16 @@ class CSR:
         """
         if not sps.isspmatrix_csr(mat):
             mat = mat.tocsr(copy=copy)
-        rp = np.require(mat.indptr, np.intc, "C")
+        rp = np.require(mat.indptr, np.intc, 'C')
         if copy and rp is mat.indptr:
             rp = rp.copy()
-        cs = np.require(mat.indices, np.intc, "C")
+        cs = np.require(mat.indices, np.intc, 'C')
         if copy and cs is mat.indices:
             cs = cs.copy()
         vs = mat.data.copy() if copy else mat.data
         return cls(mat.shape[0], mat.shape[1], mat.nnz, rp, cs, vs)
 
-    def to_scipy(self, format="csr"):
+    def to_scipy(self):
         """
         Convert a CSR matrix to a SciPy :py:class:`scipy.sparse.csr_matrix`.  Avoids copying
         if possible.
@@ -251,14 +245,7 @@ class CSR:
         values = self.values
         if values is None:
             values = np.full(self.nnz, 1.0)
-        if format == "coo":
-            return sps.coo_matrix(
-                (values, self.colinds, self.rowptrs), shape=(self.nrows, self.ncols)
-            )
-        else:
-            return sps.csr_matrix(
-                (values, self.colinds, self.rowptrs), shape=(self.nrows, self.ncols)
-            )
+        return sps.csr_matrix((values, self.colinds, self.rowptrs), shape=(self.nrows, self.ncols))
 
     @property
     def N(self):
@@ -271,22 +258,18 @@ class CSR:
             # This is not yet upgraded
             impl = _impl_mod()
             if n.rowptrs.dtype == np.int64:
-                self._N = impl._CSR64(
-                    n.nrows, n.ncols, n.nnz, n.rowptrs, n.colinds, n.values
-                )
+                self._N = impl._CSR64(n.nrows, n.ncols, n.nnz, n.rowptrs, n.colinds, n.values)
             else:
-                self._N = impl._CSR(
-                    n.nrows, n.ncols, n.nnz, n.rowptrs, n.colinds, n.values
-                )
+                self._N = impl._CSR(n.nrows, n.ncols, n.nnz, n.rowptrs, n.colinds, n.values)
             # make sure types behave how we expect
             assert impl.n.config.DISABLE_JIT or not isinstance(self._N, _CSR)
         return self._N
 
-    nrows = _csr_delegate("nrows")
-    ncols = _csr_delegate("ncols")
-    nnz = _csr_delegate("nnz")
-    rowptrs = _csr_delegate("rowptrs")
-    colinds = _csr_delegate("colinds")
+    nrows = _csr_delegate('nrows')
+    ncols = _csr_delegate('ncols')
+    nnz = _csr_delegate('nnz')
+    rowptrs = _csr_delegate('rowptrs')
+    colinds = _csr_delegate('colinds')
 
     @property
     def values(self):
@@ -299,17 +282,15 @@ class CSR:
     def values(self, vs: np.ndarray):
         if vs is not None:
             if not isinstance(vs, np.ndarray):
-                raise TypeError("values not an ndarray")
+                raise TypeError('values not an ndarray')
             if vs.ndim != 1:
-                raise ValueError(
-                    "values has {} dimensions, expected 1".format(vs.ndims)
-                )
+                raise ValueError('values has {} dimensions, expected 1'.format(vs.ndims))
             if vs.shape[0] < self.nnz:
-                s = "values has only {} entries (expected at least {})"
+                s = 'values has only {} entries (expected at least {})'
                 raise ValueError(s.format(vs.shape[0], self.nnz))
 
-            vs = vs[: self.nnz]
-            vs = np.require(vs, "f8")
+            vs = vs[:self.nnz]
+            vs = np.require(vs, 'f8')
             self._N.values = vs
         else:
             self._N.values = np.zeros(0)
@@ -398,12 +379,12 @@ class CSR:
                 The normalization values for each row.
         """
         impl = _impl_mod()
-        if normalization == "center":
+        if normalization == 'center':
             return impl._center_rows(self.N)
-        elif normalization == "unit":
+        elif normalization == 'unit':
             return impl._unit_rows(self.N)
         else:
-            raise ValueError("unknown normalization: " + normalization)
+            raise ValueError('unknown normalization: ' + normalization)
 
     def transpose(self, values=True):
         """
@@ -442,14 +423,12 @@ class CSR:
             CSR: The filtered sparse matrix.
         """
         if len(filt) != self.nnz:
-            raise ValueError(
-                "filter has length %d, expected %d" % (len(filt), self.nnz)
-            )
+            raise ValueError('filter has length %d, expected %d' % (len(filt), self.nnz))
         rps2 = np.zeros_like(self.rowptrs)
         for i in range(self.nrows):
             sp, ep = self.row_extent(i)
             rlen = np.sum(filt[sp:ep])
-            rps2[i + 1] = rps2[i] + rlen
+            rps2[i+1] = rps2[i] + rlen
 
         nnz2 = rps2[-1]
         assert nnz2 == np.sum(filt)
@@ -461,32 +440,27 @@ class CSR:
         return CSR(self.nrows, self.ncols, nnz2, rps2, cis2, vs2)
 
     def __str__(self):
-        return "<CSR {}x{} ({} nnz)>".format(self.nrows, self.ncols, self.nnz)
+        return '<CSR {}x{} ({} nnz)>'.format(self.nrows, self.ncols, self.nnz)
 
     def __repr__(self):
-        repr = "<CSR {}x{} ({} nnz)".format(self.nrows, self.ncols, self.nnz)
-        repr += " {\n"
-        repr += "  rowptrs={}\n".format(self.rowptrs)
-        repr += "  colinds={}\n".format(self.colinds)
-        repr += "  values={}\n".format(self.values)
-        repr += "}"
+        repr = '<CSR {}x{} ({} nnz)'.format(self.nrows, self.ncols, self.nnz)
+        repr += ' {\n'
+        repr += '  rowptrs={}\n'.format(self.rowptrs)
+        repr += '  colinds={}\n'.format(self.colinds)
+        repr += '  values={}\n'.format(self.values)
+        repr += '}'
         return repr
 
     def __getstate__(self):
-        return dict(
-            shape=(self.nrows, self.ncols),
-            nnz=self.nnz,
-            rowptrs=self.rowptrs,
-            colinds=self.colinds,
-            values=self.values,
-        )
+        return dict(shape=(self.nrows, self.ncols), nnz=self.nnz,
+                    rowptrs=self.rowptrs, colinds=self.colinds, values=self.values)
 
     def __setstate__(self, state):
-        nrows, ncols = state["shape"]
-        nnz = state["nnz"]
-        rps = state["rowptrs"]
-        cis = state["colinds"]
-        vs = state["values"]
+        nrows, ncols = state['shape']
+        nnz = state['nnz']
+        rps = state['rowptrs']
+        cis = state['colinds']
+        vs = state['values']
         self._N = _CSR(nrows, ncols, nnz, rps, cis, vs)
 
 
@@ -505,26 +479,22 @@ def sparse_ratings(ratings, scipy=False, *, users=None, items=None):
             a named tuple containing the sparse matrix, user index, and item index.
     """
     if users is None:
-        users = pd.Index(np.unique(ratings.user), name="user")
+        users = pd.Index(np.unique(ratings.user), name='user')
 
     if items is None:
-        items = pd.Index(np.unique(ratings.item), name="item")
+        items = pd.Index(np.unique(ratings.item), name='item')
 
-    _logger.debug(
-        "creating matrix with %d ratings for %d items by %d users",
-        len(ratings),
-        len(items),
-        len(users),
-    )
+    _logger.debug('creating matrix with %d ratings for %d items by %d users',
+                  len(ratings), len(items), len(users))
 
     row_ind = users.get_indexer(ratings.user).astype(np.intc)
     if np.any(row_ind < 0):
-        raise ValueError("provided user index does not cover all users")
+        raise ValueError('provided user index does not cover all users')
     col_ind = items.get_indexer(ratings.item).astype(np.intc)
     if np.any(col_ind < 0):
-        raise ValueError("provided item index does not cover all users")
+        raise ValueError('provided item index does not cover all users')
 
-    if "rating" in ratings.columns:
+    if 'rating' in ratings.columns:
         vals = np.require(ratings.rating.values, np.float64)
     else:
         vals = None
@@ -532,7 +502,6 @@ def sparse_ratings(ratings, scipy=False, *, users=None, items=None):
     matrix = CSR.from_coo(row_ind, col_ind, vals, (len(users), len(items)))
 
     if scipy:
-        format = "csr" if scipy is True else scipy
-        matrix = matrix.to_scipy(format=format)
+        matrix = matrix.to_scipy()
 
     return RatingMatrix(matrix, users, items)

--- a/lenskit/matrix/__init__.py
+++ b/lenskit/matrix/__init__.py
@@ -470,7 +470,8 @@ def sparse_ratings(ratings, scipy=False, *, users=None, items=None):
 
     Args:
         ratings(pandas.DataFrame): a data table of (user, item, rating) triples.
-        scipy: if ``True`` or ``"csr"``, return a SciPy csr matrix instead of :py:class:`CSR`. if ``"coo"``, return a SciPy coo matrix.
+        scipy: if ``True`` or ``"csr"``, return a SciPy csr matrix instead of
+        :py:class:`CSR`. if ``"coo"``, return a SciPy coo matrix.
         users(pandas.Index): an index of user IDs.
         items(pandas.Index): an index of items IDs.
 

--- a/lenskit/matrix/__init__.py
+++ b/lenskit/matrix/__init__.py
@@ -470,7 +470,7 @@ def sparse_ratings(ratings, scipy=False, *, users=None, items=None):
 
     Args:
         ratings(pandas.DataFrame): a data table of (user, item, rating) triples.
-        scipy: if ``True``, return a SciPy matrix instead of :py:class:`CSR`.
+        scipy: if ``True`` or ``"csr"``, return a SciPy csr matrix instead of :py:class:`CSR`. if ``"coo"``, return a SciPy coo matrix.
         users(pandas.Index): an index of user IDs.
         items(pandas.Index): an index of items IDs.
 
@@ -499,9 +499,13 @@ def sparse_ratings(ratings, scipy=False, *, users=None, items=None):
     else:
         vals = None
 
-    matrix = CSR.from_coo(row_ind, col_ind, vals, (len(users), len(items)))
-
-    if scipy:
-        matrix = matrix.to_scipy()
+    if scipy == "coo":
+        matrix = sps.coo_matrix(
+            (vals, (row_ind, col_ind)), shape=(len(users), len(items))
+        )
+    else:
+        matrix = CSR.from_coo(row_ind, col_ind, vals, (len(users), len(items)))
+        if scipy:
+            matrix = matrix.to_scipy()
 
     return RatingMatrix(matrix, users, items)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -20,17 +20,17 @@ def test_sparse_matrix(rng):
     assert mat.ncols == ratings.item.nunique()
 
     # user indicators should correspond to user item counts
-    ucounts = ratings.groupby('user').item.count()
+    ucounts = ratings.groupby("user").item.count()
     ucounts = ucounts.loc[uidx].cumsum()
     assert all(mat.rowptrs[1:] == ucounts.values)
 
     # verify rating values
-    ratings = ratings.set_index(['user', 'item'])
+    ratings = ratings.set_index(["user", "item"])
     for u in rng.choice(uidx, size=50):
         ui = uidx.get_loc(u)
         vs = mat.row_vs(ui)
         vs = pd.Series(vs, iidx[mat.row_cs(ui)])
-        rates = ratings.loc[u]['rating']
+        rates = ratings.loc[u]["rating"]
         vs, rates = vs.align(rates)
         assert not any(vs.isna())
         assert not any(rates.isna())
@@ -39,7 +39,7 @@ def test_sparse_matrix(rng):
 
 def test_sparse_matrix_implicit():
     ratings = ml_test.ratings
-    ratings = ratings.loc[:, ['user', 'item']]
+    ratings = ratings.loc[:, ["user", "item"]]
     mat, uidx, iidx = lm.sparse_ratings(ratings)
 
     assert mat.nrows == len(uidx)
@@ -49,7 +49,14 @@ def test_sparse_matrix_implicit():
     assert mat.values is None
 
 
-@mark.parametrize("format,sps_fmt_checker",[(True,sps.isspmatrix_csr), ("csr",sps.isspmatrix_csr),("coo",sps.isspmatrix_coo)])
+@mark.parametrize(
+    "format,sps_fmt_checker",
+    [
+        (True, sps.isspmatrix_csr),
+        ("csr", sps.isspmatrix_csr),
+        ("coo", sps.isspmatrix_coo),
+    ],
+)
 def test_sparse_matrix_scipy(format, sps_fmt_checker):
     ratings = ml_test.ratings
     mat, uidx, iidx = lm.sparse_ratings(ratings, scipy=format)
@@ -60,7 +67,7 @@ def test_sparse_matrix_scipy(format, sps_fmt_checker):
     assert len(iidx) == ratings.item.nunique()
 
     # user indicators should correspond to user item counts
-    ucounts = ratings.groupby('user').item.count()
+    ucounts = ratings.groupby("user").item.count()
     ucounts = ucounts.loc[uidx].cumsum()
     if sps.isspmatrix_coo(mat):
         mat = mat.tocsr()
@@ -69,7 +76,7 @@ def test_sparse_matrix_scipy(format, sps_fmt_checker):
 
 def test_sparse_matrix_scipy_implicit():
     ratings = ml_test.ratings
-    ratings = ratings.loc[:, ['user', 'item']]
+    ratings = ratings.loc[:, ["user", "item"]]
     mat, uidx, iidx = lm.sparse_ratings(ratings, scipy=True)
 
     assert sps.issparse(mat)
@@ -82,8 +89,8 @@ def test_sparse_matrix_scipy_implicit():
 
 def test_sparse_matrix_indexes(rng):
     ratings = ml_test.ratings
-    uidx = pd.Index(rng.permutation(ratings['user'].unique()))
-    iidx = pd.Index(rng.permutation(ratings['item'].unique()))
+    uidx = pd.Index(rng.permutation(ratings["user"].unique()))
+    iidx = pd.Index(rng.permutation(ratings["item"].unique()))
 
     mat, _uidx, _iidx = lm.sparse_ratings(ratings, users=uidx, items=iidx)
 
@@ -93,12 +100,12 @@ def test_sparse_matrix_indexes(rng):
     assert len(_iidx) == ratings.item.nunique()
 
     # verify rating values
-    ratings = ratings.set_index(['user', 'item'])
+    ratings = ratings.set_index(["user", "item"])
     for u in rng.choice(_uidx, size=50):
         ui = _uidx.get_loc(u)
         vs = mat.row_vs(ui)
         vs = pd.Series(vs, _iidx[mat.row_cs(ui)])
-        rates = ratings.loc[u]['rating']
+        rates = ratings.loc[u]["rating"]
         vs, rates = vs.align(rates)
         assert not any(vs.isna())
         assert not any(rates.isna())

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -20,17 +20,17 @@ def test_sparse_matrix(rng):
     assert mat.ncols == ratings.item.nunique()
 
     # user indicators should correspond to user item counts
-    ucounts = ratings.groupby("user").item.count()
+    ucounts = ratings.groupby('user').item.count()
     ucounts = ucounts.loc[uidx].cumsum()
     assert all(mat.rowptrs[1:] == ucounts.values)
 
     # verify rating values
-    ratings = ratings.set_index(["user", "item"])
+    ratings = ratings.set_index(['user', 'item'])
     for u in rng.choice(uidx, size=50):
         ui = uidx.get_loc(u)
         vs = mat.row_vs(ui)
         vs = pd.Series(vs, iidx[mat.row_cs(ui)])
-        rates = ratings.loc[u]["rating"]
+        rates = ratings.loc[u]['rating']
         vs, rates = vs.align(rates)
         assert not any(vs.isna())
         assert not any(rates.isna())
@@ -39,7 +39,7 @@ def test_sparse_matrix(rng):
 
 def test_sparse_matrix_implicit():
     ratings = ml_test.ratings
-    ratings = ratings.loc[:, ["user", "item"]]
+    ratings = ratings.loc[:, ['user', 'item']]
     mat, uidx, iidx = lm.sparse_ratings(ratings)
 
     assert mat.nrows == len(uidx)
@@ -50,11 +50,11 @@ def test_sparse_matrix_implicit():
 
 
 @mark.parametrize(
-    "format,sps_fmt_checker",
+    'format, sps_fmt_checker',
     [
         (True, sps.isspmatrix_csr),
-        ("csr", sps.isspmatrix_csr),
-        ("coo", sps.isspmatrix_coo),
+        ('csr', sps.isspmatrix_csr),
+        ('coo', sps.isspmatrix_coo),
     ],
 )
 def test_sparse_matrix_scipy(format, sps_fmt_checker):
@@ -67,7 +67,7 @@ def test_sparse_matrix_scipy(format, sps_fmt_checker):
     assert len(iidx) == ratings.item.nunique()
 
     # user indicators should correspond to user item counts
-    ucounts = ratings.groupby("user").item.count()
+    ucounts = ratings.groupby('user').item.count()
     ucounts = ucounts.loc[uidx].cumsum()
     if sps.isspmatrix_coo(mat):
         mat = mat.tocsr()
@@ -76,7 +76,7 @@ def test_sparse_matrix_scipy(format, sps_fmt_checker):
 
 def test_sparse_matrix_scipy_implicit():
     ratings = ml_test.ratings
-    ratings = ratings.loc[:, ["user", "item"]]
+    ratings = ratings.loc[:, ['user', 'item']]
     mat, uidx, iidx = lm.sparse_ratings(ratings, scipy=True)
 
     assert sps.issparse(mat)
@@ -89,8 +89,8 @@ def test_sparse_matrix_scipy_implicit():
 
 def test_sparse_matrix_indexes(rng):
     ratings = ml_test.ratings
-    uidx = pd.Index(rng.permutation(ratings["user"].unique()))
-    iidx = pd.Index(rng.permutation(ratings["item"].unique()))
+    uidx = pd.Index(rng.permutation(ratings['user'].unique()))
+    iidx = pd.Index(rng.permutation(ratings['item'].unique()))
 
     mat, _uidx, _iidx = lm.sparse_ratings(ratings, users=uidx, items=iidx)
 
@@ -100,12 +100,12 @@ def test_sparse_matrix_indexes(rng):
     assert len(_iidx) == ratings.item.nunique()
 
     # verify rating values
-    ratings = ratings.set_index(["user", "item"])
+    ratings = ratings.set_index(['user', 'item'])
     for u in rng.choice(_uidx, size=50):
         ui = _uidx.get_loc(u)
         vs = mat.row_vs(ui)
         vs = pd.Series(vs, _iidx[mat.row_cs(ui)])
-        rates = ratings.loc[u]["rating"]
+        rates = ratings.loc[u]['rating']
         vs, rates = vs.align(rates)
         assert not any(vs.isna())
         assert not any(rates.isna())

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -7,7 +7,7 @@ import lenskit.matrix as lm
 
 from lenskit.util.test import ml_test
 
-from pytest import approx
+from pytest import approx, mark
 
 
 def test_sparse_matrix(rng):
@@ -49,18 +49,21 @@ def test_sparse_matrix_implicit():
     assert mat.values is None
 
 
-def test_sparse_matrix_scipy():
+@mark.parametrize("format,type_validation_fcn",[(True,sps.isspmatrix_csr), ("csr",sps.isspmatrix_csr),("coo",sps.isspmatrix_coo)])
+def test_sparse_matrix_scipy(format, type_validation_fcn):
     ratings = ml_test.ratings
-    mat, uidx, iidx = lm.sparse_ratings(ratings, scipy=True)
+    mat, uidx, iidx = lm.sparse_ratings(ratings, scipy=format)
 
     assert sps.issparse(mat)
-    assert sps.isspmatrix_csr(mat)
+    assert type_validation_fcn(mat)
     assert len(uidx) == ratings.user.nunique()
     assert len(iidx) == ratings.item.nunique()
 
     # user indicators should correspond to user item counts
     ucounts = ratings.groupby('user').item.count()
     ucounts = ucounts.loc[uidx].cumsum()
+    if sps.isspmatrix_coo(mat):
+        mat = mat.tocsr()
     assert all(mat.indptr[1:] == ucounts.values)
 
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -49,13 +49,13 @@ def test_sparse_matrix_implicit():
     assert mat.values is None
 
 
-@mark.parametrize("format,type_validation_fcn",[(True,sps.isspmatrix_csr), ("csr",sps.isspmatrix_csr),("coo",sps.isspmatrix_coo)])
-def test_sparse_matrix_scipy(format, type_validation_fcn):
+@mark.parametrize("format,sps_fmt_checker",[(True,sps.isspmatrix_csr), ("csr",sps.isspmatrix_csr),("coo",sps.isspmatrix_coo)])
+def test_sparse_matrix_scipy(format, sps_fmt_checker):
     ratings = ml_test.ratings
     mat, uidx, iidx = lm.sparse_ratings(ratings, scipy=format)
 
     assert sps.issparse(mat)
-    assert type_validation_fcn(mat)
+    assert sps_fmt_checker(mat)
     assert len(uidx) == ratings.user.nunique()
     assert len(iidx) == ratings.item.nunique()
 


### PR DESCRIPTION
Return a `scipy.sparse.coo_matrix` from `sparse_ratings` via the argument `scipy='coo'` (Fixes #213).