### PR TITLE
Implement user-kNN with Torch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,6 @@ jobs:
         - windows-latest
         - ubuntu-latest
         - macos-latest
-        - macos-13
     steps:
       - name: Check out source
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,7 @@ jobs:
         - windows-latest
         - ubuntu-latest
         - macos-latest
+        - macos-13
     steps:
       - name: Check out source
         uses: actions/checkout@v4

--- a/envs/lenskit-py3.10-ci.yaml
+++ b/envs/lenskit-py3.10-ci.yaml
@@ -8,8 +8,8 @@
 # Instead edit the corresponding pyproject.toml file.
 #
 channels:
-  - conda-forge
   - pytorch
+  - conda-forge
   - nodefaults
 dependencies:
   - python=3.10
@@ -33,7 +33,7 @@ dependencies:
   - pytest-repeat>=0.9
   - pytest==7.*
   - python-build==1
-  - pytorch==2.*
+  - pytorch<3,>=2.1
   - ruff>=0.2
   - scikit-learn>=1.1
   - scipy>=1.9.0

--- a/envs/lenskit-py3.10-ci.yaml
+++ b/envs/lenskit-py3.10-ci.yaml
@@ -30,6 +30,7 @@ dependencies:
   - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
+  - pytest-repeat>=0.9
   - pytest==7.*
   - python-build==1
   - pytorch==2.*

--- a/envs/lenskit-py3.10-dev.yaml
+++ b/envs/lenskit-py3.10-dev.yaml
@@ -35,6 +35,7 @@ dependencies:
   - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
+  - pytest-repeat>=0.9
   - pytest==7.*
   - python-build==1
   - pytorch==2.*

--- a/envs/lenskit-py3.10-dev.yaml
+++ b/envs/lenskit-py3.10-dev.yaml
@@ -8,8 +8,8 @@
 # Instead edit the corresponding pyproject.toml file.
 #
 channels:
-  - conda-forge
   - pytorch
+  - conda-forge
   - nodefaults
 dependencies:
   - python=3.10
@@ -38,7 +38,7 @@ dependencies:
   - pytest-repeat>=0.9
   - pytest==7.*
   - python-build==1
-  - pytorch==2.*
+  - pytorch<3,>=2.1
   - ruff>=0.2
   - scikit-learn>=1.1
   - scipy>=1.9.0

--- a/envs/lenskit-py3.10-doc.yaml
+++ b/envs/lenskit-py3.10-doc.yaml
@@ -8,8 +8,8 @@
 # Instead edit the corresponding pyproject.toml file.
 #
 channels:
-  - conda-forge
   - pytorch
+  - conda-forge
   - nodefaults
 dependencies:
   - python=3.10
@@ -20,7 +20,7 @@ dependencies:
   - numba<0.59,>=0.56
   - numpy>=1.23
   - pandas<3,>=1.5
-  - pytorch==2.*
+  - pytorch<3,>=2.1
   - scipy>=1.9.0
   - sphinx>=4.2
   - sphinx_rtd_theme>=0.5

--- a/envs/lenskit-py3.10-test.yaml
+++ b/envs/lenskit-py3.10-test.yaml
@@ -24,6 +24,7 @@ dependencies:
   - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
+  - pytest-repeat>=0.9
   - pytest==7.*
   - pytorch==2.*
   - scipy>=1.9.0

--- a/envs/lenskit-py3.10-test.yaml
+++ b/envs/lenskit-py3.10-test.yaml
@@ -8,8 +8,8 @@
 # Instead edit the corresponding pyproject.toml file.
 #
 channels:
-  - conda-forge
   - pytorch
+  - conda-forge
   - nodefaults
 dependencies:
   - python=3.10
@@ -26,7 +26,7 @@ dependencies:
   - pytest-doctestplus==1.*
   - pytest-repeat>=0.9
   - pytest==7.*
