### PR TITLE
Support config-based pipeline cloning

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -329,3 +329,5 @@ memory parallelism in its batch-inference code.
 .. autoclass:: ConfigurableComponent
 
 .. autoclass:: TrainableComponent
+
+.. autoclass:: AutoConfig

--- a/lenskit/lenskit/pipeline/components.py
+++ b/lenskit/lenskit/pipeline/components.py
@@ -36,6 +36,9 @@ class ConfigurableComponent(Protocol):  # pragma: nocover
     configurable.  For most common cases, extending the :class:`AutoConfig`
     class is sufficient to provide working implementations of these methods.
 
+    If a component is *not* configurable, then it should either be a function or
+    a class that can be constructed with no arguments.
+
     .. note::
 
         Configuration data should be JSON-compatible (strings, numbers, etc.).

--- a/lenskit/lenskit/pipeline/components.py
+++ b/lenskit/lenskit/pipeline/components.py
@@ -33,7 +33,8 @@ class ConfigurableComponent(Protocol):  # pragma: nocover
       :meth:`from_config`.
 
     A component must implement both of these methods to be considered
-    configurable.
+    configurable.  For most common cases, extending the :class:`AutoConfig`
+    class is sufficient to provide working implementations of these methods.
 
     .. note::
 

--- a/lenskit/tests/test_pipeline_config.py
+++ b/lenskit/tests/test_pipeline_config.py
@@ -1,19 +1,61 @@
+import json
+
+from lenskit.pipeline import Pipeline
 from lenskit.pipeline.components import AutoConfig
+from lenskit.pipeline.nodes import ComponentNode
 
 
-class MyComponent(AutoConfig):
-    param: str
+class Prefixer(AutoConfig):
+    prefix: str
 
-    def __init__(self, param: str = "hello"):
-        self.param = param
+    def __init__(self, prefix: str = "hello"):
+        self.prefix = prefix
+
+    def __call__(self, msg: str):
+        return self.prefix + msg
 
 
 def test_auto_config_roundtrip():
-    comp = MyComponent("FOOBIE BLETCH")
+    comp = Prefixer("FOOBIE BLETCH")
 
     cfg = comp.get_config()
-    assert "param" in cfg
+    assert "prefix" in cfg
 
-    c2 = MyComponent.from_config(cfg)
+    c2 = Prefixer.from_config(cfg)
     assert c2 is not comp
-    assert c2.param == comp.param
+    assert c2.prefix == comp.prefix
+
+
+def test_pipeline_config():
+    comp = Prefixer("scroll named ")
+
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    pipe.add_component("prefix", comp, msg=msg)
+
+    assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
+
+    config = pipe.component_configs()
+    print(json.dumps(config, indent=2))
+
+    assert "prefix" in config
+    assert config["prefix"]["prefix"] == "scroll named "
+
+
+def test_pipeline_clone():
+    comp = Prefixer("scroll named ")
+
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    pipe.add_component("prefix", comp, msg=msg)
+
+    assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
+
+    p2 = pipe.clone()
+    n2 = p2.node("prefix")
+    assert isinstance(n2, ComponentNode)
+    assert isinstance(n2.component, Prefixer)
+    assert n2.component is not comp
+    assert n2.component.prefix == comp.prefix
+
+    assert p2.run(msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE"

--- a/lenskit/tests/test_pipeline_config.py
+++ b/lenskit/tests/test_pipeline_config.py
@@ -1,0 +1,19 @@
+from lenskit.pipeline.components import AutoConfig
+
+
+class MyComponent(AutoConfig):
+    param: str
+
+    def __init__(self, param: str = "hello"):
+        self.param = param
+
+
+def test_auto_config_roundtrip():
+    comp = MyComponent("FOOBIE BLETCH")
+
+    cfg = comp.get_config()
+    assert "param" in cfg
+
+    c2 = MyComponent.from_config(cfg)
+    assert c2 is not comp
+    assert c2.param == comp.param

--- a/lenskit/tests/test_pipeline_config.py
+++ b/lenskit/tests/test_pipeline_config.py
@@ -17,8 +17,19 @@ class Prefixer(AutoConfig):
     def __init__(self, prefix: str = "hello"):
         self.prefix = prefix
 
-    def __call__(self, msg: str):
+    def __call__(self, msg: str) -> str:
         return self.prefix + msg
+
+
+class Question:
+    "test component that is not configurable but is a class"
+
+    def __call__(self, msg: str) -> str:
+        return msg + "?"
+
+
+def exclaim(msg: str) -> str:
+    return msg + "!"
 
 
 def test_auto_config_roundtrip():
@@ -65,3 +76,33 @@ def test_pipeline_clone():
     assert n2.component.prefix == comp.prefix
 
     assert p2.run(msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE"
+
+
+def test_pipeline_clone_with_function():
+    comp = Prefixer("scroll named ")
+
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    pfx = pipe.add_component("prefix", comp, msg=msg)
+    pipe.add_component("exclaim", exclaim, msg=pfx)
+
+    assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH!"
+
+    p2 = pipe.clone()
+
+    assert p2.run(msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE!"
+
+
+def test_pipeline_clone_with_nonconfig_class():
+    comp = Prefixer("scroll named ")
+
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    pfx = pipe.add_component("prefix", comp, msg=msg)
+    pipe.add_component("question", Question(), msg=pfx)
+
+    assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH?"
+
+    p2 = pipe.clone()
+
+    assert p2.run(msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE?"

--- a/lenskit/tests/test_pipeline_config.py
+++ b/lenskit/tests/test_pipeline_config.py
@@ -1,3 +1,9 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 import json
 
 from lenskit.pipeline import Pipeline


### PR DESCRIPTION
This builds on #462 to support component configuration and configuration-based cloning of pipelines.
