### PR TITLE
Serialize full pipeline configurations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,7 @@ intersphinx_mapping = {
     "manylog": ("https://manylog.readthedocs.io/en/latest/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
     "implicit": ("https://benfred.github.io/implicit/", None),
+    "pydantic": ("https://docs.pydantic.dev/latest/", None),
 }
 
 bibtex_bibfiles = ["lenskit.bib"]

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -493,7 +493,7 @@ class Pipeline:
         dependencies will produce the same hash.  In LensKit 2024.1, the
         configuration hash is computed by computing the JSON serialization of
         the pipeline configuration *without* a hash returning the hex-encoded
-        SHA1 hash of that configuration.
+        SHA256 hash of that configuration.
         """
         # get the config *without* a hash
         cfg = self.get_config(include_hash=False)

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -55,6 +55,32 @@ T4 = TypeVar("T4")
 T5 = TypeVar("T5")
 
 
+class PipelineError(Exception):
+    """
+    Pipeline configuration errors.
+
+    .. note::
+
+        This exception is only to note problems with the pipeline configuration
+        and structure (e.g. circular dependencies).  Errors *running* the
+        pipeline are raised as-is.
+    """
+
+
+class PipelineWarning(Warning):
+    """
+    Pipeline configuration and setup warnings.  We also emit warnings to the
+    logger in many cases, but this allows critical ones to be visible even if
+    the client code has not enabled logging.
+
+    .. note::
+
+        This warning is only to note problems with the pipeline configuration
+        and structure (e.g. circular dependencies).  Errors *running* the
+        pipeline are raised as-is.
+    """
+
+
 class Pipeline:
     """
     LensKit recommendation pipeline.  This is the core abstraction for using
@@ -416,7 +442,7 @@ class Pipeline:
 
         return clone
 
-    def get_config(self, *, include_hash=True) -> PipelineConfig:
+    def get_config(self, *, include_hash: bool = True) -> PipelineConfig:
         """
         Get this pipeline's configuration for serialization.  The configuration
         consists of all inputs and components along with their configurations
@@ -520,7 +546,7 @@ class Pipeline:
             h2 = pipe.config_hash()
             if h2 != cfg.meta.hash:
                 _log.warn("loaded pipeline does not match hash")
-                warnings.warn("loaded pipeline config does not match hash")
+                warnings.warn("loaded pipeline config does not match hash", PipelineWarning)
 
         return pipe
 

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -139,7 +139,7 @@ class Pipeline:
         """
         self._check_available_name(name)
 
-        node = InputNode[Any](name, types=set((t if t is not None else type[None]) for t in types))
+        node = InputNode[Any](name, types=set((t if t is not None else type(None)) for t in types))
         self._nodes[name] = node
         self._clear_caches()
         return node

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -484,6 +484,10 @@ class Pipeline:
                 types += [parse_type_string(t) for t in inpt.types]
             pipe.create_input(inpt.name, *types)
 
+        # we now add the components and other nodes in multiple passes to ensure
+        # that nodes are available before they are wired (since `connect` can
+        # introduce out-of-order dependencies).
+
         # pass 1: add components
         to_wire: list[PipelineComponent] = []
         for name, comp in cfg.components.items():
@@ -504,7 +508,7 @@ class Pipeline:
             elif comp.code.startswith("@"):
                 raise RuntimeError(f"unsupported meta-component {comp.code}")
 
-        # pass 2: wiring
+        # pass 3: wiring
         for name, comp in cfg.components.items():
             if isinstance(comp.inputs, dict):
                 inputs = {n: pipe.node(t) for (n, t) in comp.inputs.items()}

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -28,7 +28,7 @@ from .components import (
     TrainableComponent,
     instantiate_component,
 )
-from .config import PipelineComponent, PipelineConfig, PipelineInput
+from .config import PipelineComponent, PipelineConfig, PipelineInput, PipelineMeta
 from .nodes import ND, ComponentNode, FallbackNode, InputNode, LiteralNode, Node
 from .state import PipelineState
 
@@ -62,14 +62,25 @@ class Pipeline:
 
     If you have a scoring model and just want to generate recommenations with a
     default setup and minimal configuration, see :func:`topn_pipeline`.
+
+    Args:
+        name:
+            A name for the pipeline.
+        version:
+            A numeric version for the pipeline.
     """
+
+    name: str | None = None
+    version: str | None = None
 
     _nodes: dict[str, Node[Any]]
     _aliases: dict[str, Node[Any]]
     _defaults: dict[str, Node[Any] | Any]
     _components: dict[str, Component[Any]]
 
-    def __init__(self):
+    def __init__(self, name: str | None = None, version: str | None = None):
+        self.name = name
+        self.version = version
         self._nodes = {}
         self._aliases = {}
         self._defaults = {}
@@ -420,7 +431,8 @@ class Pipeline:
             inputs) cannot be serialized, and this method will fail if they
             are present in the pipeline.
         """
-        config = PipelineConfig()
+        meta = PipelineMeta(name=self.name, version=self.version)
+        config = PipelineConfig(meta=meta)
         for node in self.nodes:
             match node:
                 case InputNode():

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -36,6 +36,8 @@ from .state import PipelineState
 
 __all__ = [
     "Pipeline",
+    "PipelineError",
+    "PipelineWarning",
     "Node",
     "topn_pipeline",
     "Component",
@@ -529,10 +531,10 @@ class Pipeline:
         for name, comp in cfg.components.items():
             if comp.code == "@use-first-of":
                 if not isinstance(comp.inputs, list):
-                    raise RuntimeError("@use-first-of must have input list, not dict")
+                    raise PipelineError("@use-first-of must have input list, not dict")
                 pipe.use_first_of(name, *[pipe.node(n) for n in comp.inputs])
             elif comp.code.startswith("@"):
-                raise RuntimeError(f"unsupported meta-component {comp.code}")
+                raise PipelineError(f"unsupported meta-component {comp.code}")
 
         # pass 3: wiring
         for name, comp in cfg.components.items():
@@ -540,7 +542,7 @@ class Pipeline:
                 inputs = {n: pipe.node(t) for (n, t) in comp.inputs.items()}
                 pipe.connect(name, **inputs)
             elif not comp.code.startswith("@"):
-                raise RuntimeError(f"component {name} inputs must be dict, not list")
+                raise PipelineError(f"component {name} inputs must be dict, not list")
 
         if cfg.meta.hash is not None:
             h2 = pipe.config_hash()
@@ -682,7 +684,7 @@ class Pipeline:
     def _check_member_node(self, node: Node[Any]) -> None:
         nw = self._nodes.get(node.name)
         if nw is not node:
-            raise RuntimeError(f"node {node} not in pipeline")
+            raise PipelineError(f"node {node} not in pipeline")
 
     def _clear_caches(self):
         pass

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -547,7 +547,7 @@ class Pipeline:
         if cfg.meta.hash is not None:
             h2 = pipe.config_hash()
             if h2 != cfg.meta.hash:
-                _log.warn("loaded pipeline does not match hash")
+                _log.warning("loaded pipeline does not match hash")
                 warnings.warn("loaded pipeline config does not match hash", PipelineWarning)
 
         return pipe

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -149,6 +149,13 @@ class Pipeline:
         return node
 
     def literal(self, value: T) -> LiteralNode[T]:
+        """
+        Create a literal node (a node with a fixed value).
+
+        .. note::
+            Literal nodes cannot be serialized witih :meth:`get_config` or
+            :meth:`save_config`.
+        """
         name = str(uuid4())
         node = LiteralNode(name, value, types=set([type(value)]))
         self._nodes[name] = node
@@ -407,6 +414,11 @@ class Pipeline:
         although the configuration may include things such as paths to
         checkpoints to load such parameters, depending on the design of the
         components in the pipeline.
+
+        .. note::
+            Literal nodes (from :meth:`literal`, or literal values wired to
+            inputs) cannot be serialized, and this method will fail if they
+            are present in the pipeline.
         """
         config = PipelineConfig()
         for node in self.nodes:

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -26,13 +26,13 @@ class PipelineConfig(BaseModel):
 class PipelineInput(BaseModel):
     name: str
     "The name for this input."
-    types: Optional[list[str]]
+    types: Optional[set[str]]
     "The list of types for this input."
 
     @classmethod
     def from_node(cls, node: InputNode[Any]) -> Self:
         if node.types is not None:
-            types = [type_string(t) for t in node.types]
+            types = {type_string(t) for t in node.types}
         else:
             types = None
 

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -33,8 +33,15 @@ class PipelineMeta(BaseModel):
     Pipeline metadata.
     """
 
-    name: str | None = Field(default=None)
-    version: str | None = Field(default=None)
+    name: str | None = None
+    "The pipeline name."
+    version: str | None = None
+    "The pipeline version."
+    hash: str | None = None
+    """
+    The pipeline configuration hash.  This is optional, particularly when
+    hand-crafting pipeline configuration files.
+    """
 
 
 class PipelineInput(BaseModel):

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -1,0 +1,39 @@
+"""
+Pydantic models for pipeline configuration and serialization support.
+"""
+
+# pyright: strict
+from __future__ import annotations
+
+from pydantic import BaseModel
+from typing_extensions import Any, Optional, Self
+
+from lenskit.pipeline.types import type_string
+
+from .nodes import InputNode
+
+
+class PipelineConfig(BaseModel):
+    """
+    Root type for serialized pipeline configuration.  A pipeline config contains
+    the full configuration, components, and wiring for the pipeline, but does
+    not contain the
+    """
+
+    inputs: list[PipelineInput]
+
+
+class PipelineInput(BaseModel):
+    name: str
+    "The name for this input."
+    types: Optional[list[str]]
+    "The list of types for this input."
+
+    @classmethod
+    def from_node(cls, node: InputNode[Any]) -> Self:
+        if node.types is not None:
+            types = [type_string(t) for t in node.types]
+        else:
+            types = None
+
+        return cls(name=node.name, types=types)

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -23,8 +23,18 @@ class PipelineConfig(BaseModel):
     not contain the
     """
 
+    meta: PipelineMeta
     inputs: list[PipelineInput] = Field(default_factory=list)
     components: OrderedDict[str, PipelineComponent] = Field(default_factory=OrderedDict)
+
+
+class PipelineMeta(BaseModel):
+    """
+    Pipeline metadata.
+    """
+
+    name: str | None = Field(default=None)
+    version: str | None = Field(default=None)
 
 
 class PipelineInput(BaseModel):

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -6,6 +6,7 @@ Pydantic models for pipeline configuration and serialization support.
 from __future__ import annotations
 
 from collections import OrderedDict
+from hashlib import sha256
 from types import FunctionType
 
 from pydantic import BaseModel, Field
@@ -96,3 +97,13 @@ class PipelineComponent(BaseModel):
         config = comp.get_config() if isinstance(comp, ConfigurableComponent) else None
 
         return cls(code=code, config=config, inputs=node.connections)
+
+
+def hash_config(config: BaseModel) -> str:
+    """
+    Compute the hash of a configuration model.
+    """
+    json = config.model_dump_json(exclude_none=True)
+    h = sha256()
+    h.update(json.encode())
+    return h.hexdigest()

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -22,7 +22,7 @@ class PipelineConfig(BaseModel):
     not contain the
     """
 
-    inputs: list[PipelineInput]
+    inputs: list[PipelineInput] = Field(default_factory=list)
     components: dict[str, PipelineComponent] = Field(default_factory=dict)
 
 

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -65,6 +65,10 @@ class PipelineComponent(BaseModel):
     """
     The path to the component's implementation, either a class or a function.
     This is a Python qualified path of the form ``module:name``.
+
+    Special nodes, like :class:`lenskit.pipeline.Pipeline.use_first_of`, are
+    serialized as components whose code is a magic name beginning with ``@``
+    (e.g. ``@use-first-of``).
     """
 
     config: dict[str, object] | None = Field(default=None)

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -5,6 +5,7 @@ Pydantic models for pipeline configuration and serialization support.
 # pyright: strict
 from __future__ import annotations
 
+from collections import OrderedDict
 from types import FunctionType
 
 from pydantic import BaseModel, Field
@@ -23,7 +24,7 @@ class PipelineConfig(BaseModel):
     """
 
     inputs: list[PipelineInput] = Field(default_factory=list)
-    components: dict[str, PipelineComponent] = Field(default_factory=dict)
+    components: OrderedDict[str, PipelineComponent] = Field(default_factory=OrderedDict)
 
 
 class PipelineInput(BaseModel):
@@ -55,9 +56,10 @@ class PipelineComponent(BaseModel):
     with its default constructor parameters.
     """
 
-    inputs: dict[str, str] = Field(default_factory=dict)
+    inputs: dict[str, str] | list[str] = Field(default_factory=dict)
     """
-    The component's input wirings, mapping input names to node names.
+    The component's input wirings, mapping input names to node names.  For
+    certain meta-nodes, it is specified as a list instead of a dict.
     """
 
     @classmethod

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -5,12 +5,14 @@ Pydantic models for pipeline configuration and serialization support.
 # pyright: strict
 from __future__ import annotations
 
-from pydantic import BaseModel
+from types import FunctionType
+
+from pydantic import BaseModel, Field
 from typing_extensions import Any, Optional, Self
 
-from lenskit.pipeline.types import type_string
-
-from .nodes import InputNode
+from .components import ConfigurableComponent
+from .nodes import ComponentNode, InputNode
+from .types import type_string
 
 
 class PipelineConfig(BaseModel):
@@ -21,6 +23,7 @@ class PipelineConfig(BaseModel):
     """
 
     inputs: list[PipelineInput]
+    components: dict[str, PipelineComponent] = Field(default_factory=dict)
 
 
 class PipelineInput(BaseModel):
@@ -37,3 +40,36 @@ class PipelineInput(BaseModel):
             types = None
 
         return cls(name=node.name, types=types)
+
+
+class PipelineComponent(BaseModel):
+    code: str
+    """
+    The path to the component's implementation, either a class or a function.
+    This is a Python qualified path of the form ``module:name``.
+    """
+
+    config: dict[str, object] | None = Field(default=None)
+    """
+    The component configuration.  If not provided, the component will be created
+    with its default constructor parameters.
+    """
+
+    inputs: dict[str, str] = Field(default_factory=dict)
+    """
+    The component's input wirings, mapping input names to node names.
+    """
+
+    @classmethod
+    def from_node(cls, node: ComponentNode[Any]) -> Self:
+        comp = node.component
+        if isinstance(comp, FunctionType):
+            ctype = comp
+        else:
+            ctype = comp.__class__
+
+        code = f"{ctype.__module__}:{ctype.__qualname__}"
+
+        config = comp.get_config() if isinstance(comp, ConfigurableComponent) else None
+
+        return cls(code=code, config=config, inputs=node.connections)

--- a/lenskit/lenskit/pipeline/nodes.py
+++ b/lenskit/lenskit/pipeline/nodes.py
@@ -95,7 +95,14 @@ class ComponentNode(Node[ND], Generic[ND]):
         else:
             self.types = set([sig.return_annotation])
 
-        self.inputs = {
-            param.name: None if param.annotation == Signature.empty else param.annotation
-            for param in sig.parameters.values()
-        }
+        self.inputs = {}
+        for param in sig.parameters.values():
+            if param.annotation == Signature.empty:
+                warnings.warn(
+                    f"parameter {param.name} of component {component} has no type annotation",
+                    TypecheckWarning,
+                    2,
+                )
+                self.inputs[param.name] = None
+            else:
+                self.inputs[param.name] = param.annotation

--- a/lenskit/lenskit/pipeline/types.py
+++ b/lenskit/lenskit/pipeline/types.py
@@ -131,8 +131,10 @@ def type_string(typ: type | None) -> str:
         return "None"
     elif typ.__module__ == "builtins":
         return typ.__name__
-    else:
+    elif typ.__qualname__ == typ.__name__:
         return f"{typ.__module__}.{typ.__name__}"
+    else:
+        return f"{typ.__module__}:{typ.__qualname__}"
 
 
 def parse_type_string(tstr: str) -> type:

--- a/lenskit/lenskit/pipeline/types.py
+++ b/lenskit/lenskit/pipeline/types.py
@@ -122,7 +122,7 @@ def is_compatible_data(obj: object, *targets: type) -> bool:
     return False
 
 
-def type_string(typ: type) -> str:
+def type_string(typ: type | None) -> str:
     """
     Compute a string representation of a type that is both resolvable and
     human-readable.  Type parameterizations are lost.

--- a/lenskit/lenskit/pipeline/types.py
+++ b/lenskit/lenskit/pipeline/types.py
@@ -145,11 +145,14 @@ def parse_type_string(tstr: str) -> type:
     elif re.match(r"^\w+$", tstr):
         return __builtins__[tstr]
     else:
-        # separate last element from module
-        parts = re.match(r"(.*)\.(\w+)$", tstr)
-        if not parts:
-            raise ValueError(f"unparsable type string {tstr}")
+        if ":" in tstr:
+            mod_name, typ_name = tstr.split(":", 1)
+        else:
+            # separate last element from module
+            parts = re.match(r"(.*)\.(\w+)$", tstr)
+            if not parts:
+                raise ValueError(f"unparsable type string {tstr}")
+            mod_name, typ_name = parts.groups()
 
-        mod_name, typ_name = parts.groups()
         mod = import_module(mod_name)
         return getattr(mod, typ_name)

--- a/lenskit/pyproject.toml
+++ b/lenskit/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
   "scipy >= 1.9.0",
   "torch ~=2.1",            # conda: pytorch>=2.1,<3
   "threadpoolctl >=3.0",
-  "seedbank >= 0.2.0a2",    # conda: @pip
+  "pydantic >=2.8,<3",
+  "seedbank >=0.2.0a2",     # conda: @pip
   "progress-api >=0.1.0a9", # conda: @pip
   "manylog >=0.1.0a5",      # conda: @pip
 ]

--- a/lenskit/tests/pipeline/test_component_config.py
+++ b/lenskit/tests/pipeline/test_component_config.py
@@ -1,0 +1,48 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import json
+
+from lenskit.pipeline import Pipeline
+from lenskit.pipeline.components import AutoConfig
+from lenskit.pipeline.nodes import ComponentNode
+
+
+class Prefixer(AutoConfig):
+    prefix: str
+
+    def __init__(self, prefix: str = "hello"):
+        self.prefix = prefix
+
+    def __call__(self, msg: str) -> str:
+        return self.prefix + msg
+
+
+def test_auto_config_roundtrip():
+    comp = Prefixer("FOOBIE BLETCH")
+
+    cfg = comp.get_config()
+    assert "prefix" in cfg
+
+    c2 = Prefixer.from_config(cfg)
+    assert c2 is not comp
+    assert c2.prefix == comp.prefix
+
+
+def test_pipeline_config():
+    comp = Prefixer("scroll named ")
+
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    pipe.add_component("prefix", comp, msg=msg)
+
+    assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
+
+    config = pipe.component_configs()
+    print(json.dumps(config, indent=2))
+
+    assert "prefix" in config
+    assert config["prefix"]["prefix"] == "scroll named "

--- a/lenskit/tests/pipeline/test_config_node.py
+++ b/lenskit/tests/pipeline/test_config_node.py
@@ -6,6 +6,7 @@ def test_untyped_input():
     node = InputNode("scroll")
 
     cfg = PipelineInput.from_node(node)
+    print(cfg)
     assert cfg.name == "scroll"
     assert cfg.types is None
 
@@ -14,21 +15,24 @@ def test_input_with_type():
     node = InputNode("scroll", types={str})
 
     cfg = PipelineInput.from_node(node)
+    print(cfg)
     assert cfg.name == "scroll"
-    assert cfg.types == ["str"]
+    assert cfg.types == {"str"}
 
 
 def test_input_with_none():
     node = InputNode("scroll", types={str, type(None)})
 
     cfg = PipelineInput.from_node(node)
+    print(cfg)
     assert cfg.name == "scroll"
-    assert cfg.types == ["str", "None"]
+    assert cfg.types == {"None", "str"}
 
 
 def test_input_with_generic():
     node = InputNode("scroll", types={list[str]})
 
     cfg = PipelineInput.from_node(node)
+    print(cfg)
     assert cfg.name == "scroll"
-    assert cfg.types == ["list"]
+    assert cfg.types == {"list"}

--- a/lenskit/tests/pipeline/test_config_node.py
+++ b/lenskit/tests/pipeline/test_config_node.py
@@ -1,0 +1,34 @@
+from lenskit.pipeline.config import PipelineInput
+from lenskit.pipeline.nodes import InputNode
+
+
+def test_untyped_input():
+    node = InputNode("scroll")
+
+    cfg = PipelineInput.from_node(node)
+    assert cfg.name == "scroll"
+    assert cfg.types is None
+
+
+def test_input_with_type():
+    node = InputNode("scroll", types={str})
+
+    cfg = PipelineInput.from_node(node)
+    assert cfg.name == "scroll"
+    assert cfg.types == ["str"]
+
+
+def test_input_with_none():
+    node = InputNode("scroll", types={str, type(None)})
+
+    cfg = PipelineInput.from_node(node)
+    assert cfg.name == "scroll"
+    assert cfg.types == ["str", "None"]
+
+
+def test_input_with_generic():
+    node = InputNode("scroll", types={list[str]})
+
+    cfg = PipelineInput.from_node(node)
+    assert cfg.name == "scroll"
+    assert cfg.types == ["list"]

--- a/lenskit/tests/pipeline/test_pipeline.py
+++ b/lenskit/tests/pipeline/test_pipeline.py
@@ -13,7 +13,7 @@ from typing_extensions import assert_type
 from pytest import fail, raises
 
 from lenskit.data import Dataset, Vocabulary
-from lenskit.pipeline import InputNode, Node, Pipeline
+from lenskit.pipeline import InputNode, Node, Pipeline, PipelineError
 from lenskit.pipeline.components import TrainableComponent
 
 
@@ -133,7 +133,7 @@ def test_single_input_required():
 
     node = pipe.add_component("return", incr, msg=msg)
 
-    with raises(RuntimeError, match="not specified"):
+    with raises(PipelineError, match="not specified"):
         pipe.run(node)
 
 
@@ -245,7 +245,7 @@ def test_cycle():
     na = pipe.add_component("add", add, x=nd, y=b)
     pipe.connect(nd, x=na)
 
-    with raises(RuntimeError, match="cycle"):
+    with raises(PipelineError, match="cycle"):
         pipe.run(a=1, b=7)
 
 
@@ -275,7 +275,7 @@ def test_replace_component():
     assert pipe.run(nt, a=3, b=7) == 9
 
     # old node should be missing!
-    with raises(RuntimeError, match="not in pipeline"):
+    with raises(PipelineError, match="not in pipeline"):
         pipe.run(nd, a=3, b=7)
 
 
@@ -443,7 +443,7 @@ def test_fail_missing_input():
     nd = pipe.add_component("double", double, x=a)
     na = pipe.add_component("add", add, x=nd, y=b)
 
-    with raises(RuntimeError, match=r"input.*not specified"):
+    with raises(PipelineError, match=r"input.*not specified"):
         pipe.run(na, a=3)
 
     # missing inputs only matter if they are required

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -32,33 +32,6 @@ def exclaim(msg: str) -> str:
     return msg + "!"
 
 
-def test_auto_config_roundtrip():
-    comp = Prefixer("FOOBIE BLETCH")
-
-    cfg = comp.get_config()
-    assert "prefix" in cfg
-
-    c2 = Prefixer.from_config(cfg)
-    assert c2 is not comp
-    assert c2.prefix == comp.prefix
-
-
-def test_pipeline_config():
-    comp = Prefixer("scroll named ")
-
-    pipe = Pipeline()
-    msg = pipe.create_input("msg", str)
-    pipe.add_component("prefix", comp, msg=msg)
-
-    assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
-
-    config = pipe.component_configs()
-    print(json.dumps(config, indent=2))
-
-    assert "prefix" in config
-    assert config["prefix"]["prefix"] == "scroll named "
-
-
 def test_pipeline_clone():
     comp = Prefixer("scroll named ")
 

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -4,7 +4,7 @@ from typing_extensions import assert_type
 
 from pytest import fail, warns
 
-from lenskit.pipeline import InputNode, Node, Pipeline
+from lenskit.pipeline import InputNode, Node, Pipeline, PipelineWarning
 from lenskit.pipeline.components import AutoConfig
 from lenskit.pipeline.config import PipelineConfig
 from lenskit.pipeline.nodes import ComponentNode
@@ -171,5 +171,5 @@ def test_hash_validate():
     cfg.components["prefix"].config["prefix"] = "scroll called "  # type: ignore
     print("modified config:", cfg.model_dump_json(indent=2))
 
-    with warns(UserWarning):
+    with warns(PipelineWarning):
         Pipeline.from_config(cfg)

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -3,6 +3,18 @@ from types import NoneType
 from typing_extensions import assert_type
 
 from lenskit.pipeline import InputNode, Node, Pipeline
+from lenskit.pipeline.components import AutoConfig
+from lenskit.pipeline.nodes import ComponentNode
+
+
+class Prefixer(AutoConfig):
+    prefix: str
+
+    def __init__(self, prefix: str = "hello"):
+        self.prefix = prefix
+
+    def __call__(self, msg: str) -> str:
+        return self.prefix + msg
 
 
 def test_serialize_input():
@@ -45,3 +57,61 @@ def test_round_trip_optional_input():
     assert isinstance(i2, InputNode)
     assert i2.name == "user"
     assert i2.types == {int, str, NoneType}
+
+
+def msg_ident(msg: str) -> str:
+    return msg
+
+
+def test_config_single_node():
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+
+    pipe.add_component("return", msg_ident, msg=msg)
+
+    cfg = pipe.get_config()
+    assert len(cfg.inputs) == 1
+    assert len(cfg.components) == 1
+
+    assert cfg.components["return"].code == "lenskit.tests.pipeline.test_save_load:msg_ident"
+    assert cfg.components["return"].config is None
+    assert cfg.components["return"].inputs == {"msg": "msg"}
+
+
+def test_round_trip_single_node():
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+
+    pipe.add_component("return", msg_ident, msg=msg)
+
+    cfg = pipe.get_config()
+
+    p2 = Pipeline.from_config(cfg)
+    assert len(p2.nodes) == 2
+    r2 = p2.node("return")
+    assert isinstance(r2, ComponentNode)
+    assert r2.component is msg_ident
+    assert r2.connections == {"msg": "msg"}
+
+    assert p2.run("return", msg="foo") == "foo"
+
+
+def test_configurable_component():
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+
+    pfx = Prefixer("scroll named ")
+    pipe.add_component("prefix", pfx, msg=msg)
+
+    cfg = pipe.get_config()
+    assert cfg.components["prefix"].config == {"prefix": "scroll named "}
+
+    p2 = Pipeline.from_config(cfg)
+    assert len(p2.nodes) == 2
+    r2 = p2.node("prefix")
+    assert isinstance(r2, ComponentNode)
+    assert isinstance(r2.component, Prefixer)
+    assert r2.component is not pfx
+    assert r2.connections == {"msg": "msg"}
+
+    assert p2.run("prefix", msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE"

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -20,11 +20,12 @@ class Prefixer(AutoConfig):
 
 def test_serialize_input():
     "serialize with one input node"
-    pipe = Pipeline()
+    pipe = Pipeline("test")
     pipe.create_input("user", int, str)
 
     cfg = pipe.get_config()
     print(cfg)
+    assert cfg.meta.name == "test"
     assert len(cfg.inputs) == 1
     assert cfg.inputs[0].name == "user"
     assert cfg.inputs[0].types == {"int", "str"}

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -1,0 +1,47 @@
+from types import NoneType
+
+from typing_extensions import assert_type
+
+from lenskit.pipeline import InputNode, Node, Pipeline
+
+
+def test_serialize_input():
+    "serialize with one input node"
+    pipe = Pipeline()
+    pipe.create_input("user", int, str)
+
+    cfg = pipe.get_config()
+    print(cfg)
+    assert len(cfg.inputs) == 1
+    assert cfg.inputs[0].name == "user"
+    assert cfg.inputs[0].types == {"int", "str"}
+
+
+def test_round_trip_input():
+    "serialize with one input node"
+    pipe = Pipeline()
+    pipe.create_input("user", int, str)
+
+    cfg = pipe.get_config()
+    print(cfg)
+
+    p2 = Pipeline.from_config(cfg)
+    i2 = p2.node("user")
+    assert isinstance(i2, InputNode)
+    assert i2.name == "user"
+    assert i2.types == {int, str}
+
+
+def test_round_trip_optional_input():
+    "serialize with one input node"
+    pipe = Pipeline()
+    pipe.create_input("user", int, str, None)
+
+    cfg = pipe.get_config()
+    assert cfg.inputs[0].types == {"int", "str", "None"}
+
+    p2 = Pipeline.from_config(cfg)
+    i2 = p2.node("user")
+    assert isinstance(i2, InputNode)
+    assert i2.name == "user"
+    assert i2.types == {int, str, NoneType}

--- a/lenskit/tests/pipeline/test_types.py
+++ b/lenskit/tests/pipeline/test_types.py
@@ -10,6 +10,8 @@ Tests for the pipeline type-checking functions.
 
 import typing
 from collections.abc import Iterable, Sequence
+from pathlib import Path
+from types import NoneType
 
 import numpy as np
 import pandas as pd
@@ -18,7 +20,13 @@ from numpy.typing import ArrayLike, NDArray
 from pytest import warns
 
 from lenskit.data.dataset import Dataset, MatrixDataset
-from lenskit.pipeline.types import TypecheckWarning, is_compatible_data, is_compatible_type
+from lenskit.pipeline.types import (
+    TypecheckWarning,
+    is_compatible_data,
+    is_compatible_type,
+    parse_type_string,
+    type_string,
+)
 
 
 def test_type_compat_identical():
@@ -91,3 +99,31 @@ def test_numpy_typecheck():
 
 def test_pandas_typecheck():
     assert is_compatible_data(pd.Series(["a", "b"]), ArrayLike)
+
+
+def test_type_string_none():
+    assert type_string(None) == "None"
+
+
+def test_type_string_str():
+    assert type_string(str) == "str"
+
+
+def test_type_string_generic():
+    assert type_string(list[str]) == "list"
+
+
+def test_type_string_class():
+    assert type_string(Path) == "pathlib.Path"
+
+
+def test_parse_string_None():
+    assert parse_type_string("None") == NoneType
+
+
+def test_parse_string_int():
+    assert parse_type_string("int") is int
+
+
+def test_parse_string_class():
+    assert parse_type_string("pathlib.Path") is Path

--- a/lenskit/tests/pipeline/test_types.py
+++ b/lenskit/tests/pipeline/test_types.py
@@ -127,3 +127,7 @@ def test_parse_string_int():
 
 def test_parse_string_class():
     assert parse_type_string("pathlib.Path") is Path
+
+
+def test_parse_string_mod_class():
+    assert parse_type_string("pathlib:Path") is Path


### PR DESCRIPTION
This extends the configuration support to enable entire pipeline configurations to be serialized and deserialized. It is also a prerequisite for implementing #385. This version of the changes only generates the serialization — it does not save or load them to files, that will be a separate change.

It also renames and refactors some pipeline test files for clarity and improves error handling.

Working:

- [x] Input nodes (and their types)
- [x] Component nodes
- [x] Component wirings
- [x] Fallback nodes
- [x] Literal nodes
- [x] Pipeline configuration hashing
- [x] Pipeline metadata