### PR TITLE
Add Torch matrix test + improve sparse matrix hypothesis infra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
         - macos-latest
         - windows-latest
         - ubuntu-latest
+        - macos-13
 
     steps:
       - uses: actions/checkout@v4

--- a/conftest.py
+++ b/conftest.py
@@ -49,6 +49,8 @@ def torch_device(request):
     dev = request.param
     if dev == "cuda" and not torch.cuda.is_available():
         skip("CUDA not available")
+    if dev == "mps" and not torch.backends.mps.is_available():
+        skip("MPS not available")
     yield dev
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,8 @@ from seedbank import initialize, numpy_rng
 from hypothesis import settings
 from pytest import fixture, skip
 
+from lenskit.parallel import ensure_parallel_init
+
 logging.getLogger("numba").setLevel(logging.INFO)
 
 _log = logging.getLogger("lenskit.tests")
@@ -72,3 +74,4 @@ def pytest_collection_modifyitems(items):
 
 
 settings.register_profile("default", deadline=1000)
+ensure_parallel_init()

--- a/conftest.py
+++ b/conftest.py
@@ -8,10 +8,11 @@ import logging
 import os
 import warnings
 
+import torch
 from seedbank import initialize, numpy_rng
 
-from pytest import fixture
 from hypothesis import settings
+from pytest import fixture, skip
 
 logging.getLogger("numba").setLevel(logging.INFO)
 
@@ -36,6 +37,19 @@ def init_rng(request):
         initialize(os.urandom(4))
     else:
         initialize(RNG_SEED)
+
+
+@fixture(scope="module", params=["cpu", "cuda"])
+def torch_device(request):
+    """
+    Fixture for testing across Torch devices.  This fixture is parameterized, so
+    if you write a test function with a parameter ``torch_device`` as its first
+    parameter, it will be called once for each available Torch device.
+    """
+    dev = request.param
+    if dev == "cuda" and not torch.cuda.is_available():
+        skip("CUDA not available")
+    yield dev
 
 
 @fixture(autouse=True)

--- a/envs/lenskit-py3.10-ci.yaml
+++ b/envs/lenskit-py3.10-ci.yaml
@@ -27,6 +27,7 @@ dependencies:
   - pandas<3,>=1.5
   - pyarrow>=15
   - pyproject2conda~=0.11
+  - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
   - pytest==7.*

--- a/envs/lenskit-py3.10-dev.yaml
+++ b/envs/lenskit-py3.10-dev.yaml
@@ -32,6 +32,7 @@ dependencies:
   - pandas<3,>=1.5
   - pyarrow>=15
   - pyproject2conda~=0.11
+  - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
   - pytest==7.*

--- a/envs/lenskit-py3.10-test.yaml
+++ b/envs/lenskit-py3.10-test.yaml
@@ -21,6 +21,7 @@ dependencies:
   - numba<0.59,>=0.56
   - numpy>=1.23
   - pandas<3,>=1.5
+  - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
   - pytest==7.*

--- a/envs/lenskit-py3.11-ci.yaml
+++ b/envs/lenskit-py3.11-ci.yaml
@@ -27,6 +27,7 @@ dependencies:
   - pandas<3,>=1.5
   - pyarrow>=15
   - pyproject2conda~=0.11
+  - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
   - pytest==7.*

--- a/envs/lenskit-py3.11-dev.yaml
+++ b/envs/lenskit-py3.11-dev.yaml
@@ -32,6 +32,7 @@ dependencies:
   - pandas<3,>=1.5
   - pyarrow>=15
   - pyproject2conda~=0.11
+  - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
   - pytest==7.*

--- a/envs/lenskit-py3.11-test.yaml
+++ b/envs/lenskit-py3.11-test.yaml
@@ -21,6 +21,7 @@ dependencies:
   - numba<0.59,>=0.56
   - numpy>=1.23
   - pandas<3,>=1.5
+  - pytest-benchmark==4.*
   - pytest-cov>=2.12
   - pytest-doctestplus==1.*
   - pytest==7.*

