### PR TITLE
Update dataset to expose vocabularies instead of lookup functions

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -53,8 +53,8 @@ Users and items have two identifiers:
   sorted identifiers that do not yet have numbers.
 
 Identifiers and numbers can be mapped to each other with the user and item
-*vocabularies* (:attr:`~Dataset.user_vocab` and :attr:`~Dataset.item_vocab`), as
-well as convenience methods.
+*vocabularies* (:attr:`~Dataset.users` and :attr:`~Dataset.items`, see the
+:class:`~lenskit.data.vocab.Vocabulary` class).
 
 .. autodata:: lenskit.data.vocab.EntityId
 
@@ -68,6 +68,17 @@ for training, evaluation, etc. Trainable models and components expect a dataset
 instance to be passed to :meth:`~lenskit.algorithms.Recommender.fit`.
 
 .. autoclass:: Dataset
+
+Vocabularies
+~~~~~~~~~~~~
+
+LensKit uses *vocabularies* to record user/item IDs, tags, terms, etc. in a way
+that facilitates easy mapping to 0-based contiguous indexes for use in matrix
+and tensor data structures.
+
+.. module:: lenskit.data.vocab
+
+.. autoclass:: Vocabulary
 
 User-Item Data Tables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/lenskit/lenskit/data/dataset.py
+++ b/lenskit/lenskit/data/dataset.py
@@ -562,8 +562,3 @@ def _find_column(columns: Collection[str], acceptable: Iterable[str]) -> str | N
             return col
 
     return None
-
-
-def id_counts(items: ArrayLike) -> pd.Series[np.dtype[np.int64]]:
-    ids, counts = np.unique(items, return_counts=True)
-    return pd.Series(counts, index=ids)

--- a/lenskit/lenskit/data/matrix.py
+++ b/lenskit/lenskit/data/matrix.py
@@ -100,7 +100,7 @@ class InteractionMatrix:
         self.n_items = n_items
         self.n_users = n_users
         cp1 = np.zeros(self.n_users + 1, np.int32)
-        unos, ucts = np.unique(self.user_nums)
+        unos, ucts = np.unique(self.user_nums, return_counts=True)
         cp1[unos + 1] = ucts
         self.user_ptrs = cp1.cumsum()
         if self.user_ptrs[-1] != len(self.user_nums):

--- a/lenskit/lenskit/data/matrix.py
+++ b/lenskit/lenskit/data/matrix.py
@@ -100,8 +100,7 @@ class InteractionMatrix:
         self.n_items = n_items
         self.n_users = n_users
         cp1 = np.zeros(self.n_users + 1, np.int32)
-        unos, ucts = np.unique(self.user_nums, return_counts=True)
-        cp1[unos + 1] = ucts
+        np.add.at(cp1[1:], self.user_nums, 1)
         self.user_ptrs = cp1.cumsum()
         if self.user_ptrs[-1] != len(self.user_nums):
             raise ValueError("mismatched counts and array sizes")

--- a/lenskit/lenskit/data/matrix.py
+++ b/lenskit/lenskit/data/matrix.py
@@ -86,7 +86,7 @@ class InteractionMatrix:
         items: ArrayLike,
         ratings: Optional[ArrayLike],
         timestamps: Optional[ArrayLike],
-        user_counts: pd.Series,
+        n_users: int,
         n_items: int,
     ):
         self.user_nums = np.asarray(users, np.int32)
@@ -98,9 +98,10 @@ class InteractionMatrix:
 
         self.n_obs = len(self.user_nums)
         self.n_items = n_items
-        self.n_users = len(user_counts)
+        self.n_users = n_users
         cp1 = np.zeros(self.n_users + 1, np.int32)
-        cp1[1:] = user_counts
+        unos, ucts = np.unique(self.user_nums)
+        cp1[unos + 1] = ucts
         self.user_ptrs = cp1.cumsum()
         if self.user_ptrs[-1] != len(self.user_nums):
             raise ValueError("mismatched counts and array sizes")

