### PR TITLE
Add use_ratings option to ImplicitMF

### DIFF
--- a/lenskit/util/__init__.py
+++ b/lenskit/util/__init__.py
@@ -3,6 +3,7 @@ Miscellaneous utility functions.
 """
 
 import logging
+from textwrap import dedent
 from copy import deepcopy
 
 from ..algorithms import Algorithm
@@ -25,7 +26,7 @@ __all__ = [
     'read_df_detect',
     'rng', 'init_rng', 'derivable_rng',
     'proc_count',
-    'clone'
+    'clone', 'clean_str'
 ]
 
 
@@ -106,3 +107,7 @@ def cur_memory():
         return "%.1f MiB" % (res.ru_idrss,)
     else:
         return 'unknown'
+
+
+def clean_str(s):
+    return dedent(s).strip()

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ filterwarnings =
     ignore:.*np.asscalar.*:DeprecationWarning
     ignore:.*deprecated create function*:DeprecationWarning
     ignore:.*importing the ABCs*:DeprecationWarning
+    ignore:.*use_ratings option.*:UserWarning
 markers =
     eval: mark the test as running the evaluator over custom data
     slow: mark the test as taking a larger-than-usual amount of time

--- a/tests/test_als_implicit.py
+++ b/tests/test_als_implicit.py
@@ -141,7 +141,7 @@ def test_als_recs_topn_for_new_users_with_new_ratings(rng):
 
     users = rng.choice(np.unique(ratings.user), n_users)
 
-    algo = als.ImplicitMF(20, iterations=10, method="lu", use_ratings=False)
+    algo = als.ImplicitMF(20, iterations=10, method="lu", use_ratings=True)
     rec_algo = basic.TopN(algo)
     rec_algo.fit(ratings)
     # _log.debug("Items: " + str(items))


### PR DESCRIPTION
This adds a `use_ratings` option to `ImplicitMF`, currently defaulting to `True` (previous behavior), but scheduled to start defaulting to `False`.