### PR TITLE
Only run tests when the PR changes test code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           else
               echo changed=false >>$GITHUB_OUTPUT
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
   conda:
     name: Conda Python ${{matrix.python}} on ${{matrix.platform}}
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,31 @@ concurrency:
   group: test-${{github.ref}}
   cancel-in-progress: true
 jobs:
+  check-changes:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{steps.check-for-changes.outputs.changed}}
+    steps:
+      - name: 🛒 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check-for-changes
+        run: |
+          gh pr diff --name-only |grep '^lenskit.*\.py$'
+          if [ "$?" -eq 0 ]; then
+              echo changed=true >>$GITHUB_OUTPUT
+          else
+              echo changed=false >>$GITHUB_OUTPUT
+          fi
   conda:
     name: Conda Python ${{matrix.python}} on ${{matrix.platform}}
     runs-on: ${{matrix.platform}}
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     defaults:
       run:
         shell: bash -el {0}
@@ -71,6 +92,9 @@ jobs:
     name: Vanilla Python ${{matrix.python}} on ${{matrix.platform}}
     runs-on: ${{matrix.platform}}
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +153,9 @@ jobs:
     name: Non-JIT test coverage
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -179,6 +206,9 @@ jobs:
     name: Minimal dependency tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -226,6 +256,9 @@ jobs:
     name: FunkSVD tests on Python ${{matrix.python}}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     defaults:
       run:
         shell: bash -el {0}
@@ -281,6 +314,9 @@ jobs:
     name: Minimal dependency tests for FunkSVD
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -328,6 +364,9 @@ jobs:
     name: Implicit bridge tests on Python ${{matrix.python}}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     defaults:
       run:
         shell: bash -el {0}
@@ -383,6 +422,9 @@ jobs:
     name: Minimal dependency tests for Implicit
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -430,6 +472,9 @@ jobs:
     name: HPF bridge tests on Python ${{matrix.python}}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - check-changes
+    if: jobs.check-changes.outputs.changed
     strategy:
       fail-fast: false
       matrix:
@@ -592,6 +637,7 @@ jobs:
     name: Test suite results
     runs-on: ubuntu-latest
     needs:
+      - check-changes
       - conda
       - vanilla
       - nojit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,19 @@ jobs:
           fetch-depth: 0
       - id: check-for-changes
         run: |
-          gh pr diff --name-only |grep '^lenskit.*\.py$'
-          if [ "$?" -eq 0 ]; then
+          if [[ -z "$PR_NUMBER" ]]; then
               echo changed=true >>$GITHUB_OUTPUT
           else
-              echo changed=false >>$GITHUB_OUTPUT
+              gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\.py$'
+              if [ "$?" -eq 0 ]; then
+                  echo changed=true >>$GITHUB_OUTPUT
+              else
+                  echo changed=false >>$GITHUB_OUTPUT
+              fi
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
   conda:
     name: Conda Python ${{matrix.python}} on ${{matrix.platform}}
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,14 @@ jobs:
         run: |
           if [[ -z "$PR_NUMBER" ]]; then
               echo "not a PR, assuming changed"
-              echo changed=true >>"$GITHUB_OUTPUT"
+              echo changed=yes >>"$GITHUB_OUTPUT"
           else
               if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\.py$'; then
                   echo "source code changed"
-                  echo changed=true >>"$GITHUB_OUTPUT"
+                  echo changed=yes >>"$GITHUB_OUTPUT"
               else
                   echo "source code unchanged"
-                  echo changed=false >>"$GITHUB_OUTPUT"
+                  echo changed=no >>"$GITHUB_OUTPUT"
               fi
           fi
           cat $GITHUB_OUTPUT
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     defaults:
       run:
         shell: bash -el {0}
@@ -113,7 +113,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +178,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     steps:
       - name: dump test
         run: echo "$CHANGED"
@@ -235,7 +235,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     steps:
       - name: dump test
         run: echo "$CHANGED"
@@ -289,7 +289,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     defaults:
       run:
         shell: bash -el {0}
@@ -351,7 +351,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     steps:
       - name: dump test
         run: echo "$CHANGED"
