### PR TITLE
Simply Vocabulary, add types module, and improve type documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,8 +84,7 @@ autodoc_default_options = {"members": True, "member-order": "bysource", "show-in
 autodoc_typehints = "description"
 autodoc_type_aliases = {
     "ArrayLike": "numpy.typing.ArrayLike",
-    "EntityVocab": "lenskit.data.EntityVocab",
-    "RandomSeed": "abc.ABC",
+    "RandomSeed": "lenskit.types.RandomSeed",
 }
 
 todo_include_todos = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,8 +83,9 @@ templates_path = ["_templates"]
 autodoc_default_options = {"members": True, "member-order": "bysource", "show-inheritance": True}
 autodoc_typehints = "description"
 autodoc_type_aliases = {
-    "Iterable": "Iterable",
-    "ArrayLike": "ArrayLike",
+    "ArrayLike": "numpy.typing.ArrayLike",
+    "EntityVocab": "lenskit.data.EntityVocab",
+    "RandomSeed": "abc.ABC",
 }
 
 todo_include_todos = True
@@ -95,7 +96,6 @@ intersphinx_mapping = {
     "pandas": ("http://pandas.pydata.org/pandas-docs/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "scikit": ("https://scikit-learn.org/stable/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "seedbank": ("https://seedbank.lenskit.org/en/latest/", None),
     "progress_api": ("https://progress-api.readthedocs.io/en/latest/", None),

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -56,7 +56,7 @@ Identifiers and numbers can be mapped to each other with the user and item
 *vocabularies* (:attr:`~Dataset.users` and :attr:`~Dataset.items`, see the
 :class:`~lenskit.data.vocab.Vocabulary` class).
 
-.. autodata:: lenskit.data.vocab.EntityId
+.. autodata:: EntityId
 
 .. _dataset:
 
@@ -91,6 +91,11 @@ and tensor data structures.
 
 .. autoclass:: Vocabulary
 
+Type-Specific Vocabularies
+--------------------------
+
+.. autodata:: EntityVocab
+
 User and Item Data
 ~~~~~~~~~~~~~~~~~~
 
@@ -98,7 +103,7 @@ The :mod:`lenskit.data` package also provides various classes for representing
 user and item data.
 
 Item Lists
-~~~~~~~~~~
+----------
 
 LensKit uses *item lists* to represent collections of items that may be scored,
 ranked, etc.
@@ -106,7 +111,7 @@ ranked, etc.
 .. autoclass:: ItemList
 
 Utility Types
-~~~~~~~~~~~~~
+-------------
 
 .. autoclass:: UITuple
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -144,4 +144,5 @@ The lazy data set takes a function that loads a data set (of any type), and
 lazily uses that function to load an underlying data set when needed.
 
 .. autoclass:: LazyDataset
+    :no-members:
     :members: delegate

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -110,11 +110,6 @@ ranked, etc.
 
 .. autoclass:: ItemList
 
-Utility Types
--------------
-
-.. autoclass:: UITuple
-
 User-Item Data Tables
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -89,10 +89,13 @@ LensKit uses *vocabularies* to record user/item IDs, tags, terms, etc. in a way
 that facilitates easy mapping to 0-based contiguous indexes for use in matrix
 and tensor data structures.
 
-.. module:: lenskit.data
-
 .. autoclass:: Vocabulary
 
+User and Item Data
+~~~~~~~~~~~~~~~~~~
+
+The :mod:`lenskit.data` package also provides various classes for representing
+user and item data.
 
 Item Lists
 ~~~~~~~~~~
@@ -101,6 +104,11 @@ LensKit uses *item lists* to represent collections of items that may be scored,
 ranked, etc.
 
 .. autoclass:: ItemList
+
+Utility Types
+~~~~~~~~~~~~~
+
+.. autoclass:: UITuple
 
 User-Item Data Tables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -91,11 +91,6 @@ and tensor data structures.
 
 .. autoclass:: Vocabulary
 
-Type-Specific Vocabularies
---------------------------
-
-.. autodata:: EntityVocab
-
 User and Item Data
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -4,3 +4,19 @@ LensKit Internals
 These modules are primarily for internal infrastructural support in Lenskit.
 Neither LensKit users nor algorithm developers are likely to need to use this
 code directly.
+
+.. class:: lenskit.types.RandomSeed
+
+    Random seed values for LensKit models and components.  Can be any valid
+    input to :func:`seedbank.numpy_rng`, including:
+
+    * Any :data:`seedbank.SeedLike`
+    * A :class:`numpy.random.Generator`
+    * A :class:`numpy.random.RandomState` (deprecated)
+
+    .. note::
+
+        This is a type alias, not a class; it is documented as a class to work
+        around limitations in Sphinx.
+
+.. autoclass:: lenskit.types.UITuple

--- a/lenskit-implicit/lenskit/implicit.py
+++ b/lenskit-implicit/lenskit/implicit.py
@@ -17,7 +17,7 @@ from typing_extensions import override
 
 from lenskit.algorithms import Predictor, Recommender
 from lenskit.data.dataset import Dataset
-from lenskit.data.vocab import EntityId, Vocabulary
+from lenskit.data.vocab import Vocabulary
 
 _logger = logging.getLogger(__name__)
 
@@ -59,11 +59,11 @@ class BaseRec(Recommender, Predictor):
     """
     The user-item rating matrix from training.
     """
-    users_: Vocabulary[EntityId]
+    users_: Vocabulary
     """
     The user ID mapping from training.
     """
-    items_: Vocabulary[EntityId]
+    items_: Vocabulary
     """
     The item ID mapping from training.
     """

--- a/lenskit/lenskit/algorithms/als/common.py
+++ b/lenskit/lenskit/algorithms/als/common.py
@@ -18,8 +18,7 @@ from typing_extensions import Iterator, NamedTuple, Optional, Self, override
 
 from lenskit import util
 from lenskit.algorithms.mf_common import MFPredictor
-from lenskit.data.dataset import Dataset
-from lenskit.data.vocab import EntityId, Vocabulary
+from lenskit.data import Dataset, EntityVocab, Vocabulary
 from lenskit.parallel.config import ensure_parallel_init
 
 
@@ -55,9 +54,9 @@ class TrainingData(NamedTuple):
     Data for training the ALS model.
     """
 
-    users: Vocabulary[EntityId]
+    users: EntityVocab
     "User ID mapping."
-    items: Vocabulary[EntityId]
+    items: EntityVocab
     "Item ID mapping."
     ui_rates: torch.Tensor
     "User-item rating matrix."
@@ -73,9 +72,7 @@ class TrainingData(NamedTuple):
         return len(self.items)
 
     @classmethod
-    def create(
-        cls, users: Vocabulary[EntityId], items: Vocabulary[EntityId], ratings: torch.Tensor
-    ) -> TrainingData:
+    def create(cls, users: EntityVocab, items: EntityVocab, ratings: torch.Tensor) -> TrainingData:
         assert ratings.shape == (len(users), len(items))
 
         transposed = ratings.transpose(0, 1).to_sparse_csr()

--- a/lenskit/lenskit/algorithms/als/common.py
+++ b/lenskit/lenskit/algorithms/als/common.py
@@ -18,7 +18,7 @@ from typing_extensions import Iterator, NamedTuple, Optional, Self, override
 
 from lenskit import util
 from lenskit.algorithms.mf_common import MFPredictor
-from lenskit.data import Dataset, EntityVocab, Vocabulary
+from lenskit.data import Dataset, Vocabulary
 from lenskit.parallel.config import ensure_parallel_init
 
 
@@ -54,9 +54,9 @@ class TrainingData(NamedTuple):
     Data for training the ALS model.
     """
 
-    users: EntityVocab
+    users: Vocabulary
     "User ID mapping."
-    items: EntityVocab
+    items: Vocabulary
     "Item ID mapping."
     ui_rates: torch.Tensor
     "User-item rating matrix."
@@ -72,7 +72,7 @@ class TrainingData(NamedTuple):
         return len(self.items)
 
     @classmethod
-    def create(cls, users: EntityVocab, items: EntityVocab, ratings: torch.Tensor) -> TrainingData:
+    def create(cls, users: Vocabulary, items: Vocabulary, ratings: torch.Tensor) -> TrainingData:
         assert ratings.shape == (len(users), len(items))
 
         transposed = ratings.transpose(0, 1).to_sparse_csr()

--- a/lenskit/lenskit/algorithms/knn/item.py
+++ b/lenskit/lenskit/algorithms/knn/item.py
@@ -24,7 +24,7 @@ from lenskit import util
 from lenskit.data import FeedbackType
 from lenskit.data.dataset import Dataset
 from lenskit.data.matrix import normalize_sparse_rows, safe_spmv
-from lenskit.data.vocab import EntityId, Vocabulary
+from lenskit.data.vocab import Vocabulary
 from lenskit.diagnostics import ConfigWarning, DataWarning
 from lenskit.parallel import ensure_parallel_init
 from lenskit.util.logging import pbh_update, progress_handle
@@ -111,7 +111,7 @@ class ItemItem(Predictor):
     aggregate: str
     use_ratings: bool
 
-    items_: Vocabulary[EntityId]
+    items_: Vocabulary
     "Vocabulary of item IDs."
     item_means_: torch.Tensor | None
     "Mean rating for each known item."
@@ -119,7 +119,7 @@ class ItemItem(Predictor):
     "Number of saved neighbors for each item."
     sim_matrix_: torch.Tensor
     "Similarity matrix (sparse CSR tensor)."
-    users_: Vocabulary[EntityId]
+    users_: Vocabulary
     "Vocabulary of user IDs."
     rating_matrix_: torch.Tensor
     "Normalized rating matrix to look up user ratings at prediction time."

--- a/lenskit/lenskit/algorithms/knn/user.py
+++ b/lenskit/lenskit/algorithms/knn/user.py
@@ -23,7 +23,7 @@ from lenskit import util
 from lenskit.data import FeedbackType
 from lenskit.data.dataset import Dataset
 from lenskit.data.matrix import normalize_sparse_rows, safe_spmv
-from lenskit.data.vocab import EntityId, Vocabulary
+from lenskit.data.vocab import Vocabulary
 from lenskit.diagnostics import DataWarning
 from lenskit.parallel.config import ensure_parallel_init
 
@@ -83,9 +83,9 @@ class UserUser(Predictor):
     aggregate: str
     use_ratings: bool
 
-    users_: Vocabulary[EntityId]
+    users_: Vocabulary
     "The index of user IDs."
-    items_: Vocabulary[EntityId]
+    items_: Vocabulary
     "The index of item IDs."
     user_means_: torch.Tensor | None
     "Mean rating for each known user."

--- a/lenskit/lenskit/algorithms/svd.py
+++ b/lenskit/lenskit/algorithms/svd.py
@@ -13,7 +13,7 @@ import pandas as pd
 from typing_extensions import Literal, override
 
 from lenskit.data.dataset import Dataset
-from lenskit.data.vocab import EntityId, Vocabulary
+from lenskit.data.vocab import Vocabulary
 
 try:
     from sklearn.decomposition import TruncatedSVD
@@ -42,8 +42,8 @@ class BiasedSVD(Predictor):
 
     bias: Bias
     factorization: TruncatedSVD
-    users_: Vocabulary[EntityId]
-    items_: Vocabulary[EntityId]
+    users_: Vocabulary
+    items_: Vocabulary
 
     def __init__(
         self,

--- a/lenskit/lenskit/data/__init__.py
+++ b/lenskit/lenskit/data/__init__.py
@@ -3,13 +3,42 @@
 # Copyright (C) 2023-2024 Drexel University
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
 
-from typing import Literal, TypeAlias
+from typing_extensions import Generic, Literal, NamedTuple, TypeAlias, TypeVar
 
 from .vocab import EntityId, Vocabulary  # noqa: F401, E402
 
 FeedbackType: TypeAlias = Literal["explicit", "implicit"]
 "Types of feedback supported."
+
+
+T = TypeVar("T")
+
+
+class UITuple(Generic[T], NamedTuple):
+    """
+    Tuple of (user, item) data, typically for configuration and similar
+    purposes.
+    """
+
+    user: T
+    item: T
+
+    @classmethod
+    def create(cls, x: UITuple[T] | tuple[T, T] | T) -> UITuple[T]:
+        """
+        Create a user-item tuple from a tuple or data.  If a single value
+        is provided, it is used for both user and item.
+        """
+        if isinstance(x, UITuple):
+            return x
+        elif isinstance(x, tuple):
+            u, i = x
+            return UITuple(u, i)
+        else:
+            return UITuple(x, x)
+
 
 from .dataset import Dataset, from_interactions_df  # noqa: F401, E402
 from .items import ItemList  # noqa: F401, E402

--- a/lenskit/lenskit/data/__init__.py
+++ b/lenskit/lenskit/data/__init__.py
@@ -12,11 +12,8 @@ from lenskit.types import EntityId, NPEntityId  # noqa: F401
 FeedbackType: TypeAlias = Literal["explicit", "implicit"]
 "Types of feedback supported."
 
-from .vocab import Vocabulary  # noqa: F401, E402
-
-
-
 from .dataset import Dataset, from_interactions_df  # noqa: F401, E402
 from .items import ItemList  # noqa: F401, E402
 from .movielens import load_movielens  # noqa: F401, E402
 from .mtarray import MTArray, MTFloatArray, MTGenericArray, MTIntArray  # noqa: F401, E402
+from .vocab import Vocabulary  # noqa: F401, E402

--- a/lenskit/lenskit/data/__init__.py
+++ b/lenskit/lenskit/data/__init__.py
@@ -5,39 +5,15 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-from typing_extensions import Generic, Literal, NamedTuple, TypeAlias, TypeVar
+from typing_extensions import Literal, TypeAlias
 
-from .vocab import EntityId, Vocabulary  # noqa: F401, E402
+from lenskit.types import EntityId, NPEntityId  # noqa: F401
 
 FeedbackType: TypeAlias = Literal["explicit", "implicit"]
 "Types of feedback supported."
 
+from .vocab import Vocabulary  # noqa: F401, E402
 
-T = TypeVar("T")
-
-
-class UITuple(Generic[T], NamedTuple):
-    """
-    Tuple of (user, item) data, typically for configuration and similar
-    purposes.
-    """
-
-    user: T
-    item: T
-
-    @classmethod
-    def create(cls, x: UITuple[T] | tuple[T, T] | T) -> UITuple[T]:
-        """
-        Create a user-item tuple from a tuple or data.  If a single value
-        is provided, it is used for both user and item.
-        """
-        if isinstance(x, UITuple):
-            return x
-        elif isinstance(x, tuple):
-            u, i = x
-            return UITuple(u, i)
-        else:
-            return UITuple(x, x)
 
 
 from .dataset import Dataset, from_interactions_df  # noqa: F401, E402

--- a/lenskit/lenskit/data/dataset.py
+++ b/lenskit/lenskit/data/dataset.py
@@ -32,12 +32,12 @@ from typing_extensions import (
     override,
 )
 
-from lenskit.data.items import ItemList
-from lenskit.data.matrix import CSRStructure, InteractionMatrix
-from lenskit.data.vocab import Vocabulary
+from lenskit.types import EntityId
 
-from . import EntityId
+from .items import ItemList
+from .matrix import CSRStructure, InteractionMatrix
 from .tables import NumpyUserItemTable, TorchUserItemTable
+from .vocab import Vocabulary
 
 DF_FORMAT: TypeAlias = Literal["numpy", "pandas", "torch"]
 MAT_FORMAT: TypeAlias = Literal["scipy", "torch", "pandas", "structure"]
@@ -84,7 +84,7 @@ class Dataset(ABC):
 
     @property
     @abstractmethod
-    def items(self) -> Vocabulary[EntityId]:
+    def items(self) -> Vocabulary:
         """
         The items known by this dataset.
         """
@@ -92,7 +92,7 @@ class Dataset(ABC):
 
     @property
     @abstractmethod
-    def users(self) -> Vocabulary[EntityId]:
+    def users(self) -> Vocabulary:
         """
         The users known by this dataset.
         """
@@ -504,9 +504,9 @@ class MatrixDataset(Dataset):
         :mod:`lenskit.data`.
     """
 
-    _users: Vocabulary[EntityId]
+    _users: Vocabulary
     "User ID vocabulary, to map between IDs and row numbers."
-    _items: Vocabulary[EntityId]
+    _items: Vocabulary
     "Item ID vocabulary, to map between IDs and column or row numbers."
     _matrix: InteractionMatrix
 
@@ -546,12 +546,12 @@ class MatrixDataset(Dataset):
 
     @property
     @override
-    def items(self) -> Vocabulary[EntityId]:
+    def items(self) -> Vocabulary:
         return self._items
 
     @property
     @override
-    def users(self) -> Vocabulary[EntityId]:
+    def users(self) -> Vocabulary:
         return self._users
 
     @override
@@ -795,12 +795,12 @@ class LazyDataset(Dataset):
 
     @property
     @override
-    def items(self) -> Vocabulary[EntityId]:
+    def items(self) -> Vocabulary:
         return self.delegate().items
 
     @property
     @override
-    def users(self) -> Vocabulary[EntityId]:
+    def users(self) -> Vocabulary:
         return self.delegate().users
 
     @override

--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -20,17 +20,17 @@ from typing_extensions import (
     LiteralString,
     Sequence,
     TypeAlias,
-    TypeVar,
     cast,
     overload,
 )
 
-from lenskit.data.checks import check_1d
-from lenskit.data.mtarray import MTArray, MTGenericArray
-from lenskit.data.vocab import EntityId, NPEntityId, Vocabulary
+from lenskit.types import EntityId, NPEntityId
+
+from .checks import check_1d
+from .mtarray import MTArray, MTGenericArray
+from .vocab import Vocabulary
 
 Backend: TypeAlias = Literal["numpy", "torch"]
-EID = TypeVar("EID", bound=EntityId)
 
 
 class ItemList:
@@ -110,7 +110,7 @@ class ItemList:
     _len: int
     _ids: np.ndarray[int, np.dtype[NPEntityId]] | None = None
     _numbers: MTArray[np.int32] | None = None
-    _vocab: Vocabulary[EntityId] | None = None
+    _vocab: Vocabulary | None = None
     _ranks: MTArray[np.int32] | None = None
     _fields: dict[str, MTGenericArray]
 
@@ -119,7 +119,7 @@ class ItemList:
         *,
         item_ids: NDArray[NPEntityId] | pd.Series[EntityId] | Sequence[EntityId] | None = None,
         item_nums: NDArray[np.int32] | pd.Series[int] | Sequence[int] | ArrayLike | None = None,
-        vocabulary: Vocabulary[EID] | None = None,
+        vocabulary: Vocabulary | None = None,
         ordered: bool = False,
         scores: NDArray[np.generic] | torch.Tensor | ArrayLike | None = None,
         **fields: NDArray[np.generic] | torch.Tensor | ArrayLike,
@@ -167,7 +167,7 @@ class ItemList:
 
     @classmethod
     def from_df(
-        cls, df: pd.DataFrame, *, vocabulary=Vocabulary[EntityId], keep_user: bool = False
+        cls, df: pd.DataFrame, *, vocabulary=Vocabulary, keep_user: bool = False
     ) -> ItemList:
         """
         Create a item list from a Pandas data frame.  The frame should have
@@ -223,24 +223,24 @@ class ItemList:
             if self._vocab is None:
                 raise RuntimeError("item IDs not available (no IDs or vocabulary provided)")
             assert self._numbers is not None
-            self._ids = self._vocab.ids(self._numbers.numpy())
+            self._ids = cast(NDArray[NPEntityId], self._vocab.ids(self._numbers.numpy()))
 
         return self._ids
 
     @overload
     def numbers(
-        self, format: Literal["numpy"] = "numpy", *, vocabulary: Vocabulary[EID] | None = None
+        self, format: Literal["numpy"] = "numpy", *, vocabulary: Vocabulary | None = None
     ) -> NDArray[np.int32]: ...
     @overload
     def numbers(
-        self, format: Literal["torch"], *, vocabulary: Vocabulary[EID] | None = None
+        self, format: Literal["torch"], *, vocabulary: Vocabulary | None = None
     ) -> torch.Tensor: ...
     @overload
     def numbers(
-        self, format: LiteralString = "numpy", *, vocabulary: Vocabulary[EID] | None = None
+        self, format: LiteralString = "numpy", *, vocabulary: Vocabulary | None = None
     ) -> ArrayLike: ...
     def numbers(
-        self, format: LiteralString = "numpy", *, vocabulary: Vocabulary[EID] | None = None
+        self, format: LiteralString = "numpy", *, vocabulary: Vocabulary | None = None
     ) -> ArrayLike:
         """
         Get the item numbers.

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -20,7 +20,12 @@ from typing_extensions import Any, LiteralString, TypeVar, overload
 
 from lenskit.data import Dataset
 
-from .components import Component, ConfigurableComponent, TrainableComponent
+from .components import (
+    AutoConfig,  # noqa: F401 # type: ignore
+    Component,
+    ConfigurableComponent,
+    TrainableComponent,
+)
 from .nodes import ND, ComponentNode, FallbackNode, InputNode, LiteralNode, Node
 
 __all__ = [

--- a/lenskit/lenskit/splitting/holdout.py
+++ b/lenskit/lenskit/splitting/holdout.py
@@ -12,9 +12,9 @@ from typing import Protocol
 
 import numpy as np
 from seedbank import numpy_rng
-from seedbank.numpy import NPRNGSource
 
 from lenskit.data.items import ItemList
+from lenskit.types import RandomSeed
 
 
 class HoldoutMethod(Protocol):
@@ -51,7 +51,7 @@ class SampleN(HoldoutMethod):
     n: int
     rng: np.random.Generator
 
-    def __init__(self, n: int, rng_spec: NPRNGSource | None = None):
+    def __init__(self, n: int, rng_spec: RandomSeed | None = None):
         self.n = n
         self.rng = numpy_rng(rng_spec)
 
@@ -74,7 +74,7 @@ class SampleFrac(HoldoutMethod):
     fraction: float
     rng: np.random.Generator
 
-    def __init__(self, frac: float, rng_spec: NPRNGSource | None = None):
+    def __init__(self, frac: float, rng_spec: RandomSeed | None = None):
         self.fraction = frac
         self.rng = numpy_rng(rng_spec)
 

--- a/lenskit/lenskit/splitting/records.py
+++ b/lenskit/lenskit/splitting/records.py
@@ -10,9 +10,9 @@ from typing import Iterator, overload
 import numpy as np
 import pandas as pd
 from seedbank import numpy_rng
-from seedbank.numpy import NPRNGSource
 
 from lenskit.data.dataset import Dataset, MatrixDataset
+from lenskit.types import RandomSeed
 
 from .split import TTSplit, dict_from_df
 
@@ -20,7 +20,7 @@ _log = logging.getLogger(__name__)
 
 
 def crossfold_records(
-    data: Dataset, partitions: int, *, rng_spec: NPRNGSource | None = None
+    data: Dataset, partitions: int, *, rng_spec: RandomSeed | None = None
 ) -> Iterator[TTSplit]:
     """
     Partition a dataset by **records** into cross-fold partitions.  This
@@ -67,7 +67,7 @@ def sample_records(
     size: int,
     *,
     disjoint: bool = True,
-    rng_spec: NPRNGSource | None = None,
+    rng_spec: RandomSeed | None = None,
     repeats: None = None,
 ) -> TTSplit: ...
 @overload
@@ -77,7 +77,7 @@ def sample_records(
     *,
     repeats: int,
     disjoint: bool = True,
-    rng_spec: NPRNGSource | None = None,
+    rng_spec: RandomSeed | None = None,
 ) -> Iterator[TTSplit]: ...
 def sample_records(
     data: Dataset,
@@ -85,7 +85,7 @@ def sample_records(
     *,
     repeats: int | None = None,
     disjoint: bool = True,
-    rng_spec: NPRNGSource | None = None,
+    rng_spec: RandomSeed | None = None,
 ) -> TTSplit | Iterator[TTSplit]:
     """
     Sample train-test a frame of ratings into train-test partitions.  This

--- a/lenskit/lenskit/splitting/records.py
+++ b/lenskit/lenskit/splitting/records.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2023-2024 Drexel University
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
 
 import logging
 from typing import Iterator, overload

--- a/lenskit/lenskit/splitting/split.py
+++ b/lenskit/lenskit/splitting/split.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from lenskit.data.dataset import Dataset
 from lenskit.data.items import ItemList
-from lenskit.data.vocab import EntityId
+from lenskit.types import EntityId
 
 SplitTable: TypeAlias = Literal["matrix"]
 

--- a/lenskit/lenskit/splitting/users.py
+++ b/lenskit/lenskit/splitting/users.py
@@ -4,16 +4,18 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import logging
 from typing import Iterable, Iterator, overload
 
 import numpy as np
 import pandas as pd
 from seedbank import numpy_rng
-from seedbank.numpy import NPRNGSource
 
 from lenskit.data.dataset import Dataset, MatrixDataset
 from lenskit.data.vocab import EntityId
+from lenskit.types import RandomSeed
 
 from .holdout import HoldoutMethod
 from .split import TTSplit
@@ -22,7 +24,7 @@ _log = logging.getLogger(__name__)
 
 
 def crossfold_users(
-    data: Dataset, partitions: int, method: HoldoutMethod, *, rng_spec: NPRNGSource | None = None
+    data: Dataset, partitions: int, method: HoldoutMethod, *, rng_spec: RandomSeed | None = None
 ) -> Iterator[TTSplit]:
     """
     Partition a frame of ratings or other data into train-test partitions
@@ -80,7 +82,7 @@ def sample_users(
     *,
     repeats: int,
     disjoint: bool = True,
-    rng_spec: NPRNGSource | None = None,
+    rng_spec: RandomSeed | None = None,
 ) -> Iterator[TTSplit]: ...
 @overload
 def sample_users(
@@ -89,7 +91,7 @@ def sample_users(
     method: HoldoutMethod,
     *,
     disjoint: bool = True,
-    rng_spec: NPRNGSource | None = None,
+    rng_spec: RandomSeed | None = None,
     repeats: None = None,
 ) -> TTSplit: ...
 def sample_users(
@@ -99,7 +101,7 @@ def sample_users(
     *,
     repeats: int | None = None,
     disjoint: bool = True,
-    rng_spec: NPRNGSource | None = None,
+    rng_spec: RandomSeed | None = None,
 ) -> Iterator[TTSplit] | TTSplit:
     """
     Create train-test splits by sampling users.  When ``repeats`` is None,

--- a/lenskit/lenskit/splitting/users.py
+++ b/lenskit/lenskit/splitting/users.py
@@ -14,8 +14,7 @@ import pandas as pd
 from seedbank import numpy_rng
 
 from lenskit.data.dataset import Dataset, MatrixDataset
-from lenskit.data.vocab import EntityId
-from lenskit.types import RandomSeed
+from lenskit.types import EntityId, RandomSeed
 
 from .holdout import HoldoutMethod
 from .split import TTSplit

--- a/lenskit/lenskit/types.py
+++ b/lenskit/lenskit/types.py
@@ -1,0 +1,70 @@
+# pyright: strict
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeAlias, TypeVar, cast
+
+import numpy as np
+from seedbank import SeedLike
+
+RandomSeed: TypeAlias = SeedLike | np.random.Generator | np.random.RandomState
+
+EntityId: TypeAlias = int | str | bytes
+"Allowable entity identifier types."
+NPEntityId: TypeAlias = np.integer[Any] | np.str_ | np.bytes_ | np.object_
+"Allowable entity identifier types (NumPy version)"
+
+T = TypeVar("T")
+
+if TYPE_CHECKING or sys.version_info >= (3, 11):
+
+    class UITuple(NamedTuple, Generic[T]):
+        """
+        Tuple of (user, item) data, typically for configuration and similar
+        purposes.
+        """
+
+        user: T
+        "User data."
+        item: T
+        "Item data."
+
+        @classmethod
+        def create(cls, x: UITuple[T] | tuple[T, T] | T) -> UITuple[T]:
+            """
+            Create a user-item tuple from a tuple or data.  If a single value
+            is provided, it is used for both user and item.
+            """
+            if isinstance(x, UITuple):
+                return cast(UITuple[T], x)
+            elif isinstance(x, tuple):
+                u, i = cast(tuple[T, T], x)
+                return UITuple(u, i)
+            else:
+                return UITuple(x, x)
+else:
+
+    class UITuple(NamedTuple):
+        """
+        Tuple of (user, item) data, typically for configuration and similar
+        purposes.
+        """
+
+        user: Any
+        "User data."
+        item: Any
+        "Item data."
+
+        @classmethod
+        def create(cls, x: UITuple | tuple[Any, Any] | Any) -> UITuple:
+            """
+            Create a user-item tuple from a tuple or data.  If a single value
+            is provided, it is used for both user and item.
+            """
+            if isinstance(x, UITuple):
+                return x
+            elif isinstance(x, tuple):
+                u, i = x
+                return UITuple(u, i)
+            else:
+                return UITuple(x, x)

--- a/lenskit/tests/test_knn_item_item.py
+++ b/lenskit/tests/test_knn_item_item.py
@@ -374,7 +374,7 @@ def test_ii_implicit_large(rng, ml_ratings):
 
     users = rng.choice(ml_ratings["user"].unique(), NUSERS)
 
-    items: Vocabulary[EntityId] = algo.predictor.items_
+    items: Vocabulary = algo.predictor.items_
     mat: torch.Tensor = algo.predictor.sim_matrix_.to_dense()
 
     for user in users:

--- a/lenskit/tests/test_knn_item_item.py
+++ b/lenskit/tests/test_knn_item_item.py
@@ -23,8 +23,7 @@ from lenskit.algorithms import Recommender
 from lenskit.algorithms.basic import Fallback
 from lenskit.algorithms.bias import Bias
 from lenskit.algorithms.ranking import TopN
-from lenskit.data.dataset import from_interactions_df
-from lenskit.data.vocab import EntityId, Vocabulary
+from lenskit.data import Vocabulary, from_interactions_df
 from lenskit.diagnostics import ConfigWarning, DataWarning
 from lenskit.util import clone
 from lenskit.util.test import ml_ds, ml_ratings  # noqa: F401

--- a/lenskit/tests/test_pipeline.py
+++ b/lenskit/tests/test_pipeline.py
@@ -553,7 +553,7 @@ def test_train(ml_ds: Dataset):
 
 
 class TestComponent:
-    items: Vocabulary[EntityId]
+    items: Vocabulary
 
     def __call__(self, *, item: int) -> bool:
         return self.items.number(item, "none") is not None

--- a/lenskit/tests/test_pipeline.py
+++ b/lenskit/tests/test_pipeline.py
@@ -12,8 +12,7 @@ from typing_extensions import assert_type
 
 from pytest import fail, raises
 
-from lenskit.data.dataset import Dataset
-from lenskit.data.vocab import EntityId, Vocabulary
+from lenskit.data import Dataset, Vocabulary
 from lenskit.pipeline import InputNode, Node, Pipeline
 from lenskit.pipeline.components import TrainableComponent
 


### PR DESCRIPTION
This simplifies the `Vocabulary` class to no longer be generic, and introduces a `lenskit.types` module to hold various utility types, and uses these to improve type-level documentation.