### PR TITLE
Add PipelineState to support getting all pipeline outputs

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -15,3 +15,4 @@ POPROX
 rankers
 Scikit-Learn
 unpickle
+rerankers

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -195,13 +195,14 @@ Component Names
 
 As noted above, each component (and pipeline input) has a *name* that is unique
 across the pipeline.  For consistency and clarity, we recommend naming
-components with a verb or kebab-case verb phrase that captures the action that component performs, such as:
+components with a noun or kebab-case noun phrase that describes the component
+itself, e.g.:
 
-* ``recommend``
-* ``rerank``
-* ``score``
-* ``lookup-user-history``
-* ``embed-items``
+* ``recommender``
+* ``reranker``
+* ``scorer``
+* ``user-history-resolver``
+* ``item-embedder``
 
 Component nodes can also have *aliases*, allowing them to be accessed by more
 than one name. Use :meth:`Pipeline.alias` to define these aliases.
@@ -209,21 +210,22 @@ than one name. Use :meth:`Pipeline.alias` to define these aliases.
 Various LensKit facilities recognize several standard component names that we
 recommend you use when applicable:
 
-* ``score`` — compute (usually personalized) scores for items for a given user.
-* ``rank`` — compute a (ranked) list of recommendations for a user.  If you are
-  configuring a pipeline with rerankers whose outputs are also rankings, this
-  name should usually be used for the last such ranker, and downstream
+* ``scorer`` — compute (usually personalized) scores for items for a given user.
+* ``ranker`` — compute a (ranked) list of recommendations for a user.  If you
+  are configuring a pipeline with rerankers whose outputs are also rankings,
+  this name should usually be used for the last such ranker, and downstream
   components (if any) transform that ranking into another layout; that way the
   evaluation tools will operate on the last such ranking.
-* ``recommend`` — compute recommendations for a user.  This will often be an
-  alias for ``rank``, as in a top-*N* recommender, but may return other formats
-  such as grids or unordered slates.
-* ``predict-ratings`` — predict a user's ratings for the specified items.  When
-  present, this is usually an alias for ``score``, but in some pipelines it will
-  be a different component that transforms the scores into rating predictions.
+* ``recommender`` — compute recommendations for a user.  This will often be an
+  alias for ``ranker``, as in a top-*N* recommender, but may return other
+  formats such as grids or unordered slates.
+* ``rating-predictor`` — predict a user's ratings for the specified items.  When
+  present, this is usually an alias for ``scorer``, but in some pipelines it
+  will be a different component that transforms the scores into rating
+  predictions.
 
 These component names replace the task-specific interfaces in pre-2024 LensKit;
-a ``Recommender`` is now just a pipeline with ``recommend`` and/or ``rank``
+a ``Recommender`` is now just a pipeline with ``recommender`` and/or ``ranker``
 components.
 
 .. _pipeline-serialization:

--- a/lenskit/lenskit/data/__init__.py
+++ b/lenskit/lenskit/data/__init__.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2023-2024 Drexel University
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 from typing_extensions import Literal, TypeAlias

--- a/lenskit/lenskit/pipeline/state.py
+++ b/lenskit/lenskit/pipeline/state.py
@@ -1,3 +1,9 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 # pyright: strict
 from collections.abc import Mapping
 from typing import Any, Iterator

