### PR TITLE
Support Numba 0.56 in 0.14 series

### DIFF
--- a/lenskit/math/solve.py
+++ b/lenskit/math/solve.py
@@ -42,8 +42,10 @@ def _dposv(A, b, lower):
     # invert the meaning of 'lower' and 'trans', and the function will work fine.
     # We also need to swap index orders
     uplo = __uplo_U if lower else __uplo_L
-    n_p = __ffi.from_buffer(np.array([A.shape[0]], dtype=np.intc))
-    nrhs_p = __ffi.from_buffer(np.ones(1, dtype=np.intc))
+    narr = np.array([A.shape[0]], dtype=np.intc)
+    n_p = __ffi.from_buffer(narr)
+    nrhs = np.ones(1, dtype=np.intc)
+    nrhs_p = __ffi.from_buffer(nrhs)
     info = np.zeros(1, dtype=np.intc)
     info_p = __ffi.from_buffer(info)
 
@@ -52,7 +54,7 @@ def _dposv(A, b, lower):
             __ffi.from_buffer(b), n_p,
             info_p)
 
-    _ref_sink(n_p, nrhs_p, info, info_p)
+    _ref_sink(narr, n_p, nrhs, nrhs_p, info, info_p)
 
     return info[0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pandas >=1.0, ==1.*",
     "numpy >= 1.17",
     "scipy >= 1.2",
-    "numba >= 0.51, < 0.56",
+    "numba >= 0.51, < 0.57",
     "cffi >= 1.12.2",
     "psutil >= 5",
     "binpickle >= 0.3.2",


### PR DESCRIPTION
This adds Numba 0.56 to the LensKIt 0.14 support matrix. Closes #319.