@@ -405,7 +405,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     defaults:
       run:
         shell: bash -el {0}
@@ -467,7 +467,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     steps:
       - name: dump test
         run: echo "$CHANGED"
@@ -521,7 +521,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     defaults:
       run:
         shell: bash -el {0}
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -208,7 +208,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -258,7 +258,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     defaults:
       run:
         shell: bash -el {0}
@@ -316,7 +316,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -366,7 +366,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     defaults:
       run:
         shell: bash -el {0}
@@ -424,7 +424,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -474,7 +474,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: jobs.check-changes.outputs.changed
+    if: ${{jobs.check-changes.outputs.changed}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,14 @@ jobs:
       - id: check-for-changes
         run: |
           if [[ -z "$PR_NUMBER" ]]; then
+              echo "not a PR, assuming changed"
               echo changed=true >>$GITHUB_OUTPUT
           else
               if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\.py$'; then
+                  echo "source code changed"
                   echo changed=true >>$GITHUB_OUTPUT
               else
+                  echo "source code unchanged"
                   echo changed=false >>$GITHUB_OUTPUT
               fi
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: check-for-changes
+        name: 🔎 Check for changes
         run: |
           if [[ -z "$PR_NUMBER" ]]; then
               echo "not a PR, assuming changed"
@@ -36,6 +37,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number }}
+      - name: Inspect outputs
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{steps.check-for-changes.outputs.changed}}
   conda:
     name: Conda Python ${{matrix.python}} on ${{matrix.platform}}
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     defaults:
       run:
         shell: bash -el {0}
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -208,7 +208,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -258,7 +258,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     defaults:
       run:
         shell: bash -el {0}
@@ -316,7 +316,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -366,7 +366,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     defaults:
       run:
         shell: bash -el {0}
@@ -424,7 +424,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
@@ -474,7 +474,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - check-changes
-    if: ${{jobs.check-changes.outputs.changed}}
+    if: needs.check-changes.outputs.changed
     strategy:
       fail-fast: false
       matrix:
@@ -531,6 +531,9 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    needs:
+      - check-changes
+    if: needs.check-changes.outputs.changed
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
               if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\.py$'; then
                   echo "source code changed"
                   echo changed=yes >>"$GITHUB_OUTPUT"
+              elif gh pr view $PR_NUMBER --json body -t '{{.body}}' | grep 'tests: force'; then
+                  echo "test run forced from PR text"
+                  echo changed=yes >>"$GITHUB_OUTPUT"
               else
                   echo "source code unchanged"
                   echo changed=no >>"$GITHUB_OUTPUT"
@@ -37,10 +40,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number }}
-      - name: Inspect outputs
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{steps.check-for-changes.outputs.changed}}
   conda:
     name: Conda Python ${{matrix.python}} on ${{matrix.platform}}
     runs-on: ${{matrix.platform}}
@@ -63,10 +62,6 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -126,10 +121,6 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -180,10 +171,6 @@ jobs:
       - check-changes
     if: needs.check-changes.outputs.changed == 'yes'
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -237,10 +224,6 @@ jobs:
       - check-changes
     if: needs.check-changes.outputs.changed == 'yes'
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -301,10 +284,6 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -353,10 +332,6 @@ jobs:
       - check-changes
     if: needs.check-changes.outputs.changed == 'yes'
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -417,10 +392,6 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -469,10 +440,6 @@ jobs:
       - check-changes
     if: needs.check-changes.outputs.changed == 'yes'
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -530,10 +497,6 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
-      - name: dump test
-        run: echo "$CHANGED"
-        env:
-          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -584,7 +547,7 @@ jobs:
         shell: bash -el {0}
     needs:
       - check-changes
-    if: needs.check-changes.outputs.changed
+    if: needs.check-changes.outputs.changed == 'yes'
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -579,10 +579,7 @@ jobs:
           python -m lenskit.datasets.fetch ml-100k ml-20m
       - name: Run Eval Tests
         run: |
-          echo changed: $CHANGED
           python -m pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit -m 'eval or realdata' --log-file test-eval.log */tests