--- a/lenskit/lenskit/pipeline/state.py
+++ b/lenskit/lenskit/pipeline/state.py
@@ -1,0 +1,89 @@
+# pyright: strict
+from collections.abc import Mapping
+from typing import Any, Iterator
+
+
+class PipelineState(Mapping[str, Any]):
+    """
+    Full results of running a pipeline.  A pipeline state is a dictionary
+    mapping node names to their results; it is implemented as a separate class
+    instead of directly using a dictionary to allow data to be looked up by node
+    aliases in addition to original node names (and to be read-only).
+
+    Client code will generally not construct this class directly.
+
+    Args:
+        state:
+            The pipeline state to wrap.  The state object stores a reference to
+            this dictionary.
+        aliases:
+            Dictionary of node aliases.
+        default:
+            The name of the default node (whose data should be returned by
+            :attr:`default` ).
+    """
+
+    _state: dict[str, Any]
+    _aliases: dict[str, str]
+    _default: str | None = None
+
+    def __init__(
+        self,
+        state: dict[str, Any] | None = None,
+        aliases: dict[str, str] | None = None,
+        default: str | None = None,
+    ) -> None:
+        self._state = state if state is not None else {}
+        self._aliases = aliases if aliases is not None else {}
+        self._default = default
+        if default is not None and default not in self:
+            raise ValueError("default node is not in state or aliases")
+
+    @property
+    def default(self) -> Any:
+        """
+        Return the data from of the default node (typically the last node run).
+
+        Returns:
+            The data associated with the default node.
+
+        Raises:
+            ValueError: if there is no specified default node.
+        """
+        if self._default is not None:
+            return self[self._default]
+        else:
+            raise ValueError("pipeline state has no default value")
+
+    @property
+    def default_node(self) -> str | None:
+        "Return the name of the default node (typically the last node run)."
+        return self._default
+
+    def __len__(self):
+        return len(self._state)
+
+    def __contains__(self, key: object) -> bool:
+        if key in self._state:
+            return True
+        if key in self._aliases:
+            return self._aliases[key] in self
+        else:
+            return False
+
+    def __getitem__(self, key: str) -> Any:
+        if key in self._state:
+            return self._state[key]
+        elif key in self._aliases:
+            return self[self._aliases[key]]
+        else:
+            raise KeyError(f"pipeline node <{key}>")
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._state)
+
+    def __str__(self) -> str:
+        return f"<PipelineState with {len(self)} nodes>"
+
+    def __repr__(self) -> str:
+        return f"<PipelineState with nodes {set(self._state.keys())}>"

--- a/lenskit/lenskit/splitting/records.py
+++ b/lenskit/lenskit/splitting/records.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2023-2024 Drexel University
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import logging

--- a/lenskit/lenskit/types.py
+++ b/lenskit/lenskit/types.py
@@ -1,3 +1,9 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 # pyright: strict
 from __future__ import annotations
 

--- a/lenskit/tests/test_pipeline.py
+++ b/lenskit/tests/test_pipeline.py
@@ -353,6 +353,50 @@ def test_run_by_alias():
     assert pipe.run("result", a=1, b=7) == 9
 
 
+def test_run_all():
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def double(x: int) -> int:
+        return x * 2
+
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    nd = pipe.add_component("double", double, x=a)
+    na = pipe.add_component("add", add, x=nd, y=b)
+
+    pipe.alias("result", na)
+
+    state = pipe.run_all(a=1, b=7)
+    assert state["double"] == 2
+    assert state["add"] == 9
+    assert state["result"] == 9
+
+
+def test_run_all_limit():
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def double(x: int) -> int:
+        return x * 2
+
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    nd = pipe.add_component("double", double, x=a)
+    na = pipe.add_component("add", add, x=nd, y=b)
+
+    pipe.alias("result", na)
+
+    state = pipe.run_all("double", a=1, b=7)
+    assert state["double"] == 2
+    assert "add" not in state
+    assert "result" not in state
+
+
 def test_connect_literal():
     pipe = Pipeline()
     a = pipe.create_input("a", int)

--- a/lenskit/tests/test_pipeline_state.py
+++ b/lenskit/tests/test_pipeline_state.py
@@ -1,3 +1,9 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
 from pytest import raises
 
 from lenskit.pipeline import PipelineState

--- a/lenskit/tests/test_pipeline_state.py
+++ b/lenskit/tests/test_pipeline_state.py
@@ -1,0 +1,38 @@
+from pytest import raises
+
+from lenskit.pipeline import PipelineState
+
+
+def test_empty():
+    state = PipelineState()
+    assert len(state) == 0
+    assert not state
+    assert "scroll" not in state
+
+    with raises(KeyError):
+        state["scroll"]
+
+
+def test_single_value():
+    state = PipelineState({"scroll": "HACKEM MUCHE"})
+    assert len(state) == 1
+    assert state
+    assert "scroll" in state
+    assert state["scroll"] == "HACKEM MUCHE"
+
+
+def test_alias():
+    state = PipelineState({"scroll": "HACKEM MUCHE"}, {"book": "scroll"})
+    assert len(state) == 1
+    assert state
+    assert "scroll" in state
+    assert "book" in state
+    assert state["book"] == "HACKEM MUCHE"
+
+
+def test_alias_missing():
+    state = PipelineState({"scroll": "HACKEM MUCHE"}, {"book": "manuscript"})
+    assert len(state) == 1
+    assert state
+    assert "scroll" in state
+    assert "book" not in state


### PR DESCRIPTION
This adds a `PipelineState` class and `run_all` method to support running a pipeline and obtaining the results of all input nodes.