### PR TITLE
Install hpfrec from Conda

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,14 @@ name: Automatic Tests
       - main
     paths:
       - lenskit/**.py
-      - '**pyroject.toml'
+      - '**pyproject.toml'
       - requirements*.txt
       - data/**
       - .github/workflows/test.yml
   pull_request:
     paths:
       - lenskit/**.py
-      - '**pyroject.toml'
+      - '**pyproject.toml'
       - requirements*.txt
       - data/**
       - .github/workflows/test.yml

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ create a dev environment, checkout LensKit, then run:
     conda activate lkpy
 
 That will create and activate an environment named `lkpy` with all the LensKit
-dependencies. You will also need to install LensKit in editable mode to do
-things like run the tests:
+dependencies. You will also need to install the LensKit packages you want to
+work on in editable mode to do things like run the tests:
 
-    pip install -e lenskit
+    pip install --no-deps -e lenskit
 
 Each LensKit subpackage you want to work on will also need to be installed.
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -20,8 +20,8 @@ dependencies:
   - scikit-learn >=1.1
   - numba >=0.56
   - implicit >=0.6.1
+  - hpfrec ==0.2.*
   - pip:
       - seedbank>=0.2.0a2
       - progress-api>=0.1.0a9
       - manylog>=0.1.0a5
-      - hpfrec==0.2.*

--- a/lenskit-hpf/pyproject.toml
+++ b/lenskit-hpf/pyproject.toml
@@ -14,10 +14,7 @@ classifiers = [
 readme = "README.md"
 license = { file = "LICENSE.md" }
 requires-python = ">= 3.10"
-dependencies = [
-  "lenskit",
-  "hpfrec==0.2.*", # conda: @pip
-]
+dependencies = ["lenskit", "hpfrec==0.2.*"]
 dynamic = ["version"]
 
 [project.urls]

--- a/lkdev/conda.py
+++ b/lkdev/conda.py
@@ -26,7 +26,6 @@ Options:
     --micromamba    use micromamba
     --mkl           enable MKL BLAS
     --cuda          enable CUDA PyTorch
-    --env           write a Conda environment specification
 
 This tool is implemented as its own script, because it is used to
 bootstrap LensKit and therefore cannot depend on LensKit being installed.

--- a/lkdev/workflows/test.py
+++ b/lkdev/workflows/test.py
@@ -11,7 +11,7 @@ PYTHONS = ["3.10", "3.11", "3.12"]
 PLATFORMS = ["ubuntu-latest", "macos-latest", "windows-latest"]
 FILTER_PATHS = [
     "lenskit/**.py",
-    "**pyroject.toml",
+    "**pyproject.toml",
     "requirements*.txt",
     "data/**",
     ".github/workflows/test.yml",


### PR DESCRIPTION
Now that `hpfrec` is in conda-forge, this drops the override to install it from PyPI.