### PR TITLE
Include aliases in serialized pipeline configuration

### DIFF
--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -477,6 +477,8 @@ class Pipeline:
                 case _:  # pragma: nocover
                     raise RuntimeError(f"invalid node {node}")
 
+        config.aliases = {a: t.name for (a, t) in self._aliases.items()}
+
         if include_hash:
             config.meta.hash = hash_config(config)
 
@@ -539,6 +541,10 @@ class Pipeline:
                 pipe.connect(name, **inputs)
             elif not comp.code.startswith("@"):
                 raise PipelineError(f"component {name} inputs must be dict, not list")
+
+        # pass 4: aliases
+        for n, t in cfg.aliases.items():
+            pipe.alias(n, t)
 
         if cfg.meta.hash is not None:
             h2 = pipe.config_hash()

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -27,6 +27,7 @@ class PipelineConfig(BaseModel):
     meta: PipelineMeta
     inputs: list[PipelineInput] = Field(default_factory=list)
     components: OrderedDict[str, PipelineComponent] = Field(default_factory=OrderedDict)
+    aliases: dict[str, str] = Field(default_factory=dict)
 
 
 class PipelineMeta(BaseModel):

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -173,3 +173,32 @@ def test_hash_validate():
 
     with warns(PipelineWarning):
         Pipeline.from_config(cfg)
+
+
+def test_alias_input():
+    "alias an input node"
+    pipe = Pipeline()
+    user = pipe.create_input("user", int, str)
+
+    pipe.alias("person", user)
+
+    cfg = pipe.get_config()
+
+    p2 = Pipeline.from_config(cfg)
+    assert p2.run("person", user=32) == 32
+
+
+def test_alias_node():
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    nd = pipe.add_component("double", double, x=a)
+    na = pipe.add_component("add", add, x=nd, y=b)
+    pipe.alias("result", na)
+
+    assert pipe.run("result", a=5, b=7) == 17
+
+    cfg = pipe.get_config()
+    p2 = Pipeline.from_config(cfg)
+    assert p2.run("result", a=5, b=7) == 17


### PR DESCRIPTION
This adds aliases to the serialized pipeline configuration, omitted in #469.