### PR TITLE
Fix clone/config/hash use of defaults and aliases

### DIFF
--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -17,7 +17,7 @@ from types import FunctionType
 from typing import Literal, cast
 from uuid import uuid4
 
-from typing_extensions import Any, Self, TypeVar, overload
+from typing_extensions import Any, Self, TypeAlias, TypeVar, overload
 
 from lenskit.data import Dataset
 from lenskit.pipeline.types import parse_type_string
@@ -54,6 +54,7 @@ T2 = TypeVar("T2")
 T3 = TypeVar("T3")
 T4 = TypeVar("T4")
 T5 = TypeVar("T5")
+CloneMethod: TypeAlias = Literal["config"]
 
 
 class PipelineError(Exception):
@@ -421,21 +422,27 @@ class Pipeline:
             if isinstance(comp, ConfigurableComponent)
         }
 
-    def clone(self, *, params: bool = False) -> Pipeline:
+    def clone(self, how: CloneMethod = "config") -> Pipeline:
         """
         Clone the pipeline, optionally including trained parameters.
 
+        The ``how`` parameter controls how the pipeline is cloned, and what is
+        available in the clone pipeline.  Currently only ``"config"`` is
+        supported, which creates fresh component instances using the
+        configurations of the components in this pipeline.  When applied to a
+        trained pipeline, the clone does **not** have the original's learned
+        parameters.
+
         Args:
-            params:
-                Pass ``True`` to clone parameters as well as the configuration
-                and wiring.
+            how:
+                The mechanism to use for cloning the pipeline.
 
         Returns:
             A new pipeline with the same components and wiring, but fresh
             instances created by round-tripping the configuration.
         """
-        if params:  # pragma: nocover
-            raise NotImplementedError()
+        if how != "config":  # pragma: nocover
+            raise NotImplementedError("only 'config' cloning is currently supported")
 
         clone = Pipeline()
         for node in self.nodes:

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -461,6 +461,12 @@ class Pipeline:
                 case _:  # pragma: nocover
                     raise RuntimeError(f"invalid node {node}")
 
+        for n, t in self._aliases.items():
+            clone.alias(n, t.name)
+
+        for n, t in self._defaults.items():
+            clone.set_default(n, clone.node(t.name))
+
         return clone
 
     def get_config(self, *, include_hash: bool = True) -> PipelineConfig:

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -25,9 +25,15 @@ class PipelineConfig(BaseModel):
     """
 
     meta: PipelineMeta
+    "Pipeline metadata."
     inputs: list[PipelineInput] = Field(default_factory=list)
+    "Pipeline inputs."
+    defaults: dict[str, str] = Field(default_factory=dict)
+    "Default pipeline wirings."
     components: OrderedDict[str, PipelineComponent] = Field(default_factory=OrderedDict)
+    "Pipeline components, with their configurations and wiring."
     aliases: dict[str, str] = Field(default_factory=dict)
+    "Pipeline node aliases."
 
 
 class PipelineMeta(BaseModel):

--- a/lenskit/lenskit/pipeline/runner.py
+++ b/lenskit/lenskit/pipeline/runner.py
@@ -124,8 +124,12 @@ class PipelineRunner:
                 return None
 
             if itype and not is_compatible_data(ival, itype):
+                if ival is None:
+                    raise TypeError(
+                        f"no data available for required input ❬{iname}❭ on component ❬{name}❭"
+                    )
                 raise TypeError(
-                    f"input {iname} for component {name}"
+                    f"input ❬{iname}❭ on component ❬{name}❭"
                     f" has invalid type {type(ival)} (expected {itype})"
                 )
 

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -92,3 +92,16 @@ def test_clone_defaults():
     p2 = pipe.clone()
 
     assert p2.run(msg="hello") == "hello!"
+
+
+def test_clone_alias():
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    excl = pipe.add_component("exclaim", exclaim, msg=msg)
+    pipe.alias("return", excl)
+
+    assert pipe.run("return", msg="hello") == "hello!"
+
+    p2 = pipe.clone()
+
+    assert p2.run("return", msg="hello") == "hello!"

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -79,3 +79,16 @@ def test_pipeline_clone_with_nonconfig_class():
     p2 = pipe.clone()
 
     assert p2.run(msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE?"
+
+
+def test_clone_defaults():
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    pipe.set_default("msg", msg)
+    pipe.add_component("return", exclaim)
+
+    assert pipe.run(msg="hello") == "hello!"
+
+    p2 = pipe.clone()
+
+    assert p2.run(msg="hello") == "hello!"

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -105,3 +105,18 @@ def test_clone_alias():
     p2 = pipe.clone()
 
     assert p2.run("return", msg="hello") == "hello!"
+
+
+def test_clone_hash():
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    pipe.set_default("msg", msg)
+    excl = pipe.add_component("exclaim", exclaim)
+    pipe.alias("return", excl)
+
+    assert pipe.run("return", msg="hello") == "hello!"
+
+    p2 = pipe.clone()
+
+    assert p2.run("return", msg="hello") == "hello!"
+    assert p2.config_hash() == pipe.config_hash()

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -13,6 +13,7 @@ from lenskit.pipeline.nodes import ComponentNode
 _log = logging.getLogger(__name__)
 
 
+# region Test Components
 class Prefixer(AutoConfig):
     prefix: str
 
@@ -21,6 +22,29 @@ class Prefixer(AutoConfig):
 
     def __call__(self, msg: str) -> str:
         return self.prefix + msg
+
+
+def negative(x: int) -> int:
+    return -x
+
+
+def double(x: int) -> int:
+    return x * 2
+
+
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+def msg_ident(msg: str) -> str:
+    return msg
+
+
+def msg_prefix(prefix: str, msg: str) -> str:
+    return prefix + msg
+
+
+# endregion
 
 
 def test_serialize_input():
@@ -64,10 +88,6 @@ def test_round_trip_optional_input():
     assert isinstance(i2, InputNode)
     assert i2.name == "user"
     assert i2.types == {int, str, NoneType}
-
-
-def msg_ident(msg: str) -> str:
-    return msg
 
 
 def test_config_single_node():
@@ -147,18 +167,6 @@ def test_hashes_different():
     _log.info("p1 stage 2 hash: %s", p1.config_hash())
     _log.info("p2 stage 2 hash: %s", p2.config_hash())
     assert p1.config_hash() != p2.config_hash()
-
-
-def negative(x: int) -> int:
-    return -x
-
-
-def double(x: int) -> int:
-    return x * 2
-
-
-def add(x: int, y: int) -> int:
-    return x + y
 
 
 def test_save_with_fallback():

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -148,6 +148,20 @@ def test_configurable_component():
     assert p2.config_hash() == pipe.config_hash()
 
 
+def test_save_defaults():
+    pipe = Pipeline()
+    msg = pipe.create_input("msg", str)
+    pipe.set_default("msg", msg)
+    pipe.add_component("return", msg_ident)
+
+    assert pipe.run(msg="hello") == "hello"
+
+    cfg = pipe.get_config()
+    p2 = Pipeline.from_config(cfg)
+
+    assert p2.run(msg="hello") == "hello"
+
+
 def test_hashes_different():
     p1 = Pipeline()
     p2 = Pipeline()


### PR DESCRIPTION
This fixes up defaults and aliases in `clone()`, config, and hashing, so they are consistently included and copied. It also improves the `clone()` method's (currently useless) parameter.