### PR TITLE
Expand build matrix for Apple Silicon & MacOS vanilla Python builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   conda:
     name: Conda Python ${{matrix.python}} on ${{matrix.platform}}
-    runs-on: ${{matrix.platform}}-latest
+    runs-on: ${{matrix.platform}}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -139,7 +139,7 @@ jobs:
 
   vanilla:
     name: Vanilla Python ${{matrix.python}} on ${{matrix.platform}}
-    runs-on: ${{matrix.platform}}-latest
+    runs-on: ${{matrix.platform}}
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Set up dependencies
         run: |
           python -m pip install -U 'uv>=0.1.13'
-          uv pip install --prefer-binary --system -e '.[test]'
+          uv pip install --system -e '.[test]'
 
       - name: Inspect environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,10 @@ jobs:
         - "3.10"
         - "3.11"
         platform:
-        - macos
-        - windows
-        - ubuntu
+        - macos-latest
+        - macos-14
+        - windows-latest
+        - ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,8 @@ jobs:
 
       - name: Set up dependencies
         run: |
-          pip install -e '.[test]'
+          python -m pip install -U 'uv>=0.1.13'
+          uv pip install --prefer-binary --system -e '.[test]'
 
       - name: Inspect environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,6 @@ jobs:
         platform:
         - windows-latest
         - ubuntu-latest
-        - macos-latest
         - macos-14
     steps:
       - name: Check out source

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,8 +148,10 @@ jobs:
         - "3.10"
         - "3.11"
         platform:
-        - windows
-        - ubuntu
+        - windows-latest
+        - ubuntu-latest
+        - macos-latest
+        - macos-14
     steps:
       - name: Check out source
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Set up dependencies
         run: |
           python -m pip install -U 'uv>=0.1.13'
-          uv pip install --system -e '.[test]'
+          pip install --prefer-binary -e '.[test]'
 
       - name: Inspect environment
         run: |


### PR DESCRIPTION
This adds Apple Silicon to the test matrix for both Conda and vanilla runs. Intel macOS can't correctly install dependencies for some reason.