### PR TITLE
Use threadpoolctl for debug checks

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -14,19 +14,24 @@ Quick Tips
 ----------
 
 * Use Conda-based Python, with ``tbb`` installed.
-* Set the ``MKL_THREADING_LAYER`` environment variable to ``tbb``, so both MKL and LensKit
-  will use TBB and can coordinate their thread pools.
+* When using MKL, set the ``MKL_THREADING_LAYER`` environment variable to ``tbb``, so both
+  MKL and LensKit will use TBB and can coordinate their thread pools.
 * Use ``LK_NUM_PROCS`` if you want to control LensKit's batch prediction and recommendation
   parallelism, and ``NUMBA_NUM_THREADS`` to control its model training parallelism.
 
-We generally find the best performance using MKL with TBB throughout the stack.  If both
-LensKit's Numba-accelerated code and MKL are using TBB, they will coordinate their
-thread pools to coordinate threading levels.
+We generally find the best performance using MKL with TBB throughout the stack on Intel
+processors.  If both LensKit's Numba-accelerated code and MKL are using TBB, they will
+coordinate their thread pools to coordinate threading levels.
 
-If you are **not** using MKL with TBB, we recommend setting ``MKL_NUM_THREADS=1`` and/or
-``OPENBLAS_NUM_THREADS=1`` (depending on your BLAS implementation) to turn off
-BLAS threading.  When LensKit starts (usually at model training time), it will
-check your runtime environment and log warning messages if it detects problems.
+If you are **not** using MKL (Apple Silicon, maybe also AMD processors), we recommend
+controlling your BLAS parallelism.  For OpenBLAS, how you control this depends on how
+OpenBLAS was built, whether Numba is using OpenMP or TBB, and whether you are training
+or evaluating the model.
+
+When LensKit starts (usually at model training time), it will check your runtime environment
+and log warning messages if it detects problems.  During evaluation, it also makes a
+best-effort attempt, through `threadpoolctl`_, to disable nested parallelism when running
+a parallel evaluation.
 
 Controlling Parallelism
 -----------------------

--- a/lenskit/util/debug.py
+++ b/lenskit/util/debug.py
@@ -2,7 +2,6 @@
 Debugging utility code.  Also runnable as a Python command.
 
 Usage:
-    lenskit.util.debug [options] --libraries
     lenskit.util.debug [options] --blas-info
     lenskit.util.debug [options] --numba-info
     lenskit.util.debug [options] --check-env
@@ -133,14 +132,6 @@ def check_env():
     return problems
 
 
-def print_libraries():
-    p = psutil.Process()
-
-    _log.info('printing process libraries')
-    for map in p.memory_maps():
-        print(map.path)
-
-
 def print_blas_info():
     blas = blas_info()
     print(blas)
@@ -158,8 +149,6 @@ def main():
     logging.basicConfig(level=level, stream=sys.stderr, format='%(levelname)s %(name)s %(message)s')
     logging.getLogger('numba').setLevel(logging.INFO)
 
-    if opts['--libraries']:
-        print_libraries()
     if opts['--blas-info']:
         print_blas_info()
     if opts['--numba-info']:

--- a/lenskit/util/debug.py
+++ b/lenskit/util/debug.py
@@ -284,6 +284,7 @@ def main():
     opts = docopt(__doc__)
     level = logging.DEBUG if opts['--verbose'] else logging.INFO
     logging.basicConfig(level=level, stream=sys.stderr, format='%(levelname)s %(name)s %(message)s')
+    logging.getLogger('numba').setLevel(logging.INFO)
 
     if opts['--libraries']:
         print_libraries()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "numba >= 0.56, < 0.59",
     "cffi >= 1.15.0",
     "psutil >= 5",
+    "threadpoolctl >=3.0",
     "binpickle >= 0.3.2",
     "seedbank >= 0.1.0",
     "csr >= 0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "scipy >= 1.8.0",
     "numba >= 0.56, < 0.59",
     "cffi >= 1.15.0",
-    "psutil >= 5",
     "threadpoolctl >=3.0",
     "binpickle >= 0.3.2",
     "seedbank >= 0.1.0",


### PR DESCRIPTION
This uses threadpoolctl instead of our own cffi work to detect threading errors.