### PR TITLE
Documentation fix for Recall and Hit

### DIFF
--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -74,7 +74,7 @@ def recall(recs, truth, k=None):
     Compute recommendation recall.  This is computed as:
 
     .. math::
-        \\frac{|L \\cap I_u^{\\mathrm{test}}|}{\\operatorname{max}\\{|I_u^{\\mathrm{test}}|, k\\}}
+        \\frac{|L \\cap I_u^{\\mathrm{test}}|}{\\operatorname{min}\\{|I_u^{\\mathrm{test}}|, k\\}}
 
     This metric has a bulk implementation.
     """
@@ -120,7 +120,7 @@ def hit(recs, truth, k=None):
     lists, this computes the *hit rate* :cite:p:`Deshpande2004-ht`.
 
     .. math::
-        \\frac{|L \\cap I_u^{\\mathrm{test}}|}{\\operatorname{max}\\{|I_u^{\\mathrm{test}}|, k\\}}
+        \\frac{|L \\cap I_u^{\\mathrm{test}}|}{\\operatorname{min}\\{|I_u^{\\mathrm{test}}|, k\\}}
 
     This metric has a bulk implementation.
     """

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -122,7 +122,10 @@ def hit(recs, truth, k=None):
     This metric has a bulk implementation.
     """
 
-    if k is not None:        
+    if len(truth) == 0:
+        return None
+
+    if k is not None:
         recs = recs.iloc[:k]
 
     good = recs["item"].isin(truth.index)

--- a/lenskit/metrics/topn.py
+++ b/lenskit/metrics/topn.py
@@ -119,17 +119,10 @@ def hit(recs, truth, k=None):
     is scored as 1, and lists with no relevant items as 0.  When averaged over the recommendation
     lists, this computes the *hit rate* :cite:p:`Deshpande2004-ht`.
 
-    .. math::
-        \\frac{|L \\cap I_u^{\\mathrm{test}}|}{\\operatorname{min}\\{|I_u^{\\mathrm{test}}|, k\\}}
-
     This metric has a bulk implementation.
     """
-    nrel = len(truth)
-    if nrel == 0:
-        return None
 
-    if k is not None:
-        nrel = min(nrel, k)
+    if k is not None:        
         recs = recs.iloc[:k]
 
     good = recs["item"].isin(truth.index)


### PR DESCRIPTION
The documentation contains max rather than min functions. Min functions are used in the implementation.