### PR TITLE
Drop support for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,8 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - "3.8"
-        - "3.9"
         - "3.10"
         # - "3.11"
         platform:
@@ -83,7 +81,7 @@ jobs:
         uses: lenskit/lkbuild/actions/setup-conda-env@main
         id: setup
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           extras: demo
 
       - name: Inspect Conda environment
@@ -138,8 +136,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - "3.8"
-        - "3.9"
         - "3.10"
         - "3.11"
         platform:
@@ -181,7 +177,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           architecture: x64
 
       - name: Set up Python deps

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,14 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.8
   install:
   - method: pip
     path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,6 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",

--- a/tests/test_als_explicit.py
+++ b/tests/test_als_explicit.py
@@ -1,16 +1,8 @@
 import logging
 import pickle
 
-from numpy.lib.npyio import _save_dispatcher
-
 # get a usable pickle disassembler
-if pickle.HIGHEST_PROTOCOL >= 5:
-    from pickletools import dis as pickle_dis
-else:
-    try:
-        from pickle5.pickletools import dis as pickle_dis
-    except ImportError:
-        pass
+from pickletools import dis as pickle_dis
 
 from lenskit.algorithms import als
 from lenskit import util

--- a/tests/test_batch_recommend.py
+++ b/tests/test_batch_recommend.py
@@ -12,11 +12,6 @@ from lenskit.algorithms.bias import Bias
 from lenskit import batch, topn
 import lenskit.crossfold as xf
 
-try:
-    import pickle5
-except ImportError:
-    pickle5 = None
-
 MLB = namedtuple('MLB', ['ratings', 'algo'])
 _log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Following [SPEC 0](https://scientific-python.org/specs/spec-0000/), this drops support for Python versions older than 3.10 for the LensKit 0.15 release in Q4 2023. Closes #337.