### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -141,7 +141,7 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
-        # - "3.11"
+        - "3.11"
         platform:
         - windows
         - ubuntu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    # "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
 ]


### PR DESCRIPTION
This enables the test suite on Python 3.11 (just vanilla, for now).