-  - pytorch==2.*
+  - pytorch<3,>=2.1
   - scipy>=1.9.0
   - tbb
   - threadpoolctl>=3.0

--- a/envs/lenskit-py3.11-ci.yaml
+++ b/envs/lenskit-py3.11-ci.yaml
@@ -8,8 +8,8 @@
 # Instead edit the corresponding pyproject.toml file.
 #
 channels:
-  - conda-forge
   - pytorch
+  - conda-forge
   - nodefaults
 dependencies:
   - python=3.11
@@ -33,7 +33,7 @@ dependencies:
   - pytest-repeat>=0.9
   - pytest==7.*
   - python-build==1
-  - pytorch==2.*
+  - pytorch<3,>=2.1
   - ruff>=0.2
   - scikit-learn>=1.1
   - scipy>=1.9.0

--- a/envs/lenskit-py3.11-ci.yaml
+++ b/envs/lenskit-py3.11-ci.yaml
@@ -30,6 +30,7 @@ dependencies:
   - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
+  - pytest-repeat>=0.9
   - pytest==7.*
   - python-build==1
   - pytorch==2.*

--- a/envs/lenskit-py3.11-dev.yaml
+++ b/envs/lenskit-py3.11-dev.yaml
@@ -35,6 +35,7 @@ dependencies:
   - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
+  - pytest-repeat>=0.9
   - pytest==7.*
   - python-build==1
   - pytorch==2.*

--- a/envs/lenskit-py3.11-dev.yaml
+++ b/envs/lenskit-py3.11-dev.yaml
@@ -8,8 +8,8 @@
 # Instead edit the corresponding pyproject.toml file.
 #
 channels:
-  - conda-forge
   - pytorch
+  - conda-forge
   - nodefaults
 dependencies:
   - python=3.11
@@ -38,7 +38,7 @@ dependencies:
   - pytest-repeat>=0.9
   - pytest==7.*
   - python-build==1
-  - pytorch==2.*
+  - pytorch<3,>=2.1
   - ruff>=0.2
   - scikit-learn>=1.1
   - scipy>=1.9.0

--- a/envs/lenskit-py3.11-doc.yaml
+++ b/envs/lenskit-py3.11-doc.yaml
@@ -8,8 +8,8 @@
 # Instead edit the corresponding pyproject.toml file.
 #
 channels:
-  - conda-forge
   - pytorch
+  - conda-forge
   - nodefaults
 dependencies:
   - python=3.11
@@ -20,7 +20,7 @@ dependencies:
   - numba<0.59,>=0.56
   - numpy>=1.23
   - pandas<3,>=1.5
-  - pytorch==2.*
+  - pytorch<3,>=2.1
   - scipy>=1.9.0
   - sphinx>=4.2
   - sphinx_rtd_theme>=0.5

--- a/envs/lenskit-py3.11-test.yaml
+++ b/envs/lenskit-py3.11-test.yaml
@@ -24,6 +24,7 @@ dependencies:
   - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
+  - pytest-repeat>=0.9
   - pytest==7.*
   - pytorch==2.*
   - scipy>=1.9.0

--- a/envs/lenskit-py3.11-test.yaml
+++ b/envs/lenskit-py3.11-test.yaml
@@ -8,8 +8,8 @@
 # Instead edit the corresponding pyproject.toml file.
 #
 channels:
-  - conda-forge
   - pytorch
+  - conda-forge
   - nodefaults
 dependencies:
   - python=3.11
@@ -26,7 +26,7 @@ dependencies:
   - pytest-doctestplus==1.*
   - pytest-repeat>=0.9
   - pytest==7.*
-  - pytorch==2.*
+  - pytorch<3,>=2.1
   - scipy>=1.9.0
   - tbb
   - threadpoolctl>=3.0

--- a/lenskit/algorithms/knn/user.py
+++ b/lenskit/algorithms/knn/user.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import torch
-from typing_extensions import NamedTuple, Optional, Self
+from typing_extensions import Any, NamedTuple, Optional, Self
 
 from lenskit import DataWarning, util
 from lenskit.data import FeedbackType, sparse_ratings
