### PR TITLE
Fix minimum dependency build for uv and doctestplus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install build tools
-        run: python -m pip install -U 'uv>=0.1.13'
+        run: python -m pip install -U 'uv>=0.1.15'
 
       - name: Set up Python deps
         run: uv pip install --system --resolution=lowest-direct -e '.[test]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,11 +195,11 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Install build tools
+        run: python -m pip install -U 'uv>=0.1.13'
+
       - name: Set up Python deps
-        run: |
-          set -e
-          python -m pip install -U 'uv>=0.1.13'
-          uv pip install --system --resolution=lowest-direct -e '.[test]'
+        run: uv pip install --system --resolution=lowest-direct -e '.[test]'
 
       - name: Inspect environment
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
 ]
 test = [
   "pytest ==7.*",
-  "pytest-doctestplus >= 0.9",
+  "pytest-doctestplus ==1.*",
   "pytest-cov >= 2.12",
   "coverage >= 5",
   "hypothesis >= 6",


### PR DESCRIPTION
This fixes 2 problems with the minimum dependency tests:

- uv 0.1.14 broke resolution
- doctestplus 0.9 doesn't work with modern pytest