-        env:
-          CHANGED: ${{needs.check-changes.output.changed}}
       - name: 📐 Coverage results
         run: |
           coverage xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,7 @@ jobs:
           if [[ -z "$PR_NUMBER" ]]; then
               echo changed=true >>$GITHUB_OUTPUT
           else
-              gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\.py$'
-              if [ "$?" -eq 0 ]; then
+              if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\.py$'; then
                   echo changed=true >>$GITHUB_OUTPUT
               else
                   echo changed=false >>$GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,10 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -117,6 +121,10 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -167,6 +175,10 @@ jobs:
       - check-changes
     if: needs.check-changes.outputs.changed
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -220,6 +232,10 @@ jobs:
       - check-changes
     if: needs.check-changes.outputs.changed
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -280,6 +296,10 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -328,6 +348,10 @@ jobs:
       - check-changes
     if: needs.check-changes.outputs.changed
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -388,6 +412,10 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -436,6 +464,10 @@ jobs:
       - check-changes
     if: needs.check-changes.outputs.changed
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
@@ -493,6 +525,10 @@ jobs:
           - '3.11'
           - '3.12'
     steps:
+      - name: dump test
+        run: echo "$CHANGED"
+        env:
+          CHANGED: ${{needs.check-changes-outputs.changed}}
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -579,7 +579,10 @@ jobs:
           python -m lenskit.datasets.fetch ml-100k ml-20m
       - name: Run Eval Tests
         run: |
+          echo changed: $CHANGED
           python -m pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit -m 'eval or realdata' --log-file test-eval.log */tests
+        env:
+          CHANGED: ${{needs.check-changes.output.changed}}
       - name: 📐 Coverage results
         run: |
           coverage xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
                   echo changed=false >>"$GITHUB_OUTPUT"
               fi
           fi
+          cat $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,14 @@ jobs:
         run: |
           if [[ -z "$PR_NUMBER" ]]; then
               echo "not a PR, assuming changed"
-              echo changed=true >>$GITHUB_OUTPUT
+              echo changed=true >>"$GITHUB_OUTPUT"
           else
               if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\.py$'; then
                   echo "source code changed"
-                  echo changed=true >>$GITHUB_OUTPUT
+                  echo changed=true >>"$GITHUB_OUTPUT"
               else
                   echo "source code unchanged"
-                  echo changed=false >>$GITHUB_OUTPUT
+                  echo changed=false >>"$GITHUB_OUTPUT"
               fi
           fi
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dask-worker-space/
 .tox/
 .vagrant/
 .venv/
+.uv/
 scratch/
 
 # build outputs

