### PR TITLE
Add feedback modes to k-NN recommenders

### DIFF
--- a/docs/knn.rst
+++ b/docs/knn.rst
@@ -6,17 +6,27 @@ implementations.  These lightly-configurable implementations are intended
 to capture the behavior of the Java-based LensKit implementations to provide
 a good upgrade path and enable basic experiments out of the box.
 
-There are two different primary that you can use these algorithms in.  When using **explicit
+There are two different primary modes that you can use these algorithms in.  When using **explicit
 feedback** (rating values), you usually want to use the defaults of weighted-average aggregation and
-mean-centering normalization.
+mean-centering normalization.  This is the default mode, and can be selected explicitly by passing
+``feedback='explicit'`` to the class constructor.
 
 With **implicit feedback** (unary data such as clicks and purchases, typically represented with
-rating values of 1 for positive items), the usual design is sum aggregation and no centering::
+rating values of 1 for positive items), the usual design is sum aggregation and no centering. This
+can be selected with ``feedback='implicit'``, which also configures the algorithm to ignore rating
+values (when present) and treat every rating as 1:
 
-    implicit_knn = ItemItem(20, center=False, aggregate='sum')
+    implicit_knn = ItemItem(20, feedback='implicit')
 
 Attempting to center data on the same scale (all 1, for example) will typically produce invalid
 results.  ItemKNN has diagnostics to warn you about this.
+
+The ``feedback`` option only sets defaults; the algorithm can be further configured (e.g. to re-enable
+rating values) with additional parameters to the constructor.
+
+.. versionadded:: 0.14
+    The ``feedback`` option and the ability to ignore rating values was added in LensKit 0.14.
+    In previous versions, you need to specifically configure each option.
 
 .. toctree::
 

--- a/lenskit/algorithms/__init__.py
+++ b/lenskit/algorithms/__init__.py
@@ -21,6 +21,16 @@ class Algorithm(metaclass=ABCMeta):
     :canonical: lenskit.Algorithm
     """
 
+    """
+    Names of parameters to ignore in :meth:`get_params`.
+    """
+    IGNORED_PARAMS = []
+    """
+    Names of extra parameters to include in :meth:`get_params`.  Useful when the
+    constructor takes ``**kwargs``.
+    """
+    EXTRA_PARAMS = []
+
     @abstractmethod
     def fit(self, ratings, **kwargs):
         """
@@ -51,10 +61,10 @@ class Algorithm(metaclass=ABCMeta):
             dict: the algorithm parameters.
         """
         sig = inspect.signature(self.__class__)
-        names = list(sig.parameters.keys())
+        names = list(sig.parameters.keys()) + self.EXTRA_PARAMS
         params = {}
         for name in names:
-            if hasattr(self, name):
+            if hasattr(self, name) and name not in self.IGNORED_PARAMS:
                 value = getattr(self, name)
                 params[name] = value
                 if deep and hasattr(value, 'get_params'):

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -256,6 +256,9 @@ class ItemItem(Predictor):
         user_index_(pandas.Index): the index of known user IDs for the rating matrix.
         rating_matrix_(matrix.CSR): the user-item rating matrix for looking up users' ratings.
     """
+    IGNORED_PARAMS = ['feedback']
+    EXTRA_PARAMS = ['center', 'aggregate', 'use_ratings']
+
     AGG_SUM = intern('sum')
     AGG_WA = intern('weighted-average')
     RATING_AGGS = [AGG_WA]  # the aggregates that use rating values
@@ -307,14 +310,6 @@ class ItemItem(Predictor):
                     item-item configured to ignore ratings, but use weighted averages.  This configuration
                     is unlikely to work well.
                 '''), ConfigWarning)
-
-    def get_params(self, deep=True):
-        params = super().get_params(deep)
-        for p in ['center', 'aggregate', 'use_ratings']:
-            params[p] = self.__dict__[p]
-        if 'feedback' in params:
-            del params['feedback']
-        return params
 
     def fit(self, ratings, **kwargs):
         """

--- a/lenskit/algorithms/item_knn.py
+++ b/lenskit/algorithms/item_knn.py
@@ -260,7 +260,8 @@ class ItemItem(Predictor):
     AGG_WA = intern('weighted-average')
     RATING_AGGS = [AGG_WA]  # the aggregates that use rating values
 
-    def __init__(self, nnbrs, min_nbrs=1, min_sim=1.0e-6, save_nbrs=None, feedback='explicit', **kwargs):
+    def __init__(self, nnbrs, min_nbrs=1, min_sim=1.0e-6, save_nbrs=None, feedback='explicit',
+                 **kwargs):
         self.nnbrs = nnbrs
         if self.nnbrs is not None and self.nnbrs < 1:
             self.nnbrs = -1
@@ -278,9 +279,9 @@ class ItemItem(Predictor):
             }
         elif feedback == 'implicit':
             defaults = {
-                'center': True,
-                'aggregate': self.AGG_WA,
-                'use_ratings': True
+                'center': False,
+                'aggregate': self.AGG_SUM,
+                'use_ratings': False
             }
         else:
             raise ValueError(f'invalid feedback mode: {feedback}')
@@ -306,6 +307,14 @@ class ItemItem(Predictor):
                     item-item configured to ignore ratings, but use weighted averages.  This configuration
                     is unlikely to work well.
                 '''), ConfigWarning)
