### PR TITLE
Support Pandas 2 and bump minimum Pandas & NumPy

### DIFF
--- a/envs/lenskit-py3.10-ci.yaml
+++ b/envs/lenskit-py3.10-ci.yaml
@@ -17,13 +17,13 @@ dependencies:
   - csr>=0.5
   - hypothesis>=6
   - numba<0.59,>=0.56
-  - numpy>=1.22
-  - pandas<2,>=1.4
+  - numpy>=1.23
+  - pandas<3,>=1.5
   - pytest-cov>=2.12
   - pytest-doctestplus>=0.9
   - pytest==7.*
   - scikit-learn>=1.1
-  - scipy>=1.8.0
+  - scipy>=1.9.0
   - seedbank>=0.1.0
   - tbb
   - threadpoolctl>=3.0

--- a/envs/lenskit-py3.10-dev.yaml
+++ b/envs/lenskit-py3.10-dev.yaml
@@ -19,7 +19,6 @@ dependencies:
   - docopt>=0.6
   - hypothesis>=6
   - invoke>=1
-  - ipython
   - ipython>=7
   - matplotlib~=3.4
   - myst-nb>=0.13
@@ -27,16 +26,16 @@ dependencies:
   - nbval>=0.9
   - notebook>=6
   - numba<0.59,>=0.56
-  - numpy>=1.22
-  - pandas<2,>=1.4
-  - pyproject2conda
+  - numpy>=1.23
+  - pandas<3,>=1.5
+  - pyproject2conda~=0.11
   - pytest-cov>=2.12
   - pytest-doctestplus>=0.9
   - pytest==7.*
   - python-build==1
   - ruff>=0.2
   - scikit-learn>=1.1
-  - scipy>=1.8.0
+  - scipy>=1.9.0
   - seedbank>=0.1.0
   - setuptools>=64
   - setuptools_scm>=8

--- a/envs/lenskit-py3.10-doc.yaml
+++ b/envs/lenskit-py3.10-doc.yaml
@@ -16,9 +16,9 @@ dependencies:
   - csr>=0.5
   - myst-nb>=0.13
   - numba<0.59,>=0.56
-  - numpy>=1.22
-  - pandas<2,>=1.4
-  - scipy>=1.8.0
+  - numpy>=1.23
+  - pandas<3,>=1.5
+  - scipy>=1.9.0
   - seedbank>=0.1.0
   - sphinx>=4.2
   - sphinx_rtd_theme>=0.5

--- a/envs/lenskit-py3.10-test.yaml
+++ b/envs/lenskit-py3.10-test.yaml
@@ -17,12 +17,12 @@ dependencies:
   - csr>=0.5
   - hypothesis>=6
   - numba<0.59,>=0.56
-  - numpy>=1.22
-  - pandas<2,>=1.4
+  - numpy>=1.23
+  - pandas<3,>=1.5
   - pytest-cov>=2.12
   - pytest-doctestplus>=0.9
   - pytest==7.*
-  - scipy>=1.8.0
+  - scipy>=1.9.0
   - seedbank>=0.1.0
   - tbb
   - threadpoolctl>=3.0

--- a/envs/lenskit-py3.11-ci.yaml
+++ b/envs/lenskit-py3.11-ci.yaml
@@ -17,13 +17,13 @@ dependencies:
   - csr>=0.5
   - hypothesis>=6
   - numba<0.59,>=0.56
-  - numpy>=1.22
-  - pandas<2,>=1.4
+  - numpy>=1.23
+  - pandas<3,>=1.5
   - pytest-cov>=2.12
   - pytest-doctestplus>=0.9
   - pytest==7.*
   - scikit-learn>=1.1
-  - scipy>=1.8.0
+  - scipy>=1.9.0
   - seedbank>=0.1.0
   - tbb
   - threadpoolctl>=3.0

--- a/envs/lenskit-py3.11-dev.yaml
+++ b/envs/lenskit-py3.11-dev.yaml
@@ -19,7 +19,6 @@ dependencies:
   - docopt>=0.6
   - hypothesis>=6
   - invoke>=1
-  - ipython
   - ipython>=7
   - matplotlib~=3.4
   - myst-nb>=0.13
@@ -27,16 +26,16 @@ dependencies:
   - nbval>=0.9
   - notebook>=6
   - numba<0.59,>=0.56
-  - numpy>=1.22
-  - pandas<2,>=1.4
-  - pyproject2conda
+  - numpy>=1.23
+  - pandas<3,>=1.5
+  - pyproject2conda~=0.11
   - pytest-cov>=2.12
   - pytest-doctestplus>=0.9
   - pytest==7.*
   - python-build==1
   - ruff>=0.2
   - scikit-learn>=1.1
-  - scipy>=1.8.0
+  - scipy>=1.9.0
   - seedbank>=0.1.0
   - setuptools>=64
   - setuptools_scm>=8

--- a/envs/lenskit-py3.11-doc.yaml
+++ b/envs/lenskit-py3.11-doc.yaml
@@ -16,9 +16,9 @@ dependencies:
   - csr>=0.5
   - myst-nb>=0.13
   - numba<0.59,>=0.56
-  - numpy>=1.22
-  - pandas<2,>=1.4
-  - scipy>=1.8.0
+  - numpy>=1.23
+  - pandas<3,>=1.5
+  - scipy>=1.9.0
   - seedbank>=0.1.0
   - sphinx>=4.2
   - sphinx_rtd_theme>=0.5

--- a/envs/lenskit-py3.11-test.yaml
+++ b/envs/lenskit-py3.11-test.yaml
@@ -17,12 +17,12 @@ dependencies:
   - csr>=0.5
   - hypothesis>=6
   - numba<0.59,>=0.56
-  - numpy>=1.22
-  - pandas<2,>=1.4
+  - numpy>=1.23
+  - pandas<3,>=1.5
   - pytest-cov>=2.12
   - pytest-doctestplus>=0.9
   - pytest==7.*
-  - scipy>=1.8.0
+  - scipy>=1.9.0
   - seedbank>=0.1.0
   - tbb
   - threadpoolctl>=3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ readme = "README.md"
 license = { file = "LICENSE.md" }
 dynamic = ["version"]
 dependencies = [
-  "pandas >=1.4, <2",
-  "numpy >= 1.22",
-  "scipy >= 1.8.0",
+  "pandas >=1.5, <3",
+  "numpy >= 1.23",
+  "scipy >= 1.9.0",
   "numba >= 0.56, < 0.59",
   "cffi >= 1.15.0",
   "threadpoolctl >=3.0",

--- a/tests/test_crossfold.py
+++ b/tests/test_crossfold.py
@@ -4,16 +4,16 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-import itertools as it
 import functools as ft
-import pytest
+import itertools as it
 import math
 
 import numpy as np
 
-import lenskit.util.test as lktu
+import pytest
 
 import lenskit.crossfold as xf
+import lenskit.util.test as lktu
 
 
 def test_partition_rows():
@@ -104,7 +104,7 @@ def test_sample_non_disjoint():
 
     # There are enough splits & items we should pick at least one duplicate
     ipairs = (
-        (s1.test.set_index("user", "item").index, s2.test.set_index("user", "item").index)
+        (s1.test.set_index(["user", "item"]).index, s2.test.set_index(["user", "item"]).index)
         for (s1, s2) in it.product(splits, splits)
     )
     isizes = [len(i1.intersection(i2)) for (i1, i2) in ipairs]


### PR DESCRIPTION
This updates to current Pandas and NumPy versions per SPEC0:

- Support Pandas 2
- Drop support for Pandas 1.4
- Drop support for NumPy 1.22