--- a/lenskit/data/matrix.py
+++ b/lenskit/data/matrix.py
@@ -230,7 +230,9 @@ def torch_sparse_from_scipy(
     cis = t.from_numpy(M.col)
     vs = t.from_numpy(M.data)
     indices = t.stack([ris, cis])
+    assert indices.shape == (2, M.nnz)
     T = t.sparse_coo_tensor(indices, vs, size=M.shape)
+    assert T.shape == M.shape
 
     match layout:
         case "csr":

--- a/lenskit/data/matrix.py
+++ b/lenskit/data/matrix.py
@@ -238,6 +238,6 @@ def torch_sparse_from_scipy(
         case "csc":
             return T.to_sparse_csc()
         case "coo":
-            return T
+            return T.coalesce()
         case _:
             raise ValueError(f"invalid layout {layout}")

--- a/lenskit/util/test.py
+++ b/lenskit/util/test.py
@@ -8,14 +8,12 @@
 Test utilities for LKPY tests.
 """
 
-import math
 import os
 import os.path
 from contextlib import contextmanager
 
 import numpy as np
 import scipy.sparse as sps
-import torch
 
 import hypothesis.extra.numpy as nph
 import hypothesis.strategies as st
@@ -52,19 +50,16 @@ def demo_recs():
 @contextmanager
 def set_env_var(var, val):
     "Set an environment variable & restore it."
-    is_set = var in os.environ
-    old_val = None
-    if is_set:
-        old_val = os.environ[var]
+    old_val = os.environ.get(var, None)
     try:
         if val is None:
-            if is_set:
+            if old_val is not None:
                 del os.environ[var]
         else:
             os.environ[var] = val
         yield
     finally:
-        if is_set:
+        if old_val is not None:
             os.environ[var] = old_val
         elif val is not None:
             del os.environ[var]

--- a/lenskit/util/test.py
+++ b/lenskit/util/test.py
@@ -75,7 +75,7 @@ def coo_arrays(
     draw,
     shape=None,
     dtype=nph.floating_dtypes(endianness="=", sizes=[32, 64]),
-    elements=st.floats(-10e6, 10e6, allow_nan=False, allow_infinity=False, width=32),
+    elements=st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False, width=32),
 ) -> sps.coo_array:
     if shape is None:
         shape = st.tuples(st.integers(1, 100), st.integers(1, 100))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
   "pytest ==7.*",
   "pytest-doctestplus ==1.*",
   "pytest-cov >= 2.12",
+  "pytest-benchmark ==4.*",
   "coverage >= 5",
   "hypothesis >= 6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ log_format = "[%(levelname)7s] [%(processName)s] %(name)s %(message)s"
 log_cli_format = "[%(levelname)7s] %(asctime)s [%(processName)s] %(name)s %(message)s"
 log_file_format = "[%(levelname)7s] %(asctime)s [%(processName)s] %(name)s %(message)s"
 log_file_level = "DEBUG"
+addopts = "--benchmark-skip"
 testpaths = [
   "tests",
   "lenskit",

--- a/tests/test_math_spmv.py
+++ b/tests/test_math_spmv.py
@@ -1,0 +1,162 @@
+"""
+Tests for matrix-vector multiplication to make sure it works properly.
+
+Bug: https://github.com/pytorch/pytorch/issues/127491
+"""
+
+import numpy as np
+import torch
+
+import hypothesis.extra.numpy as nph
+import hypothesis.strategies as st
+from hypothesis import HealthCheck, given, note, settings
+from pytest import approx, mark
+
+
+def draw_problem(
+    data, nrows: int, ncols: int, dtype=np.float64
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    # draw the initial matrix
+    M = data.draw(
+        nph.arrays(
+            dtype,
+            (nrows, ncols),
+            elements=st.floats(
+                -1e4,
+                1e4,
+                allow_nan=False,
+                allow_infinity=False,
+                width=np.finfo(dtype).bits,  # type: ignore
+            ),
+        )
+    )
+    # draw the vector
+    v = data.draw(
+        nph.arrays(
+            dtype,
+            ncols,
+            elements=st.floats(
+                -1e4,
+                1e4,
+                allow_nan=False,
+                allow_infinity=False,
+                width=np.finfo(dtype).bits,  # type: ignore
+            ),
+        )
+    )
+    # zero out items in the matrix
+    mask = data.draw(nph.arrays(np.bool_, (nrows, ncols)))
+    M[~mask] = 0.0
+    nnz = np.sum(M != 0.0)
+    note("matrix {} x {} ({} nnz)".format(nrows, ncols, nnz))
+
+    # multiply them (dense operation with NumPy) to get expected result
+    res = M @ v
+    # just make sure everything's finite, should always pass due to data limits
+    assert np.all(np.isfinite(res))
+
+    return M, v, res
+
+
+def tolerances(dtype=np.float64):
+    # make our tolerance depend on the data type we got
+    if dtype == np.float64:
+        rtol, atol = 1.0e-5, 1.0e-4
+    elif dtype == np.float32:
+        rtol, atol = 0.05, 1.0e-3
+    else:
+        raise TypeError(f"unexpected data type {dtype}")
+    return rtol, atol
+
+
+def torchify(M, v, res, rtol, atol) -> tuple[torch.Tensor, torch.Tensor]:
+    T = torch.from_numpy(M)
+    tv = torch.from_numpy(v)
+    assert torch.mv(T, tv).numpy() == approx(res, rel=rtol, abs=atol)
+    return T, tv
+
+
+def torch_test(func):
+    wrapped = given(st.data(), st.integers(1, 500), st.integers(1, 500))(func)
+    wrapped = settings(
+        deadline=1000, max_examples=500, suppress_health_check=[HealthCheck.too_slow]
+    )(wrapped)
+    return wrapped
+
+
+@torch_test
+def test_torch_spmv_coo(data, nrows, ncols):
+    rtol, atol = tolerances(np.float64)
+    M, v, res = draw_problem(data, nrows, ncols)
+    T, tv = torchify(M, v, res, rtol, atol)
+
+    TS = T.to_sparse_coo().coalesce()
+
+    tres = torch.mv(TS, tv)
+    assert tres.numpy() == approx(res, rel=rtol, abs=atol)
+
+
+@mark.xfail(
+    reason="spmv CSR currently broken",
+)
+@torch_test
+def test_torch_spmv_csr(data, nrows, ncols):
+    rtol, atol = tolerances(np.float64)
+    M, v, res = draw_problem(data, nrows, ncols)
+    T, tv = torchify(M, v, res, rtol, atol)
+
+    TS = T.to_sparse_csr()
+
+    tres = torch.mv(TS, tv)
+    assert tres.numpy() == approx(res, rel=rtol, abs=atol)
+
+
+@mark.xfail(
+    reason="spmv CSC currently broken",
+)
+@torch_test
+def test_torch_spmv_csc(data, nrows, ncols):
+    rtol, atol = tolerances(np.float64)
+    M, v, res = draw_problem(data, nrows, ncols)
+    T, tv = torchify(M, v, res, rtol, atol)
+
+    TS = T.to_sparse_csc()
+
+    tres = torch.mv(TS, tv)
+    assert tres.numpy() == approx(res, rel=rtol, abs=atol)
+
+
+@torch_test
+def test_torch_spmm_coo(data, nrows, ncols):
+    rtol, atol = tolerances(np.float64)
+    M, v, res = draw_problem(data, nrows, ncols)
+    T, tv = torchify(M, v, res, rtol, atol)
+
+    TS = T.to_sparse_coo().coalesce()
+
+    tres = torch.mm(TS, tv.reshape(-1, 1)).reshape(-1)
+    assert tres.numpy() == approx(res, rel=rtol, abs=atol)
+
+
+@torch_test
+def test_torch_spmm_csr(data, nrows, ncols):
+    rtol, atol = tolerances(np.float64)
+    M, v, res = draw_problem(data, nrows, ncols)
+    T, tv = torchify(M, v, res, rtol, atol)
+
+    TS = T.to_sparse_csr()
+
+    tres = torch.mm(TS, tv.reshape(-1, 1)).reshape(-1)
+    assert tres.numpy() == approx(res, rel=rtol, abs=atol)
+
+
+@torch_test
+def test_torch_spmm_csc(data, nrows, ncols):
+    rtol, atol = tolerances(np.float64)
+    M, v, res = draw_problem(data, nrows, ncols)
+    T, tv = torchify(M, v, res, rtol, atol)
+
+    TS = T.to_sparse_csc()
+
+    tres = torch.mm(TS, tv.reshape(-1, 1)).reshape(-1)
+    assert tres.numpy() == approx(res, rel=rtol, abs=atol)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -157,9 +157,9 @@ def test_torch_spmv(torch_device, data, M: sps.coo_array, layout):
 
     # quick make sure that dense works
     assert M.todense() @ v == approx(res)
-    assert torch.mv(torch.from_numpy(M.todense()).to(torch_device), tv).numpy() == approx(res)
+    assert torch.mv(torch.from_numpy(M.todense()).to(torch_device), tv).cpu().numpy() == approx(res)
 
     tres = torch.mv(TM, tv)
     tres = tres.nan_to_num()
 
-    assert tres.numpy() == approx(res, rel=1.0e-5, abs=1.0e-9)
+    assert tres.cpu().numpy() == approx(res, rel=1.0e-5, abs=1.0e-9)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -150,8 +150,8 @@ def test_torch_spmv(data, M: sps.coo_array, layout):
 
     TM = torch_sparse_from_scipy(M, layout)
     tv = torch.from_numpy(v)
-    # assert torch.all(torch.isfinite(tv))
 
     tres = torch.mv(TM, tv)
+    assert torch.all(torch.isfinite(tres))
 
-    assert tres.numpy() == approx(res)
+    assert tres.numpy() == approx(res, rel=1.0e-5)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -136,7 +136,7 @@ def test_sparse_ratings_indexes(rng):
         assert all(vs == rates)
 
 
-@settings(deadline=1000, max_examples=500, suppress_health_check=[HealthCheck.too_slow])
+@settings(deadline=1000, max_examples=200, suppress_health_check=[HealthCheck.too_slow])
 @given(st.data(), coo_arrays(dtype="f8", shape=(500, 500)), st.sampled_from(["coo", "csr"]))
 def test_torch_spmv(torch_device, data, M: sps.coo_array, layout):
     "Test to make sure Torch spmv is behaved"

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -156,8 +156,10 @@ def test_torch_spmv(torch_device, data, M: sps.coo_array, layout):
     tv = torch.from_numpy(v).to(torch_device)
 
     # quick make sure that dense works
-    assert M.todense() @ v == approx(res)
-    assert torch.mv(torch.from_numpy(M.todense()).to(torch_device), tv).cpu().numpy() == approx(res)
+    assert M.todense() @ v == approx(res, rel=1.0e-5)
+    assert torch.mv(torch.from_numpy(M.todense()).to(torch_device), tv).cpu().numpy() == approx(
+        res, rel=1.0e-5
+    )
 
     tres = torch.mv(TM, tv)
     tres = tres.nan_to_num()

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -156,9 +156,9 @@ def test_torch_spmv(torch_device, data, M: sps.coo_array, layout):
     tv = torch.from_numpy(v).to(torch_device)
 
     # quick make sure that dense works
-    assert M.todense() @ v == approx(res, rel=1.0e-5)
+    assert M.todense() @ v == approx(res, rel=1.0e-5, abs=1.0e-9)
     assert torch.mv(torch.from_numpy(M.todense()).to(torch_device), tv).cpu().numpy() == approx(
-        res, rel=1.0e-5
+        res, rel=1.0e-5, abs=1.0e-9
     )
 
     tres = torch.mv(TM, tv)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -132,7 +132,7 @@ def test_sparse_ratings_indexes(rng):
         assert all(vs == rates)
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(deadline=500, suppress_health_check=[HealthCheck.too_slow])
 @given(st.data(), coo_arrays(shape=(500, 500)), st.sampled_from(["coo", "csc", "csr"]))
 def test_torch_spmv(data, M: sps.coo_array, layout):
     "Test to make sure Torch spmv is behaved"

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -137,7 +137,7 @@ def test_sparse_ratings_indexes(rng):
 
 
 @settings(deadline=1000, max_examples=500, suppress_health_check=[HealthCheck.too_slow])
-@given(st.data(), coo_arrays(dtype="f8", shape=(500, 500)), st.sampled_from(["coo", "csr", "csc"]))
+@given(st.data(), coo_arrays(dtype="f8", shape=(500, 500)), st.sampled_from(["coo", "csr"]))
 def test_torch_spmv(torch_device, data, M: sps.coo_array, layout):
     "Test to make sure Torch spmv is behaved"
     nr, nc = M.shape

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -156,6 +156,7 @@ def test_torch_spmv(torch_device, data, M: sps.coo_array, layout):
     tv = torch.from_numpy(v).to(torch_device)
 
     # quick make sure that dense works
+    assert M.todense() @ v == approx(res)
     assert torch.mv(torch.from_numpy(M.todense()), tv).numpy() == approx(res)
 
     tres = torch.mv(TM, tv)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -157,7 +157,7 @@ def test_torch_spmv(torch_device, data, M: sps.coo_array, layout):
 
     # quick make sure that dense works
     assert M.todense() @ v == approx(res)
-    assert torch.mv(torch.from_numpy(M.todense()), tv).numpy() == approx(res)
+    assert torch.mv(torch.from_numpy(M.todense()).to(torch_device), tv).numpy() == approx(res)
 
     tres = torch.mv(TM, tv)
     tres = tres.nan_to_num()


### PR DESCRIPTION
This improves the test utilities for generating sparse matrices for testing, and adds tests for PyTorch sparse matrix logic to ensure that our underlying compute substrate is well-behaved for algorithm implementation.