### PR TITLE
Add metadata to pipeline states

### DIFF
--- a/lenskit/lenskit/pipeline/state.py
+++ b/lenskit/lenskit/pipeline/state.py
@@ -8,6 +8,8 @@
 from collections.abc import Mapping
 from typing import Any, Iterator
 
+from .config import PipelineMeta
+
 
 class PipelineState(Mapping[str, Any]):
     """
@@ -27,21 +29,29 @@ class PipelineState(Mapping[str, Any]):
         default:
             The name of the default node (whose data should be returned by
             :attr:`default` ).
+        meta:
+            The metadata for the pipeline generating this state.
     """
 
     _state: dict[str, Any]
     _aliases: dict[str, str]
     _default: str | None = None
+    meta: PipelineMeta | None
+    """
+    Pipeline metadata.
+    """
 
     def __init__(
         self,
         state: dict[str, Any] | None = None,
         aliases: dict[str, str] | None = None,
         default: str | None = None,
+        meta: PipelineMeta | None = None,
     ) -> None:
         self._state = state if state is not None else {}
         self._aliases = aliases if aliases is not None else {}
         self._default = default
+        self.meta = meta
         if default is not None and default not in self:
             raise ValueError("default node is not in state or aliases")
 

--- a/lenskit/tests/pipeline/test_pipeline.py
+++ b/lenskit/tests/pipeline/test_pipeline.py
@@ -354,7 +354,7 @@ def test_run_by_alias():
 
 
 def test_run_all():
-    pipe = Pipeline()
+    pipe = Pipeline("test", "7.2")
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
 
@@ -373,6 +373,11 @@ def test_run_all():
     assert state["double"] == 2
     assert state["add"] == 9
     assert state["result"] == 9
+
+    assert state.meta is not None
+    assert state.meta.name == "test"
+    assert state.meta.version == "7.2"
+    assert state.meta.hash == pipe.config_hash()
 
 
 def test_run_all_limit():


### PR DESCRIPTION
Cross-port changes from CCRI-POPROX/poprox-recommender#85 to include pipeline metadata in `PipelineState`.