### PR TITLE
Add sparse matrix normalization routines + sparse util tests

### DIFF
--- a/lenskit/data/matrix.py
+++ b/lenskit/data/matrix.py
@@ -167,3 +167,36 @@ def sparse_row_stats(matrix: t.Tensor) -> DimStats:
     means = sums / counts
 
     return DimStats(n, n_other, counts, sums, means)
+
+
+@overload
+def normalize_sparse_rows(
+    matrix: t.Tensor, method: Literal["center"], inplace: bool = False
+) -> tuple[t.Tensor, t.Tensor]: ...
+@overload
+def normalize_sparse_rows(
+    matrix: t.Tensor, method: Literal["unit"], inplace: bool = False
+) -> tuple[t.Tensor, t.Tensor]: ...
+def normalize_sparse_rows(
+    matrix: t.Tensor, method: str, inplace: bool = False
+) -> tuple[t.Tensor, t.Tensor]:
+    """
+    Normalize the rows of a sparse matrix.
+    """
+    match method:
+        case "unit":
+            return _nsr_unit(matrix)
+        case "mean":
+            return _nsr_mean_center(matrix)
+        case _:
+            raise ValueError(f"unsupported normalization method {method}")
+
+
+def _nsr_mean_center(matrix: t.Tensor) -> tuple[t.Tensor, t.Tensor]:
+    stats = sparse_row_stats(matrix)
+    return t.sparse_csr_tensor(
+        crow_indices=matrix.crow_indices(),
+        col_indices=matrix.col_indices(),
+        values=matrix.values() - t.repeat_interleave(stats.means, stats.counts),
+        size=matrix.shape,
+    ), stats.means

--- a/lenskit/util/test.py
+++ b/lenskit/util/test.py
@@ -70,7 +70,7 @@ def set_env_var(var, val):
 @st.composite
 def sparse_tensors(draw, shape=None):
     if shape is None:
-        shape = st.tuples(st.integers(1, 500), st.integers(1, 500))
+        shape = st.tuples(st.integers(1, 100), st.integers(1, 100))
 
     if isinstance(shape, st.SearchStrategy):
         shape = draw(shape)

--- a/lenskit/util/test.py
+++ b/lenskit/util/test.py
@@ -12,7 +12,13 @@ import os
 import os.path
 from contextlib import contextmanager
 
+import numpy as np
+import torch
+
+import hypothesis.extra.numpy as nph
+import hypothesis.strategies as st
 import pytest
+from hypothesis import assume
 
 from lenskit.algorithms.basic import PopScore
 from lenskit.algorithms.ranking import PlackettLuce
@@ -59,6 +65,40 @@ def set_env_var(var, val):
             os.environ[var] = old_val
         elif val is not None:
             del os.environ[var]
+
+
+@st.composite
+def sparse_tensors(draw, shape=None):
+    if shape is None:
+        shape = st.tuples(st.integers(1, 500), st.integers(1, 500))
+
+    if isinstance(shape, st.SearchStrategy):
+        shape = draw(shape)
+
+    if not isinstance(shape, tuple):
+        shape = shape, shape
+    rows, cols = shape
+    if isinstance(rows, st.SearchStrategy):
+        rows = draw(rows)
+    if isinstance(cols, st.SearchStrategy):
+        cols = draw(cols)
+
+    total = rows * cols
+
+    mask = draw(nph.arrays(np.bool_, total))
+    assume(np.any(mask))
+    mask = mask.reshape(rows, cols)
+
+    vals = st.floats(-10e6, 10e6, allow_nan=False, allow_infinity=False, width=32)
+    matrix = draw(
+        nph.arrays(np.float32, (rows, cols), elements=vals),
+    )
+
+    # fill in the zeros
+    matrix[mask] = 0
+
+    tensor = torch.from_numpy(matrix)
+    return tensor.to_sparse_csr()
 
 
 jit_enabled = True

--- a/tests/test_matrix_rows.py
+++ b/tests/test_matrix_rows.py
@@ -11,7 +11,7 @@ import torch
 
 import hypothesis.extra.numpy as nph
 import hypothesis.strategies as st
-from hypothesis import assume, given
+from hypothesis import HealthCheck, assume, given, settings
 from pytest import approx, mark
 
 from lenskit.data.matrix import sparse_row_stats
@@ -20,6 +20,7 @@ from lenskit.util.test import sparse_tensors
 _log = logging.getLogger(__name__)
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(sparse_tensors())
 def test_sparse_stats(tensor):
     nr, nc = tensor.shape

