### PR TITLE
Remove fastparquet import

### DIFF
--- a/lenskit/batch/_multi.py
+++ b/lenskit/batch/_multi.py
@@ -16,11 +16,6 @@ from .. import util
 from ._recommend import recommend
 from ._predict import predict
 
-try:
-    import fastparquet
-except ImportError:
-    fastparquet = None
-
 _logger = logging.getLogger(__name__)
 
 _AlgoRec = collections.namedtuple('_AlgoRec', [

--- a/lenskit/util/data.py
+++ b/lenskit/util/data.py
@@ -5,11 +5,6 @@ Data utilities
 import logging
 import pathlib
 
-try:
-    import fastparquet
-except ImportError:
-    fastparquet = None
-
 _log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This removes fastparquet imports (turns out we weren't actually using them). Closes #253.