### PR TITLE
Test with PyTest 7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ source = "https://github.com/lenskit/lkpy"
 
 [project.optional-dependencies]
 test = [
-    "pytest ==6.*",
+    "pytest ==7.*",
     "pytest-doctestplus >= 0.9",
     "hypothesis >= 6"
 ]


### PR DESCRIPTION
This bumps PyTest to 7, needed for Python 3.11 support.