### PR TITLE
Document formulas for all metrics

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,8 @@ If you use Lenskit in published research, cite [LKPY]_.
     DOI:`10.1145/3340531.3412778 <https://dx.doi.org/10.1145/3340531.3412778>`_.
     arXiv:`1809.03125 <https://arxiv.org/abs/1809.03125>`_ [cs.IR].
 
+Throughout this documentation, we use the notation of :cite:t:`Ekstrand2019-dh`.
+
 Resources
 ---------
 

--- a/docs/lenskit.bib
+++ b/docs/lenskit.bib
@@ -306,6 +306,17 @@
   pmc      = "PMC7056644"
 }
 
+@TECHREPORT{Ekstrand2019-dh,
+  title       = "Recommender Systems Notation",
+  author      = "Ekstrand, Michael D and Konstan, Joseph A",
+  number      =  177,
+  series      = "Computer Science Faculty Publications and Presentations",
+  institution = "Boise State University",
+  year        =  2019,
+  url         = "https://arxiv.org/abs/1902.01348",
+  doi         = "10.18122/cs\_facpubs/177/boisestate"
+}
+
 @ARTICLE{Pedregosa2011-gi,
   title   = "Scikit-learn: Machine Learning in {P}ython",
   author  = "Pedregosa, F and Varoquaux, G and Gramfort, A and Michel, V and

--- a/lenskit/metrics/predict.py
+++ b/lenskit/metrics/predict.py
@@ -21,7 +21,16 @@ def _check_missing(truth, missing):
 
 def rmse(predictions, truth, missing='error'):
     """
-    Compute RMSE (root mean squared error).
+    Compute RMSE (root mean squared error).  This is computed as:
+
+    .. math::
+        \\sum_{r_{ui} \\in R} \\left(r_{ui} - s(i|u)\\right)^2
+
+    When used with :func:`user_metric`, or on series grouped by user, it computes
+    a per-user RMSE; when applied to an entire prediction frame, it computes global
+    RMSE.  It does not do any fallbacks; if you want to compute RMSE with fallback
+    predictions (e.g. usign a bias model when a collaborative filter cannot predict),
+    generate predictions with :class:`lenskit.algorithms.basic.Fallback`.
 
     Args:
         predictions(pandas.Series): the predictions
@@ -51,7 +60,16 @@ def rmse(predictions, truth, missing='error'):
 
 def mae(predictions, truth, missing='error'):
     """
-    Compute MAE (mean absolute error).
+    Compute MAE (mean absolute error).  This is computed as:
+
+    .. math::
+        \\sum_{r_{ui} \\in R} \\left|r_{ui} - s(i|u)\\right|
+
+    When used with :func:`user_metric`, or on series grouped by user, it computes
+    a per-user MAE; when applied to an entire prediction frame, it computes global
+    MAE.  It does not do any fallbacks; if you want to compute MAE with fallback
+    predictions (e.g. usign a bias model when a collaborative filter cannot predict),
+    generate predictions with :class:`lenskit.algorithms.basic.Fallback`.
 
     Args:
         predictions(pandas.Series): the predictions

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -107,7 +107,7 @@ def recip_rank(recs, truth, k=None):
     """
     Compute the reciprocal rank of the first relevant item in a list of recommendations.
     Let :math:`\\kappa` denote the 1-based rank of the first relevant item in :math:`L`,
-    with :math:`\\kappa=\infty` if none of the first :math:`k` items in :math:`L` are relevant;
+    with :math:`\\kappa=\\infty` if none of the first :math:`k` items in :math:`L` are relevant;
     then the reciprocal rank is :math:`1 / \\kappa`. If no elements are relevant, the reciprocal
     rank is therefore 0.
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,1 +1,10 @@
 from lkbuild.tasks import *
+
+
+@task
+def docs(c, watch=False, rebuild=False):
+    rb = '-a' if rebuild else ''
+    if watch:
+        c.run(f'sphinx-autobuild {rb} --watch lenskit docs build/doc')
+    else:
+        c.run(f'sphinx-build {rb} docs build/doc')


### PR DESCRIPTION
This adds documentation to all metric definitions with their mathematical formulas, to respond to http://dx.doi.org/10.1145/3460231.3478848. Closes #285.