### PR TITLE
Remove sparse_ratings and sparse_row_stats functions

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -119,12 +119,3 @@ User-Item Data Tables
 
 .. autoclass:: NumpyUserItemTable
 .. autoclass:: TorchUserItemTable
-
-Building Ratings Matrices
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. module:: lenskit.data.matrix
-
-.. autofunction:: sparse_ratings
-.. autoclass:: RatingMatrix
-.. autoclass:: CSRStructure

--- a/lenskit/lenskit/data/__init__.py
+++ b/lenskit/lenskit/data/__init__.py
@@ -12,5 +12,4 @@ FeedbackType: TypeAlias = Literal["explicit", "implicit"]
 "Types of feedback supported."
 
 from .dataset import Dataset, from_interactions_df  # noqa: F401, E402
-from .matrix import RatingMatrix, sparse_ratings  # noqa: F401, E402
 from .movielens import load_movielens  # noqa: F401, E402

--- a/lenskit/lenskit/data/matrix.py
+++ b/lenskit/lenskit/data/matrix.py
@@ -15,11 +15,10 @@ import logging
 import platform
 
 import numpy as np
-import pandas as pd
 import scipy.sparse as sps
 import torch
 from numpy.typing import ArrayLike
-from typing_extensions import Any, Generic, Literal, NamedTuple, Optional, TypeVar, overload
+from typing_extensions import Literal, NamedTuple, Optional, TypeVar, overload
 
 _log = logging.getLogger(__name__)
 
@@ -114,19 +113,6 @@ class InteractionMatrix:
         return (self.n_users, self.n_items)
 
 
