### PR TITLE
knn: don't add item means to similarity sums

### DIFF
--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -232,6 +232,7 @@ class ItemItem(Predictor):
     """
     AGG_SUM = intern('sum')
     AGG_WA = intern('weighted-average')
+    RATING_AGGS = [AGG_WA]  # the aggregates that use rating values
 
     def __init__(self, nnbrs, min_nbrs=1, min_sim=1.0e-6, save_nbrs=None,
                  center=True, aggregate='weighted-average'):
@@ -472,7 +473,7 @@ class ItemItem(Predictor):
             iscores = agg(self.sim_matrix_.R, len(self.item_index_), (self.min_nbrs, self.nnbrs),
                           rate_v, rated, i_pos)
 
-        if self.center:
+        if self.center and self.aggregate in self.RATING_AGGS:
             iscores += self.item_means_
 
         results = pd.Series(iscores, index=self.item_index_)

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -208,6 +208,16 @@ class ItemItem(Predictor):
     is not terribly configurable; it hard-codes design decisions found to work well in the previous
     Java-based LensKit code.
 
+    The k-NN predictor supports several aggregate functions:
+
+    ``weighted-average``
+        The weighted average of the user's rating values, using item-item similarities as
+        weights.
+
+    ``sum``
+        The sum of the similarities between the target item and the user's rated items,
+        regardless of the rating the user gave the items.
+
     Args:
         nnbrs(int):
             the maximum number of neighbors for scoring each item (``None`` for unlimited)
@@ -217,8 +227,9 @@ class ItemItem(Predictor):
             the number of neighbors to save per item in the trained model
             (``None`` for unlimited)
         center(bool):
-            whether to normalize (mean-center) rating vectors.  Turn this off when working
-            with unary data and other data types that don't respond well to centering.
+            whether to normalize (mean-center) rating vectors prior to computing similarities
+            and aggregating user rating values.  Turn this off when working with unary data
+            and other data types that don't respond well to centering.
         aggregate:
             the type of aggregation to do. Can be ``weighted-average`` or ``sum``.
 

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -118,6 +118,7 @@ class UserUser(Predictor):
     """
     AGG_SUM = intern('sum')
     AGG_WA = intern('weighted-average')
+    RATING_AGGS = [AGG_WA]
 
     def __init__(self, nnbrs, min_nbrs=1, min_sim=0, center=True, aggregate='weighted-average'):
         self.nnbrs = nnbrs
@@ -206,7 +207,8 @@ class UserUser(Predictor):
 
         _score(ri_pos, results, self.transpose_matrix_.R, nsims,
                self.nnbrs, self.min_sim, self.min_nbrs, agg)
-        results += umean
+        if self.aggregate in self.RATING_AGGS:
+            results += umean
 
         results = pd.Series(results, index=items, name='prediction')
 


### PR DESCRIPTION
Previously, if centering was turned on in item-item, it would add item means to similarity sum scores. This makes no sense, but in our use we had always turned off centering when we use item-item with sum scores.

This corrects the issue by allowing for two categories of aggregates: rating-based and rating-oblivious. Only rating-based aggregates get the mean rating added back.