+
+    def get_params(self, deep=True):
+        params = super().get_params(deep)
+        for p in ['center', 'aggregate', 'use_ratings']:
+            params[p] = self.__dict__[p]
+        if 'feedback' in params:
+            del params['feedback']
+        return params
 
     def fit(self, ratings, **kwargs):
         """

--- a/lenskit/algorithms/user_knn.py
+++ b/lenskit/algorithms/user_knn.py
@@ -130,6 +130,8 @@ class UserUser(Predictor):
         rating_matrix_(matrix.CSR): Normalized user-item rating matrix.
         transpose_matrix_(matrix.CSR): Transposed un-normalized rating matrix.
     """
+    IGNORED_PARAMS = ['feedback']
+    EXTRA_PARAMS = ['center', 'aggregate', 'use_ratings']
     AGG_SUM = intern('sum')
     AGG_WA = intern('weighted-average')
     RATING_AGGS = [AGG_WA]
@@ -158,14 +160,6 @@ class UserUser(Predictor):
         self.center = defaults['center']
         self.aggregate = intern(defaults['aggregate'])
         self.use_ratings = defaults['use_ratings']
-
-    def get_params(self, deep=True):
-        params = super().get_params(deep)
-        for p in ['center', 'aggregate', 'use_ratings']:
-            params[p] = self.__dict__[p]
-        if 'feedback' in params:
-            del params['feedback']
-        return params
 
     def fit(self, ratings, **kwargs):
         """

--- a/tests/test_knn_item_item.py
+++ b/tests/test_knn_item_item.py
@@ -508,7 +508,7 @@ def test_ii_no_ratings():
     a1 = knn.ItemItem(20, save_nbrs=100, center=False, aggregate='sum')
     a1.fit(ml_ratings.loc[:, ['user', 'item']])
 
-    algo = knn.ItemItem(20, save_nbrs=100, center=False, aggregate='sum', use_ratings=False)
+    algo = knn.ItemItem(20, save_nbrs=100, feedback='implicit')
 
     algo.fit(ml_ratings)
     assert algo.item_counts_.sum() == algo.sim_matrix_.nnz

--- a/tests/test_knn_item_item.py
+++ b/tests/test_knn_item_item.py
@@ -57,6 +57,27 @@ def ml_subset():
     return top_rates.reset_index()
 
 
+def test_ii_dft_config():
+    algo = knn.ItemItem(30, save_nbrs=500)
+    assert algo.center
+    assert algo.aggregate == 'weighted-average'
+    assert algo.use_ratings
+
+
+def test_ii_exp_config():
+    algo = knn.ItemItem(30, save_nbrs=500, feedback='explicit')
+    assert algo.center
+    assert algo.aggregate == 'weighted-average'
+    assert algo.use_ratings
+
+
+def test_ii_imp_config():
+    algo = knn.ItemItem(30, save_nbrs=500, feedback='implicit')
+    assert not algo.center
+    assert algo.aggregate == 'sum'
+    assert not algo.use_ratings
+
+
 def test_ii_train():
     algo = knn.ItemItem(30, save_nbrs=500)
     algo.fit(simple_ratings)

--- a/tests/test_knn_item_item.py
+++ b/tests/test_knn_item_item.py
@@ -6,6 +6,7 @@ from lenskit import batch
 import lenskit.algorithms.item_knn as knn
 from lenskit.sharing import persist
 from lenskit.util.parallel import run_sp
+from lenskit.util import clone
 
 import gc
 from pathlib import Path
@@ -76,6 +77,14 @@ def test_ii_imp_config():
     assert not algo.center
     assert algo.aggregate == 'sum'
     assert not algo.use_ratings
+
+
+def test_ii_imp_clone():
+    algo = knn.ItemItem(30, save_nbrs=500, feedback='implicit')
+    a2 = clone(algo)
+
+    assert a2.get_params() == algo.get_params()
+    assert a2.__dict__ == algo.__dict__
 
 
 def test_ii_train():


### PR DESCRIPTION
This adds a `feedback` option to the k-NN recommenders as a preferred way for setting whether they are being used for implicit or explicit feedback. Previous options are still supported as keyword parameters.