### PR TITLE
Use popularity-weighted sampling in BPR by default

### DIFF
--- a/lenskit/algorithms/tf/bpr.py
+++ b/lenskit/algorithms/tf/bpr.py
@@ -92,7 +92,7 @@ if tf is not None:
             assert len(picked) == self.neg_count * (end - start)
             uv = self.users[picked]
             iv = self.items[picked]
-            jv, j_samps = _neg_sample(self.matrix.R, uv, self._sample)
+            jv, j_samps = _neg_sample(self.matrix, uv, self._sample)
             assert all(jv < self.n_items)
             _log.debug('max sample count: %d', j_samps.max())
             return [uv.astype(np.int32),

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -143,12 +143,14 @@ def test_tf_ibmf_batch_accuracy(n_jobs, tf_session):
 
 
 @mark.slow
-def test_tf_bpr_general(tmp_path, tf_session):
+@mark.parametrize('weight', [True, False])
+def test_tf_bpr_general(tmp_path, tf_session, weight):
     "Training, saving, loading, and using a BPR model."
     fn = tmp_path / 'bias.bpk'
     ratings = lktu.ml_test.ratings
 
-    original = lktf.BPR(20, batch_size=1024, epochs=20, neg_count=2, rng_spec=42)
+    original = lktf.BPR(20, batch_size=1024, epochs=20,
+                        neg_count=2, neg_weight=weight, rng_spec=42)
     original.fit(ratings)
     ue = original.model.get_layer('user-embed')
     assert ue.get_weights()[0].shape == (ratings.user.nunique(), 20)


### PR DESCRIPTION
This closes #191, adding popularity-weighted sampling to our TensorFlow BPR and turning it on by default.