### PR TITLE
Fix nDCG truncation bug (#309)

### DIFF
--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -300,10 +300,10 @@ def ndcg(recs, truth, discount=np.log2, k=None):
             The maximum list length.
     """
 
-    tpos = truth.index.get_indexer(recs['item'])
-
     if k is not None:
         recs = recs.iloc[:k]
+
+    tpos = truth.index.get_indexer(recs['item'])
 
     if 'rating' in truth.columns:
         i_rates = np.sort(truth.rating.values)[::-1]

--- a/tests/test_topn_ndcg.py
+++ b/tests/test_topn_ndcg.py
@@ -87,6 +87,14 @@ def test_ndcg_perfect():
     assert ndcg(recs, truth) == approx(1.0)
 
 
+def test_ndcg_perfect_k_short():
+    recs = pd.DataFrame({'item': [2, 3, 1]})
+    truth = pd.DataFrame({'item': [1, 2, 3], 'rating': [3.0, 5.0, 4.0]})
+    truth = truth.set_index('item')
+    assert ndcg(recs, truth, k=2) == approx(1.0)
+    assert ndcg(recs[:2], truth, k=2) == approx(1.0)
+
+
 def test_ndcg_wrong():
     recs = pd.DataFrame({'item': [1, 2]})
     truth = pd.DataFrame({'item': [1, 2, 3], 'rating': [3.0, 5.0, 4.0]})


### PR DESCRIPTION
This ports the nDCG truncation fix (#310) to `main`. Closes #309.