### PR TITLE
Correctly include missing user scores with multiple runs

### DIFF
--- a/lenskit/topn.py
+++ b/lenskit/topn.py
@@ -148,9 +148,21 @@ class RecListAnalysis:
             ug_cols = [c for c in rec_key if c not in truth_key]
             tcount = truth.groupby(truth_key)['item'].count()
             tcount.name = 'ntruth'
+            _log.debug('truth data:\n%s', tcount)
             if ug_cols:
                 _log.debug('regrouping by %s to fill', ug_cols)
-                res = res.groupby(ug_cols).apply(lambda f: f.join(tcount, how='outer', on=truth_key))
+                _log.debug('pre-group series:\n%s', res)
+
+                rdict = {}
+
+                for key, df in res.groupby(ug_cols):
+                    df2 = df.drop(columns=ug_cols).join(tcount, how='outer', on=truth_key)
+                    rdict[key] = df2
+
+                res = pd.concat(rdict, names=ug_cols)
+                res = res.reset_index()
+                _log.debug('joined result:\n%s', res)
+
             else:
                 _log.debug('no ungroup cols, directly merging to fill')
                 res = res.join(tcount, how='outer', on=truth_key)

--- a/tests/test_topn_analysis.py
+++ b/tests/test_topn_analysis.py
@@ -197,6 +197,7 @@ def test_fill_users():
     algo.fit(train)
 
     rec_users = test['user'].sample(50).unique()
+    assert len(rec_users) < 50
     recs = batch.recommend(algo, rec_users, 25)
 
     scores = rla.compute(recs, test, include_missing=True)
@@ -251,6 +252,10 @@ def test_adv_fill_users():
     assert all(scores['ntruth'] == 5)
     assert scores['recall'].isna().sum() > 0
     _log.info('scores:\n%s', scores)
+
+    ucounts = scores.reset_index().groupby('algo')['user'].agg(['count', 'nunique'])
+    assert all(ucounts['count'] == 100)
+    assert all(ucounts['nunique'] == 100)
 
     mscores = rla.compute(recs, test)
     mscores = mscores.reset_index().set_index(inames)


### PR DESCRIPTION
This closes #289, fixing the `include_missing` logic to correctly fill in missing rows when there are multiple runs (e.g. algorithms) in the recommendation data being evaluated.