--- a/lkdev/ghactions.py
+++ b/lkdev/ghactions.py
@@ -60,6 +60,8 @@ GHJob = TypedDict(
     {
         "name": str,
         "runs-on": str,
+        "if": NotRequired[str],
+        "outputs": NotRequired[dict[str, str]],
         "timeout-minutes": NotRequired[int],
         "strategy": NotRequired[dict[str, Any]],
         "defaults": NotRequired[dict[str, Any]],

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -12,8 +12,8 @@ PACKAGES = ["lenskit", "lenskit-funksvd", "lenskit-implicit"]
 
 
 def workflow():
-    jobs: dict[str, GHJob] = test_jobs()
-    jobs["results"] = result_job(list(jobs.keys()))
+    jobs: dict[str, GHJob] = jobs_test_matrix()
+    jobs["results"] = jobs_result(list(jobs.keys()))
     return {
         "name": "Automatic Tests",
         "on": {
@@ -355,7 +355,7 @@ def test_doc_job() -> GHJob:
     }
 
 
-def test_jobs() -> dict[str, GHJob]:
+def jobs_test_matrix() -> dict[str, GHJob]:
     return {
         "conda": test_job(
             JobOptions(
@@ -436,7 +436,7 @@ def test_jobs() -> dict[str, GHJob]:
     }
 
 
-def result_job(deps: list[str]) -> GHJob:
+def jobs_result(deps: list[str]) -> GHJob:
     return {
         "name": "Test suite results",
         "runs-on": "ubuntu-latest",

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -298,7 +298,13 @@ def test_job(options: JobOptions) -> GHJob:
         }
 
     job.update(job_strategy(options))  # type: ignore
-    job["steps"] = test_job_steps(options)
+    job["steps"] = [
+        {
+            "name": "dump test",
+            "run": 'echo "$CHANGED"',
+            "env": {"CHANGED": "${{needs.check-changes-outputs.changed}}"},
+        }
+    ] + test_job_steps(options)
     return job
 
 

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -288,7 +288,7 @@ def test_job(options: JobOptions) -> GHJob:
         "runs-on": options.vm_platform,
         "timeout-minutes": 30,
         "needs": ["check-changes"],
-        "if": "jobs.check-changes.outputs.changed",
+        "if": "${{jobs.check-changes.outputs.changed}}",
     }
     if options.env == "conda":
         job["defaults"] = {

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -382,6 +382,7 @@ def job_check_changes() -> GHJob:
                             echo changed=false >>"$GITHUB_OUTPUT"
                         fi
                     fi
+                    cat $GITHUB_OUTPUT
                 """),
                 "env": {
                     "GH_TOKEN": "${{ github.token }}",

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -370,14 +370,21 @@ def job_check_changes() -> GHJob:
             {
                 "id": "check-for-changes",
                 "run": script("""
-                    gh pr diff --name-only |grep '^lenskit.*\\.py$'
-                    if [ "$?" -eq 0 ]; then
+                    if [[ -z "$PR_NUMBER" ]]; then
                         echo changed=true >>$GITHUB_OUTPUT
                     else
-                        echo changed=false >>$GITHUB_OUTPUT
+                        gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\\.py$'
+                        if [ "$?" -eq 0 ]; then
+                            echo changed=true >>$GITHUB_OUTPUT
+                        else
+                            echo changed=false >>$GITHUB_OUTPUT
+                        fi
                     fi
                 """),
-                "env": {"GH_TOKEN": "${{ github.token }}"},
+                "env": {
+                    "GH_TOKEN": "${{ github.token }}",
+                    "PR_NUMBER": "${{ github.event.number }}",
+                },
             },
         ],
     }

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -372,14 +372,14 @@ def job_check_changes() -> GHJob:
                 "run": script("""
                     if [[ -z "$PR_NUMBER" ]]; then
                         echo "not a PR, assuming changed"
-                        echo changed=true >>$GITHUB_OUTPUT
+                        echo changed=true >>"$GITHUB_OUTPUT"
                     else
                         if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\\.py$'; then
                             echo "source code changed"
-                            echo changed=true >>$GITHUB_OUTPUT
+                            echo changed=true >>"$GITHUB_OUTPUT"
                         else
                             echo "source code unchanged"
-                            echo changed=false >>$GITHUB_OUTPUT
+                            echo changed=false >>"$GITHUB_OUTPUT"
                         fi
                     fi
                 """),

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -324,8 +324,10 @@ def test_eval_job() -> GHJob:
             {
                 "name": "Run Eval Tests",
                 "run": script(f"""
+                    echo changed: $CHANGED
                     python -m pytest {cov} -m 'eval or realdata' --log-file test-eval.log */tests
                 """),
+                "env": {"CHANGED": "${{needs.check-changes.output.changed}}"},
             },
         ]
         + steps_coverage(opts),

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -324,10 +324,8 @@ def test_eval_job() -> GHJob:
             {
                 "name": "Run Eval Tests",
                 "run": script(f"""
-                    echo changed: $CHANGED
                     python -m pytest {cov} -m 'eval or realdata' --log-file test-eval.log */tests
                 """),
-                "env": {"CHANGED": "${{needs.check-changes.output.changed}}"},
             },
         ]
         + steps_coverage(opts),

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -288,7 +288,7 @@ def test_job(options: JobOptions) -> GHJob:
         "runs-on": options.vm_platform,
         "timeout-minutes": 30,
         "needs": ["check-changes"],
-        "if": "${{jobs.check-changes.outputs.changed}}",
+        "if": "needs.check-changes.outputs.changed",
     }
     if options.env == "conda":
         job["defaults"] = {
@@ -315,6 +315,8 @@ def test_eval_job() -> GHJob:
         "name": opts.name,
         "runs-on": opts.vm_platform,
         "defaults": {"run": {"shell": "bash -el {0}"}},
+        "needs": ["check-changes"],
+        "if": "needs.check-changes.outputs.changed",
         "steps": [step_checkout(opts)]
         + steps_setup_conda(opts)
         + steps_mldata(opts, ["ml-100k", "ml-20m"])

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -375,6 +375,7 @@ def job_check_changes() -> GHJob:
             step_checkout(),
             {
                 "id": "check-for-changes",
+                "name": "🔎 Check for changes",
                 "run": script("""
                     if [[ -z "$PR_NUMBER" ]]; then
                         echo "not a PR, assuming changed"
@@ -394,6 +395,11 @@ def job_check_changes() -> GHJob:
                     "GH_TOKEN": "${{ github.token }}",
                     "PR_NUMBER": "${{ github.event.number }}",
                 },
+            },
+            {
+                "name": "Inspect outputs",
+                "run": 'echo "$CHANGED"',
+                "env": {"CHANGED": "${{steps.check-for-changes.outputs.changed}}"},
             },
         ],
     }

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -371,11 +371,14 @@ def job_check_changes() -> GHJob:
                 "id": "check-for-changes",
                 "run": script("""
                     if [[ -z "$PR_NUMBER" ]]; then
+                        echo "not a PR, assuming changed"
                         echo changed=true >>$GITHUB_OUTPUT
                     else
                         if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\\.py$'; then
+                            echo "source code changed"
                             echo changed=true >>$GITHUB_OUTPUT
                         else
+                            echo "source code unchanged"
                             echo changed=false >>$GITHUB_OUTPUT
                         fi
                     fi

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -288,7 +288,7 @@ def test_job(options: JobOptions) -> GHJob:
         "runs-on": options.vm_platform,
         "timeout-minutes": 30,
         "needs": ["check-changes"],
-        "if": "needs.check-changes.outputs.changed",
+        "if": "needs.check-changes.outputs.changed == 'yes'",
     }
     if options.env == "conda":
         job["defaults"] = {
@@ -379,14 +379,14 @@ def job_check_changes() -> GHJob:
                 "run": script("""
                     if [[ -z "$PR_NUMBER" ]]; then
                         echo "not a PR, assuming changed"
-                        echo changed=true >>"$GITHUB_OUTPUT"
+                        echo changed=yes >>"$GITHUB_OUTPUT"
                     else
                         if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\\.py$'; then
                             echo "source code changed"
-                            echo changed=true >>"$GITHUB_OUTPUT"
+                            echo changed=yes >>"$GITHUB_OUTPUT"
                         else
                             echo "source code unchanged"
-                            echo changed=false >>"$GITHUB_OUTPUT"
+                            echo changed=no >>"$GITHUB_OUTPUT"
                         fi
                     fi
                     cat $GITHUB_OUTPUT

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -377,6 +377,7 @@ def job_check_changes() -> GHJob:
                         echo changed=false >>$GITHUB_OUTPUT
                     fi
                 """),
+                "env": {"GH_TOKEN": "${{ github.token }}"},
             },
         ],
     }

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -373,8 +373,7 @@ def job_check_changes() -> GHJob:
                     if [[ -z "$PR_NUMBER" ]]; then
                         echo changed=true >>$GITHUB_OUTPUT
                     else
-                        gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\\.py$'
-                        if [ "$?" -eq 0 ]; then
+                        if gh pr diff $PR_NUMBER --name-only |grep '^lenskit.*\\.py$'; then
                             echo changed=true >>$GITHUB_OUTPUT
                         else
                             echo changed=false >>$GITHUB_OUTPUT


### PR DESCRIPTION
This adds a check to see if we have actually changed any code, and if not it skips tests to reduce overhead when we're working on doc tweaks and such.

tests: force