### PR TITLE
Bump minimum SciPy version to 1.3.2.

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Set up Python deps
         run: |
           set -e
-          python -m pip install -U pip
+          python -m pip install -U pip wheel
           python -m pip install -c min-constraints.txt .[test]
           python -m pip install pytest-cov
 

--- a/min-constraints.txt
+++ b/min-constraints.txt
@@ -1,6 +1,6 @@
 pandas==1.0.0
 numpy==1.19.0
-scipy==1.2.1
+scipy==1.3.2
 numba==0.51.0
 pyarrow==0.15.1
 cffi==1.12.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ['version', 'description']
 dependencies = [
     "pandas >=1.0, ==1.*",
     "numpy >= 1.19",
-    "scipy >= 1.2",
+    "scipy >= 1.3.2",
     "numba >= 0.51, < 0.57",
     "cffi >= 1.12.2",
     "psutil >= 5",


### PR DESCRIPTION
SciPy didn't publish wheels for Python 3.8 until 1.3.2, so let's bump the minimum supported SciPy version.