### PR TITLE
Add a "safe" SPMV to work around PyTorch bug

### DIFF
--- a/lenskit/algorithms/knn/item.py
+++ b/lenskit/algorithms/knn/item.py
@@ -22,7 +22,7 @@ import torch
 
 from lenskit import ConfigWarning, DataWarning, util
 from lenskit.data import FeedbackType
-from lenskit.data.matrix import normalize_sparse_rows, sparse_ratings
+from lenskit.data.matrix import normalize_sparse_rows, safe_spmv, sparse_ratings
 from lenskit.parallel import ensure_parallel_init
 from lenskit.util.logging import pbh_update, progress_handle
 
@@ -343,7 +343,7 @@ def _sim_row(
     # _item_dbg(item, f"comparing item with {row.indices().shape[1]} users")
     # _item_dbg(item, f"row norm {torch.linalg.vector_norm(row.values()).item()}")
     row = row.to_dense()
-    sim = torch.mv(matrix, row.to(torch.float64))
+    sim = safe_spmv(matrix, row.to(torch.float64))
     sim[item] = 0
 
     mask = sim >= min_sim

--- a/lenskit/data/matrix.py
+++ b/lenskit/data/matrix.py
@@ -243,3 +243,17 @@ def torch_sparse_from_scipy(
             return T.coalesce()
         case _:
             raise ValueError(f"invalid layout {layout}")
+
+
+def safe_spmv(matrix: t.Tensor, vector: t.Tensor) -> t.Tensor:
+    """
+    Sparse matrix-vector multiplication working around PyTorch bugs.
+
+    This is equivalent to :func:`torch.mv` for sparse CSR matrix
+    and dense vector, but it works around PyTorch bug 127491_ by
+    falling back to SciPy on ARM.
+
+    .. _127491: https://github.com/pytorch/pytorch/issues/127491
+    """
+    assert matrix.is_sparse_csr
+    return t.mv(matrix, vector)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -6,14 +6,19 @@
 
 import logging
 
+import numpy as np
 import pandas as pd
 import scipy.sparse as sps
 import torch
 
-from pytest import mark
+import hypothesis.extra.numpy as nph
+import hypothesis.strategies as st
+from hypothesis import HealthCheck, assume, given, settings
+from pytest import approx, mark
 
 from lenskit.data import sparse_ratings
-from lenskit.util.test import ml_test
+from lenskit.data.matrix import safe_spmv, torch_sparse_from_scipy
+from lenskit.util.test import coo_arrays, ml_test
 
 _log = logging.getLogger(__name__)
 
@@ -129,3 +134,25 @@ def test_sparse_ratings_indexes(rng):
         assert not any(vs.isna())
         assert not any(rates.isna())
         assert all(vs == rates)
+
+
+@settings(deadline=1000, max_examples=500, suppress_health_check=[HealthCheck.too_slow])
+@given(st.data())
+def test_safe_spmv(data):
+    M = data.draw(coo_arrays(dtype="f8", shape=st.tuples(st.integers(1, 500), st.integers(1, 500))))
+    nr, nc = M.shape
+    v = data.draw(
+        nph.arrays(
+            M.data.dtype,
+            nc,
+            elements=st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False, width=32),
+        )
+    )
+    res = M @ v
+    assume(np.all(np.isfinite(res)))
+
+    TM = torch_sparse_from_scipy(M, "csr")
+    tv = torch.from_numpy(v)
+
+    tres = safe_spmv(TM, tv)
+    assert tres.cpu().numpy() == approx(res, rel=1.0e-5, abs=1.0e-9)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -155,4 +155,4 @@ def test_safe_spmv(data):
     tv = torch.from_numpy(v)
 
     tres = safe_spmv(TM, tv)
-    assert tres.cpu().numpy() == approx(res, rel=1.0e-5, abs=1.0e-9)
+    assert tres.cpu().numpy() == approx(res, rel=1.0e-4, abs=1.0e-6)


### PR DESCRIPTION
This adds a function `safe_spmv` that falls back to SciPy on ARM64 to work around pytorch/pytorch#127491. Once that bug is fixed in a release, we'll phase out the fallback.

It uses this fallback in item-kNN.