### PR TITLE
Remove Binpickle from tests and docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,7 +114,6 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
     "scikit": ("https://scikit-learn.org/stable/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
-    "binpickle": ("https://binpickle.lenskit.org/en/stable/", None),
     "seedbank": ("https://seedbank.lenskit.org/en/latest/", None),
     "progress_api": ("https://progress-api.readthedocs.io/en/latest/", None),
     "manylog": ("https://manylog.readthedocs.io/en/latest/", None),

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -3,25 +3,22 @@ Algorithm Interfaces
 
 .. module:: lenskit
 
-LKPY's batch routines and utility support for managing algorithms expect algorithms
-to implement consistent interfaces.  This page describes those interfaces.
+LKPY's batch routines and utility support for managing algorithms expect
+algorithms to implement consistent interfaces.  This page describes those
+interfaces.
 
-The interfaces are realized as abstract base classes with the Python :py:mod:`abc` module.
-Implementations must be registered with their interfaces, either by subclassing the interface
-or by calling :py:meth:`abc.ABCMeta.register`.
+The interfaces are realized as abstract base classes with the Python
+:py:mod:`abc` module. Implementations must be registered with their interfaces,
+either by subclassing the interface or by calling
+:py:meth:`abc.ABCMeta.register`.
 
 Serialization
 -------------
 
-Like SciKit models, all LensKit algorithms are pickleable, and this is how we
-recommend saving models to disk for later use.  This can be done with
-:py:mod:`pickle`, but we recommend using :py:mod:`binpickle` for more
-automatically-optimized storage.  For example, to save a fully-configured ALS
-module with fairly aggressive ZSTD compression::
+Like SciKit models, all LensKit algorithms support :mod:`pickle`, and this is
+how we recommend saving models to disk for later use.
 
-    algo = Recommender.adapt(ImplicitMF(50))
-    algo.fit(ratings)
-    binpickle.dump(algo, binpickle.codecs.Blosc('zstd', 9))
+.. todo:: It would be good to support e.g. safetensors.
 
 Base Algorithm
 --------------

--- a/lenskit/pyproject.toml
+++ b/lenskit/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   "scipy >= 1.9.0",
   "torch ~=2.1",            # conda: pytorch>=2.1,<3
   "threadpoolctl >=3.0",
-  "binpickle >= 0.3.2",
   "seedbank >= 0.2.0a2",    # conda: @pip
   "progress-api >=0.1.0a9", # conda: @pip
   "manylog >=0.1.0a5",      # conda: @pip

--- a/lenskit/tests/test_als_implicit.py
+++ b/lenskit/tests/test_als_implicit.py
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import pickle
 
-import binpickle
 import numpy as np
 import pandas as pd
 import torch
@@ -245,9 +245,12 @@ def test_als_save_load(tmp_path):
     algo.fit(ratings)
 
     fn = tmp_path / "model.bpk"
-    binpickle.dump(algo, fn, codec=None)
+    with fn.open("wb") as pf:
+        pickle.dump(algo, pf, protocol=pickle.HIGHEST_PROTOCOL)
 
-    restored = binpickle.load(fn)
+    with fn.open("rb") as pf:
+        restored = pickle.load(pf)
+
     assert torch.all(restored.user_features_ == algo.user_features_)
     assert torch.all(restored.item_features_ == algo.item_features_)
     assert np.all(restored.item_index_ == algo.item_index_)

--- a/lenskit/tests/test_bias.py
+++ b/lenskit/tests/test_bias.py
@@ -4,18 +4,16 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-from lenskit.algorithms.bias import Bias
-from lenskit import util as lku
-
 import logging
 import pickle
-import binpickle
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
-from pytest import approx, raises, mark
+from pytest import approx, mark, raises
 
+from lenskit import util as lku
+from lenskit.algorithms.bias import Bias
 from lenskit.util.test import ml_test
 
 _log = logging.getLogger(__name__)
@@ -377,31 +375,6 @@ def test_bias_save():
     _log.info("serialized to %d bytes", len(mod))
 
     algo = pickle.loads(mod)
-
-    assert algo.mean_ == original.mean_
-
-    assert algo.item_offsets_ is not None
-    assert algo.item_offsets_.index.name == "item"
-    assert set(algo.item_offsets_.index) == set([1, 2, 3])
-    assert algo.item_offsets_.loc[1:3].values == approx(np.array([0, 0.25, -0.25]))
-
-    assert algo.user_offsets_ is not None
-    assert algo.user_offsets_.index.name == "user"
-    assert set(algo.user_offsets_.index) == set([10, 12, 13])
-    assert algo.user_offsets_.loc[[10, 12, 13]].values == approx(
-        np.array([0.25, -00.08333, -0.20833]), abs=1.0e-4
-    )
-
-
-def test_bias_binpickle(tmp_path):
-    original = Bias(damping=5)
-    original.fit(simple_df)
-    assert original.mean_ == approx(3.5)
-
-    _log.info("saving baseline model")
-    fn = tmp_path / "bias.bpk"
-    binpickle.dump(original, fn)
-    algo = binpickle.load(fn)
 
     assert algo.mean_ == original.mean_
 

--- a/lenskit/tests/test_fallback.py
+++ b/lenskit/tests/test_fallback.py
@@ -4,16 +4,17 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-from lenskit.algorithms import basic
-from lenskit.algorithms.bias import Bias
-from lenskit import util as lku
+import pickle
 
-import pandas as pd
 import numpy as np
-import binpickle
+import pandas as pd
+
+from pytest import approx
 
 import lenskit.util.test as lktu
-from pytest import approx
+from lenskit import util as lku
+from lenskit.algorithms import basic
+from lenskit.algorithms.bias import Bias
 
 simple_df = pd.DataFrame(
     {"item": [1, 1, 2, 3], "user": [10, 12, 10, 13], "rating": [4.0, 3.0, 5.0, 2.0]}
@@ -117,10 +118,10 @@ def test_fallback_save_load(tmp_path):
     original.fit(lktu.ml_test.ratings)
 
     fn = tmp_path / "fb.mod"
-
-    binpickle.dump(original, fn)
-
-    algo = binpickle.load(fn)
+    with fn.open("wb") as pf:
+        pickle.dump(original, pf)
+    with fn.open("rb") as pf:
+        algo = pickle.load(pf)
 
     bias = algo.algorithms[1]
     assert bias.mean_ == approx(lktu.ml_test.ratings.rating.mean())


### PR DESCRIPTION
This removes Binpickle from the tests and documentation, as it doesn't work well with Torch at this point. Closes #422.