### PR TITLE
fix: invalid file references to requirements files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can also use a standard virtual environment and vanilla Python to develop Le
 To do this, the easiest way is to use [uv][]:
 
     uv venv -p python3.11
-    uv pip install -r full-dev-requirements.txt
+    uv pip install -r requirements-full-dev.txt
 
 You can also use traditional Pip:
 

--- a/requirements-full-dev.txt
+++ b/requirements-full-dev.txt
@@ -1,6 +1,6 @@
 # This requirements file sets up a *full* dev environment, including
 # editable copies of LensKit and all subpackages.
--r dev-requirements.txt
+-r requirements-dev.txt
 -e ./lenskit
 -e ./lenskit-funksvd
 -e ./lenskit-implicit


### PR DESCRIPTION
Fixed a bug where `requirements-full-dev.txt` seems to be using an outdated reference to dev-requirements.txt by changing it to requirements-dev.txt instead. Also fixed a similar bug in README.md for uv builds.