--- a/tests/test_matrix_rows.py
+++ b/tests/test_matrix_rows.py
@@ -39,7 +39,7 @@ def test_sparse_stats(tensor):
     assert tots.numpy()[mask] == approx(sums.numpy()[mask])
 
 
-@settings(deadline=500, suppress_health_check=[HealthCheck.too_slow])
+@settings(deadline=1000, suppress_health_check=[HealthCheck.too_slow])
 @given(sparse_tensors())
 def test_sparse_mean_center(tensor):
     nr, nc = tensor.shape
@@ -55,7 +55,7 @@ def test_sparse_mean_center(tensor):
         assert nr == approx(tr - means[i].numpy())
 
 
-@settings(deadline=500, suppress_health_check=[HealthCheck.too_slow])
+@settings(deadline=1000, suppress_health_check=[HealthCheck.too_slow])
 @given(sparse_tensors())
 def test_sparse_unit_norm(tensor):
     nr, nc = tensor.shape

--- a/tests/test_matrix_rows.py
+++ b/tests/test_matrix_rows.py
@@ -1,0 +1,38 @@
+"""
+Tests for matrix row utilities.
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sps
+import torch
+
+import hypothesis.extra.numpy as nph
+import hypothesis.strategies as st
+from hypothesis import assume, given
+from pytest import approx, mark
+
+from lenskit.data.matrix import sparse_row_stats
+from lenskit.util.test import sparse_tensors
+
+_log = logging.getLogger(__name__)
+
+
+@given(sparse_tensors())
+def test_sparse_stats(tensor):
+    nr, nc = tensor.shape
+    _log.debug("tensor: %d x %d", nr, nc)
+
+    stats = sparse_row_stats(tensor)
+    assert stats.means.shape == (nr,)
+    assert stats.counts.shape == (nr,)
+
+    assert np.sum(stats.counts.numpy()) == tensor.values().shape[0]
+
+    sums = tensor.sum(dim=1, keepdim=True)
+    sums = sums.to_dense().reshape(-1)
+    tots = stats.means * stats.counts
+    mask = stats.counts.numpy() > 0
+    assert tots.numpy()[mask] == approx(sums.numpy()[mask])

--- a/tests/test_matrix_rows.py
+++ b/tests/test_matrix_rows.py
@@ -39,6 +39,7 @@ def test_sparse_stats(tensor):
     assert tots.numpy()[mask] == approx(sums.numpy()[mask])
 
 
+@settings(deadline=500, suppress_health_check=[HealthCheck.too_slow])
 @given(sparse_tensors())
 def test_sparse_mean_center(tensor):
     nr, nc = tensor.shape
@@ -54,7 +55,7 @@ def test_sparse_mean_center(tensor):
         assert nr == approx(tr - means[i].numpy())
 
 
-@settings(deadline=500)
+@settings(deadline=500, suppress_health_check=[HealthCheck.too_slow])
 @given(sparse_tensors())
 def test_sparse_unit_norm(tensor):
     nr, nc = tensor.shape

--- a/tests/test_matrix_rows.py
+++ b/tests/test_matrix_rows.py
@@ -44,7 +44,7 @@ def test_sparse_mean_center(tensor):
     nr, nc = tensor.shape
 
     stats = sparse_row_stats(tensor)
-    nt, means = normalize_sparse_rows(tensor, "mean")
+    nt, means = normalize_sparse_rows(tensor, "center")
 
     assert means.numpy() == approx(stats.means.numpy(), nan_ok=True)
 
@@ -52,3 +52,20 @@ def test_sparse_mean_center(tensor):
         tr = tensor[i].values().numpy()
         nr = nt[i].values().numpy()
         assert nr == approx(tr - means[i].numpy())
+
+
+@settings(deadline=500)
+@given(sparse_tensors())
+def test_sparse_unit_norm(tensor):
+    nr, nc = tensor.shape
+
+    nt, norms = normalize_sparse_rows(tensor, "unit")
+
+    assert norms.numpy() == approx(
+        torch.linalg.vector_norm(tensor.to_dense(), dim=1).numpy(), rel=1.0e-3
+    )
+
+    for i in range(nr):
+        tr = tensor[i].values().numpy()
+        nr = nt[i].values().numpy()
+        assert nr * norms[i].numpy() == approx(tr)


### PR DESCRIPTION
This makes a few sequenced changes to improve sparse matrix utilities and testing:

1. Add a `sparse_tensors` Hypothesis generator to `lenskit.util.test`.
2. Add tests for `sparse_row_stats`.
3. Add `normalize_sparse_rows` function to normalize rows of a CSR matrix, with tests.
4. Use `normalize_sparse_rows` in item KNN.