### PR TITLE
Optimize top-N analysis

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,3 +1,4 @@
 *.yml
 *.zip
 ml-*/
+*.parquet

--- a/lenskit/crossfold.py
+++ b/lenskit/crossfold.py
@@ -329,3 +329,14 @@ def sample_users(data, partitions: int, size: int, method: PartitionMethod, disj
         rest = data.index.difference(test.index)
         train = data.loc[rest]
         yield TTPair(train, test)
+
+
+def simple_test_pair(ratings, n_users=1000, n_rates=5):
+    """
+    Return a single, basic train-test pair for some ratings.  This is only intended
+    for convenience use in test and demos - do not use for research.
+    """
+
+    train, test = next(sample_users(ratings, 1, n_users, SampleN(n_rates)))
+
+    return train, test

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -99,7 +99,6 @@ def _dcg(scores, discount=np.log2):
     return np.dot(scores, disc)
 
 
-# @profile
 def ndcg(recs, truth, discount=np.log2):
     """
     Compute the normalized discounted cumulative gain.

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -4,7 +4,6 @@ Top-N evaluation metrics.
 
 import logging
 import numpy as np
-import pandas as pd
 
 _log = logging.getLogger(__name__)
 

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -123,7 +123,7 @@ class RecListAnalysis:
             res['ntruth'] = res['ntruth'].fillna(0)
             res['nrecs'] = res['nrecs'].fillna(0)
 
-        return res
+        return res.set_index(rec_key)
 
     def _number_truth(self, truth, truth_key):
         _log.info('numbering truth lists')

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -48,7 +48,6 @@ class RecListAnalysis:
     """
 
     DEFAULT_SKIP_COLS = ['item', 'rank', 'score', 'rating']
-    _use_bulk = True
 
     def __init__(self, group_cols=None, n_jobs=None):
         self.group_cols = group_cols
@@ -105,7 +104,7 @@ class RecListAnalysis:
         bulk_res = []
         ind_metrics = []
         for mf, mn, margs in self.metrics:
-            if self._use_bulk and hasattr(mf, 'bulk_score') and 'rank' in r_data.columns:
+            if hasattr(mf, 'bulk_score') and 'rank' in r_data.columns:
                 _log.debug('bulk-scoring %s', mn)
                 mbs = mf.bulk_score(r_data, t_data, **margs).to_frame(name=mn)
                 assert mbs.index.name == 'LKRecID'

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -48,6 +48,7 @@ class RecListAnalysis:
     """
 
     DEFAULT_SKIP_COLS = ['item', 'rank', 'score', 'rating']
+    _use_bulk = True
 
     def __init__(self, group_cols=None, n_jobs=None):
         self.group_cols = group_cols
@@ -104,7 +105,7 @@ class RecListAnalysis:
         bulk_res = []
         ind_metrics = []
         for mf, mn, margs in self.metrics:
-            if hasattr(mf, 'bulk_score'):
+            if self._use_bulk and hasattr(mf, 'bulk_score'):
                 _log.debug('bulk-scoring %s', mn)
                 mbs = mf.bulk_score(r_data, t_data, **margs).to_frame(name=mn)
                 assert mbs.index.name == 'LKRecID'

--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -105,7 +105,7 @@ class RecListAnalysis:
         bulk_res = []
         ind_metrics = []
         for mf, mn, margs in self.metrics:
-            if self._use_bulk and hasattr(mf, 'bulk_score'):
+            if self._use_bulk and hasattr(mf, 'bulk_score') and 'rank' in r_data.columns:
                 _log.debug('bulk-scoring %s', mn)
                 mbs = mf.bulk_score(r_data, t_data, **margs).to_frame(name=mn)
                 assert mbs.index.name == 'LKRecID'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "coverage",
     "pytest-cov",
     "ipython",
+    "docopt",
 ]
 doc = [
     "sphinx >= 1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest-cov",
     "ipython",
     "docopt",
+    "tqdm",
 ]
 doc = [
     "sphinx >= 1.8",

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -31,64 +31,6 @@ def test_split_keys_gcol():
     assert recs == ['algorithm', 'fishtank', 'user']
 
 
-def test_iter_one():
-    df = pd.DataFrame({'user': 1, 'item': [17]})
-    gs = list(topn._grouping_iter(df, ['user']))
-    assert len(gs) == 1
-    uk, idf = gs[0]
-    assert uk == (1,)
-    assert all(idf['item'] == df['item'])
-
-
-def test_iter_one_group():
-    df = pd.DataFrame({'user': 1, 'item': [17, 13, 24]})
-    gs = list(topn._grouping_iter(df, ['user']))
-    assert len(gs) == 1
-    uk, idf = gs[0]
-    assert uk == (1,)
-    assert len(idf) == 3
-    assert all(idf['item'] == df['item'])
-
-
-def test_iter_mixed():
-    df = pd.DataFrame({'user': [1, 1, 2, 2, 1], 'item': ['a', 'b', 'c', 'd', 'e']})
-    gs = list(topn._grouping_iter(df, ['user']))
-    assert len(gs) == 2
-    uk, idf = gs[0]
-    assert uk == (1,)
-    assert len(idf) == 3
-    assert all(idf['item'] == ['a', 'b', 'e'])
-
-    uk, idf = gs[1]
-    assert uk == (2,)
-    assert len(idf) == 2
-    assert all(idf['item'] == ['c', 'd'])
-
-
-def test_iter_multilevel():
-    df = pd.DataFrame({
-        'user': [1, 1, 2, 2, 1],
-        'bob': [10, 13, 10, 10, 10],
-        'item': ['a', 'b', 'c', 'd', 'e']
-    })
-    gs = list(topn._grouping_iter(df, ['user', 'bob']))
-    assert len(gs) == 3
-    uk, idf = gs[0]
-    assert uk == (1, 10)
-    assert len(idf) == 2
-    assert all(idf['item'] == ['a', 'e'])
-
-    uk, idf = gs[1]
-    assert uk == (1, 13)
-    assert len(idf) == 1
-    assert all(idf['item'] == ['b'])
-
-    uk, idf = gs[2]
-    assert uk == (2, 10)
-    assert len(idf) == 2
-    assert all(idf['item'] == ['c', 'd'])
-
-
 def test_run_one():
     rla = topn.RecListAnalysis()
     rla.add_metric(topn.precision)

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -111,7 +111,7 @@ def test_inner_format():
 
     def inner(recs, truth, foo='a'):
         assert foo == 'b'
-        assert set(recs.columns) == set(['item', 'rank'])
+        assert set(recs.columns) == set(['LKRecID', 'LKTruthID', 'item', 'rank'])
         assert truth.index.name == 'item'
         assert truth.index.is_unique
         print(truth)

--- a/tests/test_topn_mrr.py
+++ b/tests/test_topn_mrr.py
@@ -67,13 +67,10 @@ def test_mrr_bulk():
 
     recs = recommend(algo, users, 100)
 
-    bulk_rla = RecListAnalysis()
-    bulk_rla.add_metric(recip_rank)
-    bulk = bulk_rla.compute(recs, test)
+    rla = RecListAnalysis()
+    rla.add_metric(recip_rank)
+    # metric without the bulk capabilities
+    rla.add_metric(lambda *a: recip_rank(*a), name='ind_rr')
+    res = rla.compute(recs, test)
 
-    ind_rla = RecListAnalysis()
-    ind_rla._use_bulk = False
-    ind_rla.add_metric(recip_rank)
-    ind = ind_rla.compute(recs, test)
-
-    assert all(bulk.recip_rank == ind.recip_rank)
+    assert all(res.recip_rank == res.ind_rr)

--- a/tests/test_topn_mrr.py
+++ b/tests/test_topn_mrr.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from pytest import approx
+from pytest import approx, mark
 
 from lenskit.topn import RecListAnalysis, recip_rank
 from lenskit.util.test import ml_test
@@ -57,9 +57,12 @@ def test_mrr_array_late():
     assert rr == approx(0.1)
 
 
-def test_mrr_bulk():
+@mark.parametrize('drop_rating', [False, True])
+def test_mrr_bulk(drop_rating):
     "bulk and normal match"
     train, test = simple_test_pair(ml_test.ratings)
+    if drop_rating:
+        test = test[['user', 'item']]
 
     users = test['user'].unique()
     algo = Popular()

--- a/tests/test_topn_ndcg.py
+++ b/tests/test_topn_ndcg.py
@@ -3,9 +3,12 @@ import pandas as pd
 
 from pytest import approx
 
-from lenskit.metrics.topn import _dcg, ndcg
-import lenskit.util.test as lktu
-
+from lenskit.metrics.topn import _dcg, dcg, ndcg, _bulk_ndcg
+from lenskit.topn import RecListAnalysis
+from lenskit.util.test import ml_test
+from lenskit.algorithms.basic import Popular
+from lenskit.batch import recommend
+from lenskit.crossfold import simple_test_pair
 
 def test_dcg_empty():
     "empty should be zero"
@@ -91,3 +94,62 @@ def test_ndcg_wrong():
     truth = pd.DataFrame({'item': [1, 2, 3], 'rating': [3.0, 5.0, 4.0]})
     truth = truth.set_index('item')
     assert ndcg(recs, truth) == approx(_dcg([3.0, 5.0] / _dcg([5.0, 4.0, 3.0])))
+
+
+def test_ndcg_bulk_at_top():
+    truth = pd.DataFrame.from_records([
+        (1, 50, 3.5),
+        (1, 30, 3.5)
+    ], columns=['LKTruthID', 'item', 'rating']).set_index(['LKTruthID', 'item'])
+
+    recs = pd.DataFrame.from_records([
+        (1, 1, 50, 1),
+        (1, 1, 30, 2),
+        (1, 1, 72, 3)
+    ], columns=['LKRecID', 'LKTruthID', 'item', 'rank'])
+
+    ndcg = _bulk_ndcg(recs, truth)
+    assert len(ndcg) == 1
+    assert ndcg.index.tolist() == [1]
+    assert ndcg.iloc[0] == approx(1.0)
+
+
+def test_ndcg_bulk_not_at_top():
+    truth = pd.DataFrame.from_records([
+        (1, 50, 3.5),
+        (1, 30, 3.5)
+    ], columns=['LKTruthID', 'item', 'rating']).set_index(['LKTruthID', 'item'])
+
+    recs = pd.DataFrame.from_records([
+        (1, 1, 50, 1),
+        (1, 1, 72, 2),
+        (1, 1, 30, 3)
+    ], columns=['LKRecID', 'LKTruthID', 'item', 'rank'])
+
+    ndcg = _bulk_ndcg(recs, truth)
+    assert len(ndcg) == 1
+    assert ndcg.index.tolist() == [1]
+    assert ndcg.iloc[0] == approx(0.8155, abs=0.001)
+
+
+def test_ndcg_bulk():
+    "bulk and normal match"
+    train, test = simple_test_pair(ml_test.ratings)
+
+    users = test['user'].unique()
+    algo = Popular()
+    algo.fit(train)
+
+    recs = recommend(algo, users, 100)
+
+    rla = RecListAnalysis()
+    rla.add_metric(ndcg)
+    rla.add_metric(dcg)
+    # metric without the bulk capabilities
+    rla.add_metric(lambda *a: ndcg(*a), name='ind_ndcg')
+    res = rla.compute(recs, test)
+
+    res['ind_ideal'] = res['dcg'] / res['ind_ndcg']
+    print(res)
+
+    assert res.ndcg.values == approx(res.ind_ndcg.values)

--- a/tests/test_topn_ndcg.py
+++ b/tests/test_topn_ndcg.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from pytest import approx
+from pytest import approx, mark
 
 from lenskit.metrics.topn import _dcg, dcg, ndcg, _bulk_ndcg
 from lenskit.topn import RecListAnalysis
@@ -9,6 +9,7 @@ from lenskit.util.test import ml_test
 from lenskit.algorithms.basic import Popular
 from lenskit.batch import recommend
 from lenskit.crossfold import simple_test_pair
+
 
 def test_dcg_empty():
     "empty should be zero"
@@ -132,9 +133,12 @@ def test_ndcg_bulk_not_at_top():
     assert ndcg.iloc[0] == approx(0.8155, abs=0.001)
 
 
-def test_ndcg_bulk():
+@mark.parametrize('drop_rating', [False, True])
+def test_ndcg_bulk_match(drop_rating):
     "bulk and normal match"
     train, test = simple_test_pair(ml_test.ratings)
+    if drop_rating:
+        test = test[['user', 'item']]
 
     users = test['user'].unique()
     algo = Popular()

--- a/utils/rla-perf.py
+++ b/utils/rla-perf.py
@@ -89,7 +89,8 @@ def do_measure(opts):
 if __name__ == '__main__':
     opts = docopt(__doc__)
     level = logging.DEBUG if opts['--verbose'] else logging.INFO
-    logging.basicConfig(stream=sys.stderr, level=level)
+    format = '%(relativeCreated)6d: %(levelname)s %(name)s %(message)s'
+    logging.basicConfig(stream=sys.stderr, level=level, format=format)
 
     if opts['--prepare']:
         do_prepare(opts)

--- a/utils/rla-perf.py
+++ b/utils/rla-perf.py
@@ -17,10 +17,6 @@ Options:
 
 import sys
 import logging
-from os import fspath
-from pathlib import Path
-homedir = Path(__file__).parent.parent
-sys.path.insert(0, fspath(homedir))
 
 import tqdm
 from docopt import docopt

--- a/utils/rla-perf.py
+++ b/utils/rla-perf.py
@@ -22,6 +22,7 @@ from pathlib import Path
 homedir = Path(__file__).parent.parent
 sys.path.insert(0, fspath(homedir))
 
+import tqdm
 from docopt import docopt
 import pandas as pd
 
@@ -91,6 +92,7 @@ if __name__ == '__main__':
     level = logging.DEBUG if opts['--verbose'] else logging.INFO
     format = '%(relativeCreated)6d: %(levelname)s %(name)s %(message)s'
     logging.basicConfig(stream=sys.stderr, level=level, format=format)
+    tqdm.tqdm.pandas()
 
     if opts['--prepare']:
         do_prepare(opts)

--- a/utils/rla-perf.py
+++ b/utils/rla-perf.py
@@ -1,0 +1,100 @@
+"""
+Little script to test RLA performance.
+
+Usage:
+    rla-perf.py (--prepare|--measure) [options]
+
+Options:
+    --prepare
+        Prepare for running.
+    --measure
+        Measure the results.
+    -d DATASET
+        Use dataset DATASET [default: ml-20m]
+    --verbose
+        Enable debug logging.
+"""
+
+import sys
+import logging
+from os import fspath
+from pathlib import Path
+homedir = Path(__file__).parent.parent
+sys.path.insert(0, fspath(homedir))
+
+from docopt import docopt
+import pandas as pd
+
+from lenskit.datasets import MovieLens
+from lenskit.util import Stopwatch
+from lenskit.batch import recommend
+from lenskit.crossfold import sample_users, SampleN
+from lenskit.algorithms.basic import Popular
+from lenskit.algorithms import Recommender
+from lenskit.algorithms.als import ImplicitMF
+from lenskit.topn import RecListAnalysis, ndcg, recip_rank
+
+_log = logging.getLogger('rla-perf')
+
+
+def do_prepare(opts):
+    name = opts['-d']
+    ml = MovieLens(f'data/{name}')
+
+    train, test = next(sample_users(ml.ratings, 1, 10000, SampleN(5)))
+
+    test.to_parquet(f'data/{name}-test.parquet', index=False)
+
+    _log.info('getting popular recs')
+    pop = Popular()
+    pop.fit(train)
+    pop_recs = recommend(pop, test['user'].unique(), 100)
+
+    _log.info('getting ALS recs')
+    als = ImplicitMF(20, iterations=10)
+    als = Recommender.adapt(als)
+    als.fit(train.drop(columns=['rating']))
+    als_recs = recommend(als, test['user'].unique(), 100)
+
+    _log.info('merging recs')
+    recs = pd.concat({
+        'Popular': pop_recs,
+        'ALS': als_recs
+    }, names=['Algorithm'])
+    recs.reset_index('Algorithm', inplace=True)
+    recs.to_parquet(f'data/{name}-recs.parquet', index=False)
+
+
+def do_measure(opts):
+    name = opts['-d']
+
+    _log.info('reading data %s', name)
+    test = pd.read_parquet(f'data/{name}-test.parquet')
+    recs = pd.read_parquet(f'data/{name}-recs.parquet')
+
+    _log.info('setting up analysis')
+    rla = RecListAnalysis()
+    rla.add_metric(ndcg)
+    rla.add_metric(recip_rank)
+
+    timer = Stopwatch()
+    results = rla.compute(recs, test, include_missing=True)
+    _log.info('analyzed in %s', timer)
+
+    results = results.fillna(0)
+    a_res = results.groupby('Algorithm').mean()
+    _log.info('finished, results:\n%s', a_res)
+
+
+if __name__ == '__main__':
+    opts = docopt(__doc__)
+    level = logging.DEBUG if opts['--verbose'] else logging.INFO
+    logging.basicConfig(stream=sys.stderr, level=level)
+
+    if opts['--prepare']:
+        do_prepare(opts)
+    elif opts['--measure']:
+        do_measure(opts)
+    else:
+        _log.error('no operation specified')
+        sys.exit(2)

--- a/utils/rla-perf.py
+++ b/utils/rla-perf.py
@@ -80,7 +80,10 @@ def do_measure(opts):
 
     results = results.fillna(0)
     a_res = results.groupby('Algorithm').mean()
-    _log.info('finished, results:\n%s', a_res)
+    a_res['count'] = results.groupby('Algorithm')['nrecs'].count()
+    _log.info('finished')
+    print(a_res)
+    print(results.groupby('Algorithm')['recip_rank'].describe())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This improves top-N recommendation analysis

- faster algorithms
- drop parallelization (because straight Pandas is faster)
- simplify code
- bulk computation for the nDCG and Reciprocal Rank metrics