### PR TITLE
Make pipeline fallback work when nodes fail transitively

### DIFF
--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -257,23 +257,21 @@ class Pipeline:
 
         .. code:: python
 
-            pipe = Pipeline()
-            # allow candidate items to be optionally specified
-            items = pipe.create_input('items', list[EntityId], None)
-            # find candidates from the training data (optional)
-            lookup_candidates = pipe.add_component(
-                'select-candidates',
-                UnratedTrainingItemsCandidateSelector(),
+            pipe = Pipeline() # allow candidate items to be optionally specified
+            items = pipe.create_input('items', list[EntityId], None) # find
+            candidates from the training data (optional) lookup_candidates =
+            pipe.add_component(
+                'select-candidates', UnratedTrainingItemsCandidateSelector(),
                 user=history,
-            )
-            # if the client provided items as a pipeline input, use those; otherwise
-            # use the candidate selector we just configured.
-            candidates = pipe.use_first_of('candidates', items, lookup_candidates)
+            ) # if the client provided items as a pipeline input, use those;
+            otherwise # use the candidate selector we just configured.
+            candidates = pipe.use_first_of('candidates', items,
+            lookup_candidates)
 
         .. note::
 
-            This method does not distinguish between an input being unspecified and
-            explicitly specified as ``None``.
+            This method does not distinguish between an input being unspecified
+            and explicitly specified as ``None``.
 
         .. note::
 
@@ -283,6 +281,14 @@ class Pipeline:
             will not use B to fill in missing scores for individual items that A
             did not score.  A specific itemwise fallback component is needed for
             such an operation.
+
+        .. note::
+
+            If one of the fallback elements is a component ``A`` that depends on
+            another component or input ``B``, and ``B`` is missing or returns
+            ``None`` such that ``A`` would usually fail, then ``A`` will be
+            skipped and the fallback will move on to the next node. This works
+            with arbitrarily-deep transitive chains.
 
         Args:
             name:

--- a/lenskit/tests/test_pipeline.py
+++ b/lenskit/tests/test_pipeline.py
@@ -491,6 +491,25 @@ def test_fallback_transitive():
     assert pipe.run(c, b=17) == 34
 
 
+def test_fallback_transitive_deeper():
+    "deeper transitive fallback test"
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def negative(x: int) -> int:
+        return -x
+
+    def double(x: int) -> int:
+        return x * 2
+
+    nd = pipe.add_component("double", double, x=a)
+    nn = pipe.add_component("negate", negative, x=nd)
+    nr = pipe.use_first_of("fill-operand", nn, b)
+
+    assert pipe.run(nr, b=8) == 8
+
+
 def test_train(ml_ds: Dataset):
     pipe = Pipeline()
     item = pipe.create_input("item", int)

--- a/lenskit/tests/test_pipeline.py
+++ b/lenskit/tests/test_pipeline.py
@@ -472,6 +472,25 @@ def test_fallback_fail_with_missing_options():
         pipe.run(na, a=3)
 
 
+def test_fallback_transitive():
+    "test that a fallback works if a dependency's dependency fails"
+    pipe = Pipeline()
+    ia = pipe.create_input("a", int)
+    ib = pipe.create_input("b", int)
+
+    def double(x: int) -> int:
+        return 2 * x
+
+    # two components, each with a different input
+    c1 = pipe.add_component("double-a", double, x=ia)
+    c2 = pipe.add_component("double-b", double, x=ib)
+    # use the first that succeeds
+    c = pipe.use_first_of("result", c1, c2)
+
+    # omitting the first input should result in the second component
+    assert pipe.run(c, b=17) == 34
+
+
 def test_train(ml_ds: Dataset):
     pipe = Pipeline()
     item = pipe.create_input("item", int)

--- a/lenskit/tests/test_pipeline.py
+++ b/lenskit/tests/test_pipeline.py
@@ -510,6 +510,30 @@ def test_fallback_transitive_deeper():
     assert pipe.run(nr, b=8) == 8
 
 
+def test_fallback_transitive_nodefail():
+    "deeper transitive fallback test"
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def negative(x: int) -> int | None:
+        # make this return None in some cases to trigger failure
+        if x >= 0:
+            return -x
+        else:
+            return None
+
+    def double(x: int) -> int:
+        return x * 2
+
+    nd = pipe.add_component("double", double, x=a)
+    nn = pipe.add_component("negate", negative, x=nd)
+    nr = pipe.use_first_of("fill-operand", nn, b)
+
+    assert pipe.run(nr, a=2, b=8) == -4
+    assert pipe.run(nr, a=-7, b=8) == 8
+
+
 def test_train(ml_ds: Dataset):
     pipe = Pipeline()
     item = pipe.create_input("item", int)


### PR DESCRIPTION
This adds transitive fallback support: if `A` depends on `B` and `B` is missing or returns `None`, then the fallback should proceed to the next item instead of failing because `A` failed. The old behavior was that the fallback would only work if one of its direct dependencies yielded the missing data.