### PR TITLE
Drop RNG compatibility code for NumPy 1.16

### DIFF
--- a/doc/random.rst
+++ b/doc/random.rst
@@ -13,18 +13,14 @@ random seed and the conclusions compared.
 
 LensKit is built to support this experimental design, making consistent use of
 configurable random number generators throughout its algorithm implementations.
-When run against NumPy 1.17 or later, it uses the new :py:class:`numpy.random.Generator`
-and :py:class:`numpy.random.SeedSequence` facilities to provide consistent random
-number generation and initialization.  LensKit is compatible with older versions
-of NumPy, but the RNG reproducibility logic will not fully function, and some
-functions will not work.
+It uses the new :py:class:`numpy.random.Generator` and
+:py:class:`numpy.random.SeedSequence` facilities to provide consistent random
+number generation and initialization.
 
 .. note::
    For fully reproducible research, including random seeds and the use thereof,
    make sure that you are running on the same platform with the same verions of all
-   packages (particularly LensKit, NumPy, SciPy, Pandas, and related packages),
-   and are using at least NumPy 1.17.  LensKit manages state for older versions of
-   NumPy on a best-effort basis.
+   packages (particularly LensKit, NumPy, SciPy, Pandas, and related packages).
 
 Developers *using* LensKit will be primarily intrested in the :py:func:`init_rng`
 function, so they can initialize LensKit's random seed.  LensKit components using

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from lenskit.util.parallel import invoker, proc_count, run_sp, is_worker, is_mp_worker
 from lenskit.util.test import set_env_var
-from lenskit.util.random import get_root_seed, _have_gen
+from lenskit.util.random import get_root_seed
 from lenskit.sharing import persist_binpickle
 
 from pytest import mark, raises, approx
@@ -121,7 +121,6 @@ def _get_seed():
     return get_root_seed()
 
 
-@mark.skipif(not _have_gen, reason='only works on NumPy 1.17 and newer')
 def test_sp_random_seed():
     init = get_root_seed()
     seed = run_sp(_get_seed)

--- a/tests/test_util_algos.py
+++ b/tests/test_util_algos.py
@@ -1,11 +1,9 @@
 from lenskit.algorithms import basic
-from lenskit import util as lku
 
 import pandas as pd
 import numpy as np
 
 import lenskit.util.test as lktu
-from pytest import mark
 
 simple_df = pd.DataFrame({'item': [1, 1, 2, 3],
                           'user': [10, 12, 10, 13],
@@ -83,7 +81,6 @@ def test_random():
     assert set(items) == set(recs_all['item'])
 
 
-@mark.skipif(not lku.random._have_gen, reason='derived seeds require NumPy 1.17')
 def test_random_derive_seed():
     algo = basic.Random(rng_spec='user')
     model = algo.fit(lktu.ml_test.ratings)
@@ -118,6 +115,7 @@ def test_random_rec_from_candidates():
     assert len(recs1) == 100
     assert len(recs2) == 100
 
+
 def test_knownrating():
     algo = basic.KnownRating()
     algo.fit(simple_df)
@@ -130,6 +128,7 @@ def test_knownrating():
     assert set(preds.index) == set([1, 3])
     assert preds.loc[1] == 3.0
     assert np.isnan(preds.loc[3])
+
 
 def test_knownrating_batch_missing():
     algo = basic.KnownRating()

--- a/tests/test_util_random.py
+++ b/tests/test_util_random.py
@@ -2,25 +2,17 @@ import zlib
 import numpy as np
 from lenskit.util import random
 
-from pytest import mark
 
-new_gen = mark.skipif(not random._have_gen, reason="requires NumPy with generators")
-old_gen = mark.skipif(random._have_gen, reason="only for legacy NumPy")
-
-
-@new_gen
 def test_generator():
     rng = random.rng()
     assert isinstance(rng, np.random.Generator)
 
 
-@new_gen
 def test_generator_seed():
     rng = random.rng(42)
     assert isinstance(rng, np.random.Generator)
 
 
-@new_gen
 def test_generator_seed_seq():
     seq = np.random.SeedSequence(42)
     rng = random.rng(seq)
@@ -43,21 +35,18 @@ def test_generator_legacy_passthrough():
     assert isinstance(rng, np.random.RandomState)
 
 
-@new_gen
 def test_generator_legacy_ss():
     seq = np.random.SeedSequence(42)
     rng = random.rng(seq, legacy=True)
     assert isinstance(rng, np.random.RandomState)
 
 
-@new_gen
 def test_generator_convert_to_legacy():
     rng1 = random.rng()
     rng = random.rng(rng1, legacy=True)
     assert isinstance(rng, np.random.RandomState)
 
 
-@new_gen
 def test_generator_passthrough():
     rng1 = random.rng()
     rng = random.rng(rng1)
@@ -65,43 +54,18 @@ def test_generator_passthrough():
     assert rng is rng1
 
 
-@old_gen
-def test_random_state():
-    rng = random.rng()
-    assert isinstance(rng, np.random.RandomState)
-    rng2 = random.rng()
-    assert rng2 is rng  # we use the same random state multiple times
-
-
-@old_gen
-def test_random_state_int_seed():
-    rng = random.rng(42)
-    assert isinstance(rng, np.random.RandomState)
-    rng2 = random.rng()
-    assert rng is not rng2
-
-
-@new_gen
 def test_initialize():
     random.init_rng(42)
     assert random._rng_impl.seed.entropy == 42
     assert len(random._rng_impl.seed.spawn_key) == 0
 
 
-@old_gen
-def test_initialize_legacy():
-    random.init_rng(42)
-    assert random._rng_impl.seed == 42
-
-
-@new_gen
 def test_initialize_key():
     random.init_rng(42, 'wombat')
     assert random._rng_impl.seed.entropy == 42
     assert random._rng_impl.seed.spawn_key == (zlib.crc32(b'wombat'),)
 
 
-@new_gen
 def test_derive_seed():
     random.init_rng(42, propagate=False)
     s2 = random.derive_seed()
@@ -109,7 +73,6 @@ def test_derive_seed():
     assert s2.spawn_key == (0,)
 
 
-@new_gen
 def test_derive_seed_intkey():
     random.init_rng(42, propagate=False)
     s2 = random.derive_seed(10, 7)
@@ -117,7 +80,6 @@ def test_derive_seed_intkey():
     assert s2.spawn_key == (10, 7)
 
 
-@new_gen
 def test_derive_seed_str():
     random.init_rng(42, propagate=False)
     s2 = random.derive_seed(b'wombat')


### PR DESCRIPTION
This removes the legacy NumPy compatibility code from the RNG infrastructure.