### PR TITLE
Support literal nodes in configurations and configuration hashing

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -172,7 +172,7 @@ method takes two types of inputs:
     altered scores).
 
     If no components are specified, it is the same as specifying the last
-    component added to the pipeline.
+    component that was added to the pipeline.
 
 *   Keyword arguments specifying the values for the pipeline's inputs, as defined by
     calls to :meth:`create_input`.

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -649,9 +649,6 @@ class Pipeline:
         components.  See :ref:`pipeline-execution` for details of the pipeline
         execution model.
 
-        .. todo::
-            Add cycle detection.
-
         Args:
             nodes:
                 The component(s) to run.
@@ -664,6 +661,8 @@ class Pipeline:
             are returned in a tuple.
 
         Raises:
+            PipelineError:
+                when there is a pipeline configuration error (e.g. a cycle).
             ValueError:
                 when one or more required inputs are missing.
             TypeError:

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -131,20 +131,16 @@ class Pipeline:
         self._anon_nodes = set()
         self._clear_caches()
 
-    def meta(self, *, include_hash: bool | None = None) -> PipelineMeta:
+    def meta(self, *, include_hash: bool = True) -> PipelineMeta:
         """
         Get the metadata (name, version, hash, etc.) for this pipeline without
         returning the whole config.
 
         Args:
             include_hash:
-                Whether to include a configuration hash in the metadata.  If
-                ``None`` (the default), the metadata includes a hash if there
-                are no :meth:`literal` nodes in the pipeline.
+                Whether to include a configuration hash in the metadata.
         """
         meta = PipelineMeta(name=self.name, version=self.version)
-        if include_hash is None:
-            include_hash = not any(isinstance(n, LiteralNode) for n in self.nodes)
         if include_hash:
             meta.hash = self.config_hash()
         return meta

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -54,7 +54,7 @@ T2 = TypeVar("T2")
 T3 = TypeVar("T3")
 T4 = TypeVar("T4")
 T5 = TypeVar("T5")
-CloneMethod: TypeAlias = Literal["config"]
+CloneMethod: TypeAlias = Literal["config", "pipeline-config"]
 
 
 class PipelineError(Exception):
@@ -427,11 +427,16 @@ class Pipeline:
         Clone the pipeline, optionally including trained parameters.
 
         The ``how`` parameter controls how the pipeline is cloned, and what is
-        available in the clone pipeline.  Currently only ``"config"`` is
-        supported, which creates fresh component instances using the
-        configurations of the components in this pipeline.  When applied to a
-        trained pipeline, the clone does **not** have the original's learned
-        parameters.
+        available in the clone pipeline.  It can be one of the following values:
+
+        ``"config"``
+            Create fresh component instances using the configurations of the
+            components in this pipeline.  When applied to a trained pipeline,
+            the clone does **not** have the original's learned parameters. This
+            is the default clone method.
+        ``"pipeline-config"``
+            Round-trip the entire pipeline through :meth:`get_config` and
+            :meth:`from_config`.
 
         Args:
             how:
@@ -441,7 +446,10 @@ class Pipeline:
             A new pipeline with the same components and wiring, but fresh
             instances created by round-tripping the configuration.
         """
-        if how != "config":  # pragma: nocover
+        if how == "pipeline-config":
+            cfg = self.get_config()
+            return self.from_config(cfg)
+        elif how != "config":  # pragma: nocover
             raise NotImplementedError("only 'config' cloning is currently supported")
 
         clone = Pipeline()

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -97,7 +97,10 @@ class PipelineComponent(BaseModel):
     """
 
     @classmethod
-    def from_node(cls, node: ComponentNode[Any]) -> Self:
+    def from_node(cls, node: ComponentNode[Any], mapping: dict[str, str] | None = None) -> Self:
+        if mapping is None:
+            mapping = {}
+
         comp = node.component
         if isinstance(comp, FunctionType):
             ctype = comp
@@ -108,7 +111,11 @@ class PipelineComponent(BaseModel):
 
         config = comp.get_config() if isinstance(comp, ConfigurableComponent) else None
 
-        return cls(code=code, config=config, inputs=node.connections)
+        return cls(
+            code=code,
+            config=config,
+            inputs={n: mapping.get(t, t) for (n, t) in node.connections.items()},
+        )
 
 
 class PipelineLiteral(BaseModel):

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -5,11 +5,14 @@ Pydantic models for pipeline configuration and serialization support.
 # pyright: strict
 from __future__ import annotations
 
+import base64
+import pickle
 from collections import OrderedDict
 from hashlib import sha256
 from types import FunctionType
+from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, JsonValue, ValidationError
 from typing_extensions import Any, Optional, Self
 
 from .components import ConfigurableComponent
@@ -34,6 +37,8 @@ class PipelineConfig(BaseModel):
     "Pipeline components, with their configurations and wiring."
     aliases: dict[str, str] = Field(default_factory=dict)
     "Pipeline node aliases."
+    literals: dict[str, PipelineLiteral] = Field(default_factory=dict)
+    "Literals"
 
 
 class PipelineMeta(BaseModel):
@@ -104,6 +109,33 @@ class PipelineComponent(BaseModel):
         config = comp.get_config() if isinstance(comp, ConfigurableComponent) else None
 
         return cls(code=code, config=config, inputs=node.connections)
+
+
+class PipelineLiteral(BaseModel):
+    """
+    Literal nodes represented in the pipeline.
+    """
+
+    encoding: Literal["json", "base85"]
+    value: JsonValue
+
+    @classmethod
+    def represent(cls, data: Any) -> Self:
+        try:
+            return cls(encoding="json", value=data)
+        except ValidationError:
+            # data is not basic JSON values, so let's pickle it
+            dbytes = pickle.dumps(data)
+            return cls(encoding="base85", value=base64.b85encode(dbytes).decode("ascii"))
+
+    def decode(self) -> Any:
+        "Decode the represented literal."
+        match self.encoding:
+            case "json":
+                return self.value
+            case "base85":
+                assert isinstance(self.value, str)
+                return pickle.loads(base64.b85decode(self.value))
 
 
 def hash_config(config: BaseModel) -> str:

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -275,3 +275,16 @@ def test_literal_array():
     print(pipe.get_config().model_dump_json(indent=2))
     p2 = pipe.clone("pipeline-config")
     assert np.all(p2.run(a=5) == np.arange(5, 15))
+
+
+def test_stable_with_literals():
+    "test that two identical pipelines have the same hash, even with literals"
+    p1 = Pipeline("literal-add-array")
+    a = p1.create_input("a", int)
+    p1.add_component("add", add, x=np.arange(10), y=a)
+
+    p2 = Pipeline("literal-add-array")
+    a = p2.create_input("a", int)
+    p2.add_component("add", add, x=np.arange(10), y=a)
+
+    assert p1.config_hash() == p2.config_hash()

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -245,6 +245,5 @@ def test_alias_node():
 
     assert pipe.run("result", a=5, b=7) == 17
 
-    cfg = pipe.get_config()
-    p2 = Pipeline.from_config(cfg)
+    p2 = pipe.clone("pipeline-config")
     assert p2.run("result", a=5, b=7) == 17


### PR DESCRIPTION
This set of changes removes the restriction that literal nodes cannot be hashed or serialized to a configuration by exporting such nodes either in their native form or with Base85-encoded pickles if the native data is not JSON-compatible, and mapping literals' randomly-generated node names to stable node names based on the hash of the encoded literal data to remove the randomness of name generation from the config hashing process.