### PR TITLE
Require Python 3.7 and NumPy 1.17 per NEP 29

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - 3.6
         - 3.7
         - 3.8
         # - 3.9
@@ -24,9 +23,6 @@ jobs:
         blas:
         - mkl
         - openblas
-        exclude:  # Deadlocks on this combination
-        - platform: macos
-          python: 3.6
     steps:
       - uses: actions/checkout@v2
         with:
@@ -237,7 +233,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - 3.6
         - 3.7
         - 3.8
         platform:
@@ -300,7 +295,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: x64
 
       - name: Set up Python deps

--- a/min-constraints.txt
+++ b/min-constraints.txt
@@ -1,5 +1,5 @@
 pandas==0.24
-numpy==1.16.2
+numpy==1.17.0
 scipy==1.2.1
 numba==0.51.0
 pyarrow==0.15.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,12 @@ home-page = "https://lenskit.lenskit.org"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
 ]
-requires-python = ">= 3.6.1"
+requires-python = ">= 3.7"
 description-file = "README.md"
 requires = [
     "pandas >= 0.24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">= 3.7"
 description-file = "README.md"
 requires = [
     "pandas >= 0.24",
-    "numpy >= 1.16",
+    "numpy >= 1.17",
     "scipy >= 1.2",
     "numba >= 0.51, < 0.53",
     "pyarrow >= 0.15",

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 minversion = 3.4.0
 envlist =
   minimal
-  py36-pd{24,25,100}-nb{43,44,45,46,47,48}-np{16,17,18}-sp{12,13,14}
-  py37-pd{24,25,100}-nb{45,46,47,48}-np{16,17,18}-sp{12,13,14}
-  py38-pd{25,100}-nb48-np18-sp14
+  py37-pd{24,25,100}-nb{51,52}-np{17,18}-sp{12,13,14}
+  py38-pd{25,100}-nb48-np20-sp14
 
 [testenv]
 deps =
@@ -16,23 +15,13 @@ deps =
   pd25: pandas>=0.25,<0.26
   pd100: pandas>=1.0,<1.1
 
-  nb42: numba>=0.42,<0.43
-  nb42: llvmlite<0.30
-  nb43: numba>=0.43,<0.44
-  nb43: llvmlite<0.31
-  nb44: numba>=0.44,<0.45
-  nb44: llvmlite<0.31
-  nb45: numba>=0.45,<0.46
-  nb45: llvmlite<0.31
-  nb46: numba>=0.46,<0.47
-  nb46: llvmlite<0.31
-  nb47: numba>=0.47,<0.48
-  nb48: numba>=0.48,<0.49
+  nb51: numba>=0.51,<0.52
+  nb52: numba>=0.52,<0.53
 
-  np15: numpy>=1.15,<1.16
-  np16: numpy>=1.16,<1.17
   np17: numpy>=1.17,<1.18
   np18: numpy>=1.18,<1.19
+  np19: numpy>=1.19,<1.20
+  np20: numpy>=1.20,<1.21
 
   sp11: scipy>=1.1,<1.2
   sp12: scipy>=1.2,<1.3


### PR DESCRIPTION
This PR bumps our version requirements to Python 3.7 and NumPy 1.17, the versions specified for new releases by [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). Adopting this was not opposed on the Google group discussion.

This PR does the following:

- Bump minimum versions in `pyproject.toml`
- Remove Python 3.6 from the test matrix
- Bump minimum version of NumPy in the constraints file
- Clean up tox.ini