### PR TITLE
Add 'k' support to top-N metrics

### DIFF
--- a/doc/evaluation/topn-metrics.rst
+++ b/doc/evaluation/topn-metrics.rst
@@ -66,6 +66,20 @@ Metrics
 The :py:mod:`lenskit.metrics.topn` module contains metrics for evaluating top-*N*
 recommendation lists.
 
+Each of the top-*N* metrics supports an optional keyword argument ``k`` that specifies the expected list
+length.  Recommendation lists are truncated to this length prior to measurment (so you can measure a
+a metric at multiple values of ``k`` in a single analysis), and for recall-oriented metrics like
+:py:func:`recall` and :py:func:`ndcg`, it normalizes the best-case possible items to ``k`` (because if
+there are 10 relevant items, Recall@5 should be 1 when the list returns any 5 relevant items).
+To use this, pass extra arguments to :py:meth:`RecListAnalysis.add_metric`::
+
+    rla.add_metric(ndcg, k=5)
+    rla.add_metric(ndcg, name='ndcg_10', k=10)
+
+The default is to allow unbounded lists.  When using large recommendation lists, and users never have
+more test ratings than there are recommended items, the default makes sense.
+
+
 Classification Metrics
 ----------------------
 

--- a/lenskit/crossfold.py
+++ b/lenskit/crossfold.py
@@ -331,12 +331,17 @@ def sample_users(data, partitions: int, size: int, method: PartitionMethod, disj
         yield TTPair(train, test)
 
 
-def simple_test_pair(ratings, n_users=1000, n_rates=5):
+def simple_test_pair(ratings, n_users=1000, n_rates=5, f_rates=None):
     """
     Return a single, basic train-test pair for some ratings.  This is only intended
     for convenience use in test and demos - do not use for research.
     """
 
-    train, test = next(sample_users(ratings, 1, n_users, SampleN(n_rates)))
+    if f_rates:
+        samp = SampleFrac(f_rates)
+    else:
+        samp = SampleN(n_rates)
+
+    train, test = next(sample_users(ratings, 1, n_users, samp))
 
     return train, test

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -58,8 +58,13 @@ def recall(recs, truth, k=None):
 
 
 @bulk_impl(recall)
-def _bulk_recall(recs, truth):
+def _bulk_recall(recs, truth, k=None):
     tcounts = truth.reset_index().groupby('LKTruthID')['item'].count()
+
+    if k is not None:
+        _log.debug('truncating to k for recall')
+        tcounts = np.minimum(tcounts, k)
+        recs = recs[recs['rank'] <= k]
 
     good = recs.join(truth, on=['LKTruthID', 'item'], how='inner')
     gcounts = good.groupby('LKRecID')['item'].count()

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -41,13 +41,17 @@ def _bulk_precision(recs, truth):
     return gcounts / lcounts
 
 
-def recall(recs, truth):
+def recall(recs, truth, k=None):
     """
     Compute recommendation recall.
     """
     nrel = len(truth)
     if nrel == 0:
         return None
+
+    if k is not None:
+        nrel = min(nrel, k)
+        recs = recs.iloc[:k]
 
     ngood = recs['item'].isin(truth.index).sum()
     return ngood / nrel

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -19,15 +19,20 @@ def bulk_impl(metric):
 
 def precision(recs, truth, k=None):
     """
-    Compute recommendation precision.
+    Compute recommendation precision.  This is computed as:
+
+    .. math::
+        \\frac{|L \\cap I_u^{\\mathrm{test}}|}{|L|}
+
+    In the uncommon case that ``k`` is specified and ``len(recs) < k``, this metric uses
+    ``len(recs)`` as the denominator.
     """
     if k is not None:
-        nrecs = k
         recs = recs.iloc[:k]
-    else:
-        nrecs = len(recs)
-        if nrecs == 0:
-            return None
+
+    nrecs = len(recs)
+    if nrecs == 0:
+        return None
 
     ngood = recs['item'].isin(truth.index).sum()
     return ngood / nrecs

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -93,7 +93,7 @@ def _bulk_recall(recs, truth, k=None):
     return scores['ngood'] / scores['nrel']
 
 
-def recip_rank(recs, truth):
+def recip_rank(recs, truth, k=None):
     """
     Compute the reciprocal rank of the first relevant item in a list of recommendations.
 
@@ -101,6 +101,9 @@ def recip_rank(recs, truth):
 
     This metric has a bulk equivalent.
     """
+    if k is not None:
+        recs = recs.iloc[:k]
+
     good = recs['item'].isin(truth.index)
     npz, = np.nonzero(good.to_numpy())
     if len(npz):
@@ -110,8 +113,10 @@ def recip_rank(recs, truth):
 
 
 @bulk_impl(recip_rank)
-def _bulk_rr(recs, truth):
+def _bulk_rr(recs, truth, k=None):
     # find everything with truth
+    if k is not None:
+        recs = recs[recs['rank'] <= k]
     joined = recs.join(truth, on=['LKTruthID', 'item'], how='inner')
     # compute min ranks
     ranks = joined.groupby('LKRecID')['rank'].agg('min')

--- a/lenskit/util/test.py
+++ b/lenskit/util/test.py
@@ -9,9 +9,29 @@ from contextlib import contextmanager
 import pytest
 
 from lenskit.datasets import MovieLens, ML100K
+from lenskit.crossfold import simple_test_pair
+from lenskit.algorithms.basic import PopScore
+from lenskit.algorithms.ranking import PlackettLuce
+from lenskit.batch import recommend
 
 ml_test = MovieLens('data/ml-latest-small')
 ml100k = ML100K('data/ml-100k')
+
+
+@pytest.fixture(scope='session')
+def demo_recs():
+    """
+    A demo set of train, test, and recommendation data.
+    """
+    train, test = simple_test_pair(ml_test.ratings, f_rates=0.5)
+
+    users = test['user'].unique()
+    algo = PopScore()
+    algo = PlackettLuce(algo, rng_spec='user')
+    algo.fit(train)
+
+    recs = recommend(algo, users, 500)
+    return train, test, recs
 
 
 @contextmanager

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -10,7 +10,7 @@ from lenskit.algorithms.item_knn import ItemItem
 from lenskit.algorithms.basic import PopScore
 from lenskit.algorithms.ranking import PlackettLuce
 from lenskit.algorithms import Recommender
-from lenskit.util.test import ml_test
+from lenskit.util.test import ml_test, demo_recs
 from lenskit.metrics.topn import _dcg, precision, recall
 from lenskit import topn, batch, crossfold as xf
 
@@ -264,18 +264,11 @@ def test_adv_fill_users():
 
 
 @mark.parametrize('drop_rating', [False, True])
-def test_pr_bulk_match(drop_rating):
+def test_pr_bulk_match(demo_recs, drop_rating):
     "bulk and normal match"
-    train, test = xf.simple_test_pair(ml_test.ratings)
+    train, test, recs = demo_recs
     if drop_rating:
         test = test[['user', 'item']]
-
-    users = test['user'].unique()
-    algo = PopScore()
-    algo = PlackettLuce(algo, rng_spec='user')
-    algo.fit(train)
-
-    recs = batch.recommend(algo, users, 1000)
 
     rla = topn.RecListAnalysis()
     rla.add_metric(precision)

--- a/tests/test_topn_mrr.py
+++ b/tests/test_topn_mrr.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pytest import approx, mark
 
 from lenskit.topn import RecListAnalysis, recip_rank
-from lenskit.util.test import ml_test
+from lenskit.util.test import ml_test, demo_recs
 from lenskit.algorithms.basic import Popular
 from lenskit.batch import recommend
 from lenskit.crossfold import simple_test_pair
@@ -58,17 +58,11 @@ def test_mrr_array_late():
 
 
 @mark.parametrize('drop_rating', [False, True])
-def test_mrr_bulk(drop_rating):
+def test_mrr_bulk(demo_recs, drop_rating):
     "bulk and normal match"
-    train, test = simple_test_pair(ml_test.ratings)
+    train, test, recs = demo_recs
     if drop_rating:
         test = test[['user', 'item']]
-
-    users = test['user'].unique()
-    algo = Popular()
-    algo.fit(train)
-
-    recs = recommend(algo, users, 100)
 
     rla = RecListAnalysis()
     rla.add_metric(recip_rank)

--- a/tests/test_topn_ndcg.py
+++ b/tests/test_topn_ndcg.py
@@ -5,7 +5,7 @@ from pytest import approx, mark
 
 from lenskit.metrics.topn import _dcg, dcg, ndcg, _bulk_ndcg
 from lenskit.topn import RecListAnalysis
-from lenskit.util.test import ml_test
+from lenskit.util.test import ml_test, demo_recs
 from lenskit.algorithms.basic import PopScore
 from lenskit.algorithms.ranking import PlackettLuce
 from lenskit.batch import recommend
@@ -135,18 +135,11 @@ def test_ndcg_bulk_not_at_top():
 
 
 @mark.parametrize('drop_rating', [False, True])
-def test_ndcg_bulk_match(drop_rating):
+def test_ndcg_bulk_match(demo_recs, drop_rating):
     "bulk and normal match"
-    train, test = simple_test_pair(ml_test.ratings)
+    train, test, recs = demo_recs
     if drop_rating:
         test = test[['user', 'item']]
-
-    users = test['user'].unique()
-    algo = PopScore()
-    algo = PlackettLuce(algo, rng_spec='user')
-    algo.fit(train)
-
-    recs = recommend(algo, users, 100)
 
     rla = RecListAnalysis()
     rla.add_metric(ndcg)

--- a/tests/test_topn_precision.py
+++ b/tests/test_topn_precision.py
@@ -112,7 +112,7 @@ def test_prec_short_items():
     items = [1, 0, 150]
 
     r = _test_prec(items, rel, k=5)
-    assert r == approx(0.4)
+    assert r == approx(2 / 3)
 
 
 def test_recall_bulk_k(demo_recs):

--- a/tests/test_topn_recall.py
+++ b/tests/test_topn_recall.py
@@ -6,10 +6,10 @@ from pytest import approx
 from lenskit.topn import recall
 
 
-def _test_recall(items, rel):
+def _test_recall(items, rel, **kwargs):
     recs = pd.DataFrame({'item': items})
     truth = pd.DataFrame({'item': rel}).set_index('item')
-    return recall(recs, truth)
+    return recall(recs, truth, **kwargs)
 
 
 def test_recall_empty_zero():
@@ -92,3 +92,27 @@ def test_recall_array():
 
     prec = _test_recall(np.array([1, 2, 3, 4]), np.arange(4, 9, 1, 'u4'))
     assert prec == approx(0.2)
+
+
+def test_recall_long_rel():
+    rel = np.arange(100)
+    items = [1, 0, 150, 3, 10]
+
+    r = _test_recall(items, rel, k=5)
+    assert r == approx(0.8)
+
+
+def test_recall_long_truth():
+    rel = np.arange(100)
+    items = [1, 0, 150, 3, 10, 30, 120, 4, 17]
+
+    r = _test_recall(items, rel, k=5)
+    assert r == approx(0.8)
+
+
+def test_recall_partial_rel():
+    rel = np.arange(100)
+    items = [1, 0, 150, 3, 10]
+
+    r = _test_recall(items, rel, k=10)
+    assert r == approx(0.4)

--- a/tests/test_topn_recall.py
+++ b/tests/test_topn_recall.py
@@ -9,7 +9,7 @@ from lenskit.algorithms.item_knn import ItemItem
 from lenskit.algorithms.basic import PopScore
 from lenskit.algorithms.ranking import PlackettLuce
 from lenskit.algorithms import Recommender
-from lenskit.util.test import ml_test
+from lenskit.util.test import ml_test, demo_recs
 from lenskit.metrics.topn import recall
 from lenskit import topn, batch, crossfold as xf
 
@@ -128,17 +128,10 @@ def test_recall_partial_rel():
     assert r == approx(0.4)
 
 
-def test_recall_bulk_k():
+def test_recall_bulk_k(demo_recs):
     "bulk and normal match"
-    train, test = xf.simple_test_pair(ml_test.ratings, f_rates=0.5)
+    train, test, recs = demo_recs
     assert test['user'].value_counts().max() > 5
-
-    users = test['user'].unique()
-    algo = PopScore()
-    algo = PlackettLuce(algo, rng_spec='user')
-    algo.fit(train)
-
-    recs = batch.recommend(algo, users, 1000)
 
     rla = topn.RecListAnalysis()
     rla.add_metric(recall, name='rk', k=5)

--- a/tests/test_topn_recall.py
+++ b/tests/test_topn_recall.py
@@ -112,7 +112,7 @@ def test_recall_long_rel():
     assert r == approx(0.8)
 
 
-def test_recall_long_truth():
+def test_recall_long_items():
     rel = np.arange(100)
     items = [1, 0, 150, 3, 10, 30, 120, 4, 17]
 

--- a/tests/test_topn_recall.py
+++ b/tests/test_topn_recall.py
@@ -4,14 +4,9 @@ import pandas as pd
 
 from pytest import approx
 
-from lenskit.algorithms.user_knn import UserUser
-from lenskit.algorithms.item_knn import ItemItem
-from lenskit.algorithms.basic import PopScore
-from lenskit.algorithms.ranking import PlackettLuce
-from lenskit.algorithms import Recommender
-from lenskit.util.test import ml_test, demo_recs
 from lenskit.metrics.topn import recall
-from lenskit import topn, batch, crossfold as xf
+from lenskit.util.test import demo_recs
+from lenskit import topn
 
 _log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR adds a `k` parameter to top-N metrics, with appropriate tests. Closes #244.