--- a/lenskit/lenskit/data/vocab.py
+++ b/lenskit/lenskit/data/vocab.py
@@ -85,7 +85,7 @@ class Vocabulary(Generic[VT]):
             raise IndexError("negative numbers not supported")
         return self._index[num]
 
-    def terms(self, nums: list[int] | NDArray[np.integer]) -> np.ndarray:
+    def terms(self, nums: list[int] | NDArray[np.integer] | pd.Series) -> np.ndarray:
         "Look up the terms for an array of indices."
         nums = np.asarray(nums, dtype=np.int32)
         if np.any(nums < 0):
@@ -96,7 +96,7 @@ class Vocabulary(Generic[VT]):
         "Alias for :meth:`term`  for greater readability for entity ID vocabularies."
         return self.term(num)
 
-    def ids(self, nums: list[int] | NDArray[np.integer]) -> np.ndarray:
+    def ids(self, nums: list[int] | NDArray[np.integer] | pd.Series) -> np.ndarray:
         "Alias for :meth:`terms` for greater readability for entity ID vocabularies."
         return self.terms(nums)
 

--- a/lenskit/tests/test_dataset_ids.py
+++ b/lenskit/tests/test_dataset_ids.py
@@ -33,86 +33,79 @@ def test_from_ratings_names_upper(ml_ratings: pd.DataFrame):
 
 
 def test_user_id_single(ml_ds: Dataset):
-    users = ml_ds.user_vocab
-    assert ml_ds.user_id(0) == users[0]
-    assert ml_ds.user_id(ml_ds.user_count - 1) == users[-1]
-    assert ml_ds.user_id(50) == users[50]
+    users = ml_ds.users.index
+    assert ml_ds.users.id(0) == users[0]
+    assert ml_ds.users.id(ml_ds.user_count - 1) == users[-1]
+    assert ml_ds.users.id(50) == users[50]
 
 
 def test_user_id_many(ml_ds: Dataset):
-    users = ml_ds.user_vocab
-    assert np.all(ml_ds.user_id([1, 5, 23]) == users[[1, 5, 23]])
-    assert np.all(ml_ds.user_id(np.array([1, 5, 23])) == users[[1, 5, 23]])
+    users = ml_ds.users.index
+    assert np.all(ml_ds.users.ids([1, 5, 23]) == users[[1, 5, 23]])
+    assert np.all(ml_ds.users.ids(np.array([1, 5, 23])) == users[[1, 5, 23]])
 
 
 def test_item_id_single(ml_ds: Dataset):
-    items = ml_ds.item_vocab
-    assert ml_ds.item_id(0) == items[0]
-    assert ml_ds.item_id(ml_ds.item_count - 1) == items[-1]
-    assert ml_ds.item_id(50) == items[50]
+    items = ml_ds.items.index
+    assert ml_ds.items.id(0) == items[0]
+    assert ml_ds.items.id(ml_ds.item_count - 1) == items[-1]
+    assert ml_ds.items.id(50) == items[50]
 
 
 def test_item_id_many(ml_ds: Dataset):
-    items = ml_ds.item_vocab
-    assert np.all(ml_ds.item_id([1, 5, 23]) == items[[1, 5, 23]])
-    assert np.all(ml_ds.item_id(np.array([1, 5, 23])) == items[[1, 5, 23]])
+    items = ml_ds.items.index
+    assert np.all(ml_ds.items.ids([1, 5, 23]) == items[[1, 5, 23]])
+    assert np.all(ml_ds.items.ids(np.array([1, 5, 23])) == items[[1, 5, 23]])
 
 
 def test_user_num_single(ml_ds: Dataset):
-    users = ml_ds.user_vocab
-    assert ml_ds.user_num(users[0]) == 0
-    assert ml_ds.user_num(users[50]) == 50
+    users = ml_ds.users.index
+    assert ml_ds.users.number(users[0]) == 0
+    assert ml_ds.users.number(users[50]) == 50
 
 
 def test_user_num_many(ml_ds: Dataset):
