### PR TITLE
Remove x86 macOS CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         - "3.11"
         platform:
         - macos-latest
-        - macos-14
         - windows-latest
         - ubuntu-latest
 
@@ -151,7 +150,7 @@ jobs:
         platform:
         - windows-latest
         - ubuntu-latest
-        - macos-14
+        - macos-latest
     steps:
       - name: Check out source
         uses: actions/checkout@v4


### PR DESCRIPTION
This removes separate `macos-latest` and `macos-14` CI runs, only running on `macos-latest` (and therefore only running on Apple Silicon Macs).

The last Intel Macs were released in 2020. We will not actively un-support Intel Macs, but CI testing is not a priority.