-class RatingMatrix(NamedTuple, Generic[M]):
-    """
-    A rating matrix with associated indices.
-    """
-
-    matrix: M
-    "The rating matrix, with users on rows and items on columns."
-    users: pd.Index[Any]
-    "Mapping from user IDs to row numbers."
-    items: pd.Index[Any]
-    "Mapping from item IDs to column numbers."
-
-
 class DimStats(NamedTuple):
     """
     The statistics for a matrix along a dimension (e.g. rows or columns).
@@ -142,148 +128,6 @@ class DimStats(NamedTuple):
     sums: t.Tensor
     "The mean of stored entries for each element."
     means: t.Tensor
-
-
-@overload
-def sparse_ratings(
-    ratings: pd.DataFrame,
-    *,
-    type: Literal["scipy"] = "scipy",
-    layout: Literal["csr"] = "csr",
-    users: Optional[pd.Index[Any]] = None,
-    items: Optional[pd.Index[Any]] = None,
-) -> RatingMatrix[sps.csr_array]: ...
-@overload
-def sparse_ratings(
-    ratings: pd.DataFrame,
-    *,
-    type: Literal["scipy"] = "scipy",
-    layout: Literal["coo"] = "coo",
-    users: Optional[pd.Index[Any]] = None,
-    items: Optional[pd.Index[Any]] = None,
-) -> RatingMatrix[sps.coo_array]: ...
-@overload
-def sparse_ratings(
-    ratings: pd.DataFrame,
-    *,
-    type: Literal["spmatrix"] = "spmatrix",
-    layout: Literal["csr"] = "csr",
-    users: Optional[pd.Index[Any]] = None,
-    items: Optional[pd.Index[Any]] = None,
-) -> RatingMatrix[sps.csr_matrix]: ...
-@overload
-def sparse_ratings(
-    ratings: pd.DataFrame,
-    *,
-    type: Literal["spmatrix"] = "spmatrix",
-    layout: Literal["coo"] = "coo",
-    users: Optional[pd.Index[Any]] = None,
-    items: Optional[pd.Index[Any]] = None,
-) -> RatingMatrix[sps.coo_matrix]: ...
-@overload
-def sparse_ratings(
-    ratings: pd.DataFrame,
-    *,
-    type: Literal["torch"],
-    layout: Literal["coo", "csr"] = "csr",
-    users: Optional[pd.Index[Any]] = None,
-    items: Optional[pd.Index[Any]] = None,
-) -> RatingMatrix[t.Tensor]: ...
-@overload
-def sparse_ratings(
-    ratings: pd.DataFrame,
-    *,
-    type: Literal["structure"] = "structure",
-    layout: Literal["csr"] = "csr",
-    users: Optional[pd.Index[Any]] = None,
-    items: Optional[pd.Index[Any]] = None,
-) -> RatingMatrix[CSRStructure]: ...
-def sparse_ratings(
-    ratings: pd.DataFrame,
-    *,
-    type: Literal["scipy", "spmatrix", "torch", "structure"] = "scipy",
-    layout: Literal["csr", "coo"] = "csr",
-    users: Optional[pd.Index[Any]] = None,
-    items: Optional[pd.Index[Any]] = None,
-) -> RatingMatrix[Any]:
-    """
-    Convert a rating table to a sparse matrix of ratings.
-
-    Args:
-        ratings:
-            A data table of (user, item, rating) triples.
-        type:
-            The type of matrix to create.  Can be any of the following:
-
-            * ``scipy`` creates a SciPy sparse array (see :mod:`scipy.sparse`)
-            * ``torch`` creates a sparse tensor (see :mod:`torch.sparse`)
-            * ``spmatrix`` creates a legacy SciPy :class:`~scipy.sparse.spmatrix`
-        layout:
-            The matrix layout to use.
-        users:
-            An index of user IDs.
-        items:
-            An index of items IDs.
-
-    Returns:
-        RatingMatrix:
-            a named tuple containing the sparse matrix, user index, and item
-            index.
-    """
-    if users is None:
-        users = pd.Index(np.unique(ratings.user), name="user")
-
-    if items is None:
-        items = pd.Index(np.unique(ratings.item), name="item")
-
-    n = len(ratings)
-    ni = len(items)
-    nu = len(users)
-
-    _log.debug("creating matrix with %d ratings for %d items by %d users", n, ni, nu)
-
-    row_ind = users.get_indexer(ratings.user).astype(np.intc)
-    if np.any(row_ind < 0):
-        raise ValueError("provided user index does not cover all users")
-    col_ind = items.get_indexer(ratings.item).astype(np.intc)
-    if np.any(col_ind < 0):
-        raise ValueError("provided item index does not cover all users")
-
-    if type == "torch":
-        if "rating" in ratings.columns:
-            vals = t.from_numpy(ratings["rating"].values).to(t.float32)
-        else:
-            vals = t.ones((len(ratings),), dtype=t.float32)
-        indices = t.stack([t.from_numpy(row_ind), t.from_numpy(col_ind)], dim=0)
-        matrix = t.sparse_coo_tensor(indices, vals, size=(nu, ni))
-        if layout == "csr":
-            matrix = matrix.to_sparse_csr()
-    elif type == "scipy" or type == "spmatrix":
-        if "rating" in ratings.columns:
-            vals = ratings["rating"].values
-        else:
-            vals = np.ones((len(ratings),), dtype=np.float32)
-        if type == "spmatrix":
-            matrix = sps.coo_matrix((vals, (row_ind, col_ind)), shape=(nu, ni))
-        else:
-            matrix = sps.coo_array((vals, (row_ind, col_ind)), shape=(nu, ni))
-        if layout == "csr":
-            matrix = matrix.tocsr()
-    elif type == "structure":
-        if layout != "csr":
-            raise ValueError("only CSR is supported for structure matrices")
-
-        df = pd.DataFrame({"row": row_ind, "col": col_ind})
-        df.sort_values(["row", "col"], inplace=True, ignore_index=True)
-        counts = df["row"].value_counts(sort=False)
-        rps = np.zeros(nu + 1, dtype=np.int32)
-        rps[counts.index + 1] = counts.values
-        rps = np.cumsum(rps)
-        matrix = CSRStructure(rps, df["col"].values, (nu, ni))
-    else:
-        raise ValueError(f"unknown type {type}")
-
-    return RatingMatrix(matrix, users, items)
 
 
 def sparse_row_stats(matrix: t.Tensor) -> DimStats:

--- a/lenskit/tests/test_matrix.py
+++ b/lenskit/tests/test_matrix.py
@@ -4,151 +4,17 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-import logging
 
 import numpy as np
-import pandas as pd
-import scipy.sparse as sps
 import torch
 
 import hypothesis.extra.numpy as nph
 import hypothesis.strategies as st
 from hypothesis import HealthCheck, assume, given, settings
-from pytest import approx, mark
+from pytest import approx
 
-from lenskit.data import sparse_ratings
-from lenskit.data.matrix import CSRStructure, safe_spmv, torch_sparse_from_scipy
-from lenskit.util.test import coo_arrays, ml_test
-
-_log = logging.getLogger(__name__)
-
-
-def test_sparse_ratings(rng):
-    ratings = ml_test.ratings
-    mat, uidx, iidx = sparse_ratings(ratings)
-
-    assert mat.shape[0] == len(uidx)
-    assert mat.shape[0] == ratings.user.nunique()
-    assert mat.shape[1] == len(iidx)
-    assert mat.shape[1] == ratings.item.nunique()
-
-    # user indicators should correspond to user item counts
-    ucounts = ratings.groupby("user").item.count()
-    ucounts = ucounts.loc[uidx].cumsum()
-    assert all(mat.indptr[1:] == ucounts.values)
-
-    # verify rating values
-    ratings = ratings.set_index(["user", "item"])
-    for u in rng.choice(uidx, size=50):
-        ui = uidx.get_loc(u)
-        r = mat[[ui], :]
-        vs = pd.Series(r.data, iidx[r.indices])
-        rates = ratings.loc[u]["rating"]
-        print(f"values:\n{vs}")
-        print(f"ratings:\n{rates}")
-        vs, rates = vs.align(rates)
-        assert not any(vs.isna())
-        assert not any(rates.isna())
-        assert all(vs == rates)
-
-
-def test_sparse_ratings_implicit():
-    ratings = ml_test.ratings
-    ratings = ratings.loc[:, ["user", "item"]]
-    mat, uidx, iidx = sparse_ratings(ratings)
-
-    assert mat.shape[0] == len(uidx)
-    assert mat.shape[0] == ratings.user.nunique()
-    assert mat.shape[1] == len(iidx)
-    assert mat.shape[1] == ratings.item.nunique()
-    # assert mat.values is None
-
-
-@mark.parametrize(
-    "format, sps_fmt_checker",
-    [
-        ("csr", lambda a: isinstance(a, sps.csr_array)),
-        ("coo", lambda a: isinstance(a, sps.coo_array)),
-    ],
-)
-def test_sparse_ratings_scipy(format, sps_fmt_checker):
-    ratings = ml_test.ratings
-    mat, uidx, iidx = sparse_ratings(ratings, layout=format)
-
-    assert sps.issparse(mat)
-    assert sps_fmt_checker(mat)
-    assert len(uidx) == ratings.user.nunique()
-    assert len(iidx) == ratings.item.nunique()
-
-    # user indicators should correspond to user item counts
-    ucounts = ratings.groupby("user").item.count()
-    ucounts = ucounts.loc[uidx].cumsum()
-    m2 = mat.tocsr()
-    assert np.all(m2.indptr[1:] == ucounts.values)
-
-
-def test_sparse_ratings_scipy_implicit():
-    ratings = ml_test.ratings
-    ratings = ratings.loc[:, ["user", "item"]]
-    mat, uidx, iidx = sparse_ratings(ratings)
-
-    assert sps.issparse(mat)
-    assert isinstance(mat, sps.csr_array)
-    assert len(uidx) == ratings.user.nunique()
-    assert len(iidx) == ratings.item.nunique()
-
-    assert all(mat.data == 1.0)
-
-
-def test_sparse_ratings_structure():
-    ratings = ml_test.ratings
-    ratings = ratings.loc[:, ["user", "item"]]
-    mat, uidx, iidx = sparse_ratings(ratings, type="structure")
-    spmat, _uidx, _iidx = sparse_ratings(ratings, users=uidx, items=iidx)
-
-    assert isinstance(mat, CSRStructure)
-    assert mat.nrows == ratings.user.nunique()
-    assert mat.ncols == ratings.item.nunique()
-    assert mat.nnz == len(ratings)
-    assert mat.rowptrs[mat.nrows] == mat.nnz
-    assert np.all(mat.rowptrs == spmat.indptr)
-    assert np.all(mat.colinds == spmat.indices)
-
-
-def test_sparse_ratings_torch():
-    ratings = ml_test.ratings
-    mat: torch.Tensor
-    mat, uidx, iidx = sparse_ratings(ratings, type="torch")
-
-    assert torch.is_tensor(mat)
-    assert mat.is_sparse_csr
-    assert len(uidx) == ratings.user.nunique()
-    assert len(iidx) == ratings.item.nunique()
-
-
-def test_sparse_ratings_indexes(rng):
-    ratings = ml_test.ratings
-    uidx = pd.Index(rng.permutation(ratings["user"].unique()))
-    iidx = pd.Index(rng.permutation(ratings["item"].unique()))
-
-    mat, _uidx, _iidx = sparse_ratings(ratings, users=uidx, items=iidx)
-
-    assert _uidx is uidx
-    assert _iidx is iidx
-    assert len(_uidx) == ratings.user.nunique()
-    assert len(_iidx) == ratings.item.nunique()
-
-    # verify rating values
-    ratings = ratings.set_index(["user", "item"])
-    for u in rng.choice(_uidx, size=50):
-        ui = _uidx.get_loc(u)
-        r = mat[[ui], :]
-        vs = pd.Series(r.data, _iidx[r.indices])
-        rates = ratings.loc[u]["rating"]
-        vs, rates = vs.align(rates)
-        assert not any(vs.isna())
-        assert not any(rates.isna())
-        assert all(vs == rates)
+from lenskit.data.matrix import safe_spmv, torch_sparse_from_scipy
+from lenskit.util.test import coo_arrays
 
 
 @settings(deadline=1000, suppress_health_check=[HealthCheck.too_slow])

--- a/lenskit/tests/test_matrix_rows.py
+++ b/lenskit/tests/test_matrix_rows.py
@@ -23,17 +23,14 @@ _log = logging.getLogger(__name__)
 
 
 @settings(deadline=1000, suppress_health_check=[HealthCheck.too_slow])
-@given(sparse_tensors())
+@given(sparse_tensors(dtype=np.float64))
 def test_sparse_mean_center(tensor: torch.Tensor):
     nr, nc = tensor.shape
 
     coo = tensor.to_sparse_coo()
     rows = coo.indices()[0, :].numpy()
     counts = np.zeros(nr, dtype=np.int32)
-    if tensor.dtype == torch.float64:
-        sums = np.zeros(nr, dtype=np.float64)
-    else:
-        sums = np.zeros(nr, dtype=np.float64)
+    sums = np.zeros(nr, dtype=np.float64)
 
     np.add.at(counts, rows, 1)
     np.add.at(sums, rows, coo.values().numpy())
@@ -43,7 +40,7 @@ def test_sparse_mean_center(tensor: torch.Tensor):
     nt, means = normalize_sparse_rows(tensor, "center")
     assert means.shape == torch.Size([nr])
 
-    assert means.numpy() == approx(tgt_means, nan_ok=True, rel=1.0e-5)
+    assert means.numpy() == approx(tgt_means, nan_ok=True, rel=1.0e-6)
 
     for i in range(nr):
         tr = tensor[i].values().numpy()

--- a/lenskit/tests/test_matrix_rows.py
+++ b/lenskit/tests/test_matrix_rows.py
@@ -30,15 +30,20 @@ def test_sparse_mean_center(tensor: torch.Tensor):
     coo = tensor.to_sparse_coo()
     rows = coo.indices()[0, :].numpy()
     counts = np.zeros(nr, dtype=np.int32)
-    sums = np.zeros(nr, dtype=np.float64)
+    if tensor.dtype == torch.float64:
+        sums = np.zeros(nr, dtype=np.float64)
+    else:
+        sums = np.zeros(nr, dtype=np.float64)
+
     np.add.at(counts, rows, 1)
     np.add.at(sums, rows, coo.values().numpy())
     tgt_means = sums / counts
     tgt_means = np.nan_to_num(tgt_means, nan=0)
+
     nt, means = normalize_sparse_rows(tensor, "center")
     assert means.shape == torch.Size([nr])
 
-    assert means.numpy() == approx(tgt_means, nan_ok=True, rel=5.0e-5)
+    assert means.numpy() == approx(tgt_means, nan_ok=True, rel=1.0e-5)
 
     for i in range(nr):
         tr = tensor[i].values().numpy()

--- a/lenskit/tests/test_matrix_rows.py
+++ b/lenskit/tests/test_matrix_rows.py
@@ -30,7 +30,7 @@ def test_sparse_mean_center(tensor: torch.Tensor):
     coo = tensor.to_sparse_coo()
     rows = coo.indices()[0, :].numpy()
     counts = np.zeros(nr, dtype=np.int32)
-    sums = np.zeros(nr, dtype=np.float32)
+    sums = np.zeros(nr, dtype=np.float64)
     np.add.at(counts, rows, 1)
     np.add.at(sums, rows, coo.values().numpy())
     tgt_means = sums / counts
@@ -38,7 +38,7 @@ def test_sparse_mean_center(tensor: torch.Tensor):
     nt, means = normalize_sparse_rows(tensor, "center")
     assert means.shape == torch.Size([nr])
 
-    assert means.numpy() == approx(tgt_means, nan_ok=True)
+    assert means.numpy() == approx(tgt_means, nan_ok=True, rel=1.0e-5)
 
     for i in range(nr):
         tr = tensor[i].values().numpy()

--- a/lenskit/tests/test_matrix_rows.py
+++ b/lenskit/tests/test_matrix_rows.py
@@ -38,7 +38,7 @@ def test_sparse_mean_center(tensor: torch.Tensor):
     nt, means = normalize_sparse_rows(tensor, "center")
     assert means.shape == torch.Size([nr])
 
-    assert means.numpy() == approx(tgt_means, nan_ok=True, rel=1.0e-5)
+    assert means.numpy() == approx(tgt_means, nan_ok=True, rel=5.0e-5)
 
     for i in range(nr):
         tr = tensor[i].values().numpy()


### PR DESCRIPTION
This removes the now-obsolete `sparse_ratings` and `sparse_row_stats` functions, in favor of using the dataset.