-    users = ml_ds.user_vocab
-    assert np.all(ml_ds.user_num(users[[1, 5, 23]]) == [1, 5, 23])
-    assert np.all(ml_ds.user_num(list(users[[1, 5, 23]])) == [1, 5, 23])
+    users = ml_ds.users.index
+    assert np.all(ml_ds.users.numbers(users[[1, 5, 23]]) == [1, 5, 23])
+    assert np.all(ml_ds.users.numbers(list(users[[1, 5, 23]])) == [1, 5, 23])
 
 
 def test_user_num_missing_error(ml_ds: Dataset):
     with raises(KeyError):
-        ml_ds.user_num(-402, missing="error")
+        ml_ds.users.number(-402, missing="error")
 
 
 def test_user_num_missing_negative(ml_ds: Dataset):
-    assert ml_ds.user_num(-402, missing="negative") == -1
-
-
-def test_user_num_missing_omit(ml_ds: Dataset):
-    user = ml_ds.user_vocab[5]
-    series = ml_ds.user_num([user, -402], missing="omit")
-    assert len(series) == 1
-    assert series.loc[user] == 5
+    assert ml_ds.users.number(-402, missing="negative") == -1
 
 
 def test_user_num_missing_vector_negative(ml_ds: Dataset):
-    u1 = ml_ds.user_vocab[5]
-    u2 = ml_ds.user_vocab[100]
-    res = ml_ds.user_num([u1, -402, u2], missing="negative")
+    u1 = ml_ds.users.index[5]
+    u2 = ml_ds.users.index[100]
+    res = ml_ds.users.numbers([u1, -402, u2], missing="negative")
     assert len(res) == 3
     assert np.all(res == [5, -1, 100])
 
 
 def test_user_num_missing_vector_error(ml_ds: Dataset):
-    u1 = ml_ds.user_vocab[5]
-    u2 = ml_ds.user_vocab[100]
+    u1 = ml_ds.users.index[5]
+    u2 = ml_ds.users.index[100]
     with raises(KeyError):
-        ml_ds.user_num([u1, -402, u2], missing="error")
+        ml_ds.users.numbers([u1, -402, u2], missing="error")
 
 
 def test_item_num_single(ml_ds: Dataset):
-    items = ml_ds.item_vocab
-    assert ml_ds.item_num(items[0]) == 0
-    assert ml_ds.item_num(items[50]) == 50
+    items = ml_ds.items.index
+    assert ml_ds.items.number(items[0]) == 0
+    assert ml_ds.items.number(items[50]) == 50
 
 
 def test_item_num_many(ml_ds: Dataset):
-    items = ml_ds.item_vocab
-    assert np.all(ml_ds.item_num(items[[1, 5, 23]]) == [1, 5, 23])
-    assert np.all(ml_ds.item_num(list(items[[1, 5, 23]])) == [1, 5, 23])
+    items = ml_ds.items.index
+    assert np.all(ml_ds.items.numbers(items[[1, 5, 23]]) == [1, 5, 23])
+    assert np.all(ml_ds.items.numbers(list(items[[1, 5, 23]])) == [1, 5, 23])
 
 
 def test_item_num_missing_error(ml_ds: Dataset):
     with raises(KeyError):
-        ml_ds.item_num(-402, missing="error")
+        ml_ds.items.number(-402, missing="error")

--- a/lenskit/tests/test_dataset_log.py
+++ b/lenskit/tests/test_dataset_log.py
@@ -22,12 +22,12 @@ def test_pandas_log_defaults(ml_ratings: pd.DataFrame, ml_ds: Dataset):
 
     # the interact
     int_df = int_df.sort_values(["user_num", "item_num"])
-    uids = ml_ds.user_id(int_df["user_num"])
-    iids = ml_ds.item_id(int_df["item_num"])
+    uids = ml_ds.users.ids(int_df["user_num"])
+    iids = ml_ds.items.ids(int_df["item_num"])
 
     ml_df = ml_ratings.sort_values(["userId", "movieId"])