@@ -79,8 +79,10 @@ class UserUser(Predictor):
     aggregate: str
     use_ratings: bool
 
-    user_index_: pd.Index
+    user_index_: pd.Index[Any]
     "The index of user IDs."
+    item_index_: pd.Index[Any]
+    "The index of item IDs."
     user_means_: torch.Tensor | None
     "Mean rating for each known user."
     user_vectors_: torch.Tensor

--- a/lenskit/algorithms/knn/user.py
+++ b/lenskit/algorithms/knn/user.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import NamedTuple, Optional
 
 import numpy as np
 import pandas as pd
 import torch
+from typing_extensions import NamedTuple, Optional, Self
 
 from lenskit import DataWarning, util
 from lenskit.data import FeedbackType, sparse_ratings
@@ -122,7 +122,7 @@ class UserUser(Predictor):
         if self.aggregate not in [self.AGG_WA, self.AGG_SUM]:
             raise ValueError(f"invalid aggregate {self.aggregate}")
 
-    def fit(self, ratings, **kwargs):
+    def fit(self, ratings: pd.DataFrame, **kwargs) -> Self:
         """
         "Train" a user-user CF model.  This memorizes the rating data in a format that is usable
         for future computations.

--- a/lenskit/algorithms/knn/user.py
+++ b/lenskit/algorithms/knn/user.py
@@ -224,7 +224,7 @@ class UserUser(Predictor):
 
         scores += umean
 
-        results = pd.Series(scores.numpy(), index=items[ki_mask], name="prediction")
+        results = pd.Series(scores.numpy(), index=items[ki_mask.numpy()], name="prediction")
         results = results.reindex(items)
 
         _log.debug(

--- a/lenskit/algorithms/knn/user.py
+++ b/lenskit/algorithms/knn/user.py
@@ -334,9 +334,7 @@ def score_items_with_neighbors(
         results /= tot_sims
 
     # clear out too-small neighborhoods
-    assert torch.min(counts) >= 1
-    if min_nbrs > 1:
-        results[counts < min_nbrs] = torch.nan
+    results[counts < min_nbrs] = torch.nan
 
     # deal with too-large items
     exc_mask = counts > max_nbrs

--- a/lenskit/algorithms/knn/user.py
+++ b/lenskit/algorithms/knn/user.py
@@ -178,7 +178,7 @@ class UserUser(Predictor):
             return pd.Series(index=items, dtype="float32")
 
         uidx, ratings, umean = udata
-        _log.debug("scoring %d items for user %s (idx %d)", len(items), user, uidx)
+        _log.debug("scoring %d items for user %s (idx %d)", len(items), user, uidx or -1)
         assert ratings.shape == (len(self.item_index_),)  # ratings is a dense vector
 
         # now ratings has vbeen normalized to be a mean-centered unit vector

--- a/lenskit/algorithms/knn/user.py
+++ b/lenskit/algorithms/knn/user.py
@@ -322,16 +322,16 @@ def score_items_with_neighbors(
         values=nbr_rates.values()[r_mask],
         size=nbr_rates.shape,
     ).coalesce()
-    results = safe_spmv(nbr_fp.transpose(0, 1), nbr_sims)
+    results = torch.mv(nbr_fp.transpose(0, 1), nbr_sims)
 
     if average:
         nnz = len(nbr_fp.values())
         nbr_fp_ones = torch.sparse_coo_tensor(
-            indices=nbr_rates.indices()[:, r_mask],
+            indices=nbr_fp.indices(),
             values=torch.ones(nnz),
             size=nbr_rates.shape,
         )
-        tot_sims = safe_spmv(nbr_fp_ones.transpose(0, 1), nbr_sims)
+        tot_sims = torch.mv(nbr_fp_ones.transpose(0, 1), nbr_sims)
         assert torch.all(torch.isfinite(tot_sims))
         results /= tot_sims
 

--- a/lenskit/algorithms/knn/user.py
+++ b/lenskit/algorithms/knn/user.py
@@ -313,7 +313,7 @@ def score_items_with_neighbors(
     exc_mask = counts > max_nbrs
     if torch.any(exc_mask):
         _log.debug("scoring %d slow-path items", torch.sum(exc_mask))
-    for badi in items[exc_mask]:
+    for badi in torch.arange(ni)[exc_mask]:
         col = nbr_t[badi]
         assert col.shape == nbr_rates.shape[:1]
 

--- a/lenskit/batch/_predict.py
+++ b/lenskit/batch/_predict.py
@@ -21,7 +21,7 @@ def _predict_user(model, req):
     res = model.predict_for_user(user, udf["item"])
     res = pd.DataFrame({"user": user, "item": res.index, "prediction": res.values})
     _logger.debug(
-        "%s produced %f/%d predictions for %s in %s",
+        "%s produced %d/%d predictions for %s in %s",
         model,
         res.prediction.notna().sum(),
         len(udf),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "numpy >= 1.23",
   "scipy >= 1.9.0",
   "numba >= 0.56, < 0.59",
-  "torch ~=2.1",            # p2c: -s pytorch==2.*
+  "torch ~=2.1",            # p2c: -s pytorch>=2.1,<3
   "threadpoolctl >=3.0",
   "binpickle >= 0.3.2",
   "seedbank >= 0.2.0a2",    # p2c: -p
@@ -103,7 +103,7 @@ version_scheme = "release-branch-semver"
 
 # settings for generating conda environments for dev & CI, when needed
 [tool.pyproject2conda]
-channels = ["conda-forge", "pytorch", "nodefaults"]
+channels = ["pytorch", "conda-forge", "nodefaults"]
 python = ["3.10", "3.11"]
 default_envs = ["test", "doc"]
 template_python = "envs/lenskit-py{py_version}-{env}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ test = [
   "pytest-doctestplus ==1.*",
   "pytest-cov >= 2.12",
   "pytest-benchmark ==4.*",
+  "pytest-repeat >=0.9",
   "coverage >= 5",
   "hypothesis >= 6",
 ]

--- a/tests/test_knn_user_user.py
+++ b/tests/test_knn_user_user.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import torch
-from scipy.sparse import linalg as spla
 
 from pytest import approx, fail, mark
 
@@ -19,8 +18,6 @@ import lenskit.algorithms.knn.user as knn
 import lenskit.util.test as lktu
 from lenskit.algorithms import Recommender
 from lenskit.util import clone
-
-pytestmark = mark.skip("temporarily disabled while fixing")
 
 _log = logging.getLogger(__name__)
 

--- a/tests/test_knn_user_user.py
+++ b/tests/test_knn_user_user.py
@@ -246,7 +246,7 @@ def test_uu_known_preds():
     pairs = known_preds.loc[:, ["user", "item"]]
     _log.info("generating %d known predictions", len(pairs))
 
-    preds = batch.predict(algo, pairs)
+    preds = batch.predict(algo, pairs, n_jobs=1)
     merged = pd.merge(known_preds.rename(columns={"prediction": "expected"}), preds)
     assert len(merged) == len(preds)
     merged["error"] = merged.expected - merged.prediction

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -155,4 +155,4 @@ def test_safe_spmv(data):
     tv = torch.from_numpy(v)
 
     tres = safe_spmv(TM, tv)
-    assert tres.cpu().numpy() == approx(res, rel=1.0e-4, abs=1.0e-6)
+    assert tres.cpu().numpy() == approx(res, rel=1.0e-4, abs=1.0e-5)


### PR DESCRIPTION
This advances #374 by implementing user k-NN with Torch. It does not contain all code, as some was accidentally merged into `main` earlier, but finishes it and makes tests pass. Closes #377.