-    assert np.all(uids.values == ml_df["userId"])
-    assert np.all(iids.values == ml_df["movieId"])
+    assert np.all(uids == ml_df["userId"])
+    assert np.all(iids == ml_df["movieId"])
     assert np.all(int_df["rating"] == ml_df["rating"])
     assert np.all(int_df["timestamp"] == ml_df["timestamp"])
 
@@ -69,12 +69,12 @@ def test_pandas_log_no_ts(ml_ratings: pd.DataFrame, ml_ds: Dataset):
 
     # the interact
     int_df = int_df.sort_values(["user_num", "item_num"])
-    uids = ml_ds.user_id(int_df["user_num"])
-    iids = ml_ds.item_id(int_df["item_num"])
+    uids = ml_ds.users.ids(int_df["user_num"])
+    iids = ml_ds.items.ids(int_df["item_num"])
 
     ml_df = ml_ratings.sort_values(["userId", "movieId"])
-    assert np.all(uids.values == ml_df["userId"])
-    assert np.all(iids.values == ml_df["movieId"])
+    assert np.all(uids == ml_df["userId"])
+    assert np.all(iids == ml_df["movieId"])
     assert np.all(int_df["rating"] == ml_df["rating"])
 
     # and the total length

--- a/lenskit/tests/test_dataset_matrix.py
+++ b/lenskit/tests/test_dataset_matrix.py
@@ -19,31 +19,31 @@ from lenskit.util.test import ml_ds, ml_ratings  # noqa: F401
 
 
 def _check_user_offset_counts(ml_ds: Dataset, ml_ratings: pd.DataFrame, offsets: ArrayLike):
-    user_counts = ml_ratings["userId"].value_counts().reindex(ml_ds.user_vocab)
+    user_counts = ml_ratings["userId"].value_counts().reindex(ml_ds.users.index)
     row_lens = np.diff(offsets)
     assert np.all(row_lens == user_counts)
 
 
 def _check_user_number_counts(ml_ds: Dataset, ml_ratings: pd.DataFrame, nums: ArrayLike):
     users, counts = np.unique(nums, return_counts=True)
-    user_counts = ml_ratings["userId"].value_counts().reindex(ml_ds.user_vocab[users])
+    user_counts = ml_ratings["userId"].value_counts().reindex(ml_ds.users.ids(users))
     assert np.all(counts == user_counts)
 
 
 def _check_item_number_counts(ml_ds: Dataset, ml_ratings: pd.DataFrame, nums: ArrayLike):
     items, counts = np.unique(nums, return_counts=True)
-    item_counts = ml_ratings["movieId"].value_counts().reindex(ml_ds.item_vocab[items])
+    item_counts = ml_ratings["movieId"].value_counts().reindex(ml_ds.items.ids(items))
     assert np.all(counts == item_counts)
 
 
 def _check_user_ids(ml_ds: Dataset, ml_ratings: pd.DataFrame, nums: ArrayLike):
     ml_ratings = ml_ratings.sort_values(["userId", "movieId"])
-    assert np.all(ml_ds.user_vocab[np.asarray(nums)] == ml_ratings["userId"])
+    assert np.all(ml_ds.users.ids(np.asarray(nums)) == ml_ratings["userId"])
 
 
 def _check_item_ids(ml_ds: Dataset, ml_ratings: pd.DataFrame, nums: ArrayLike):
     ml_ratings = ml_ratings.sort_values(["userId", "movieId"])
-    assert np.all(ml_ds.item_vocab[np.asarray(nums)] == ml_ratings["movieId"])
+    assert np.all(ml_ds.items.ids(np.asarray(nums)) == ml_ratings["movieId"])
 
 
 def _check_ratings(ml_ds: Dataset, ml_ratings: pd.DataFrame, rates: ArrayLike):


### PR DESCRIPTION
This updates #427 to clean up some #352 by replacing the bespoke user/item lookup functions with user and item vocabularies.