### PR TITLE
Switch package builds to Hatchling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -113,7 +113,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -159,7 +159,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 -m 'not slow' --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
+          pytest --verbose --log-file=test.log --durations=25 -m 'not slow' --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
         env:
           NUMBA_DISABLE_JIT: 1
           PYTORCH_JIT: 0
@@ -208,7 +208,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -252,7 +252,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-funksvd/lenskit lenskit-funksvd/tests
+          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-funksvd/lenskit lenskit-funksvd/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -298,7 +298,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
+          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -342,7 +342,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-implicit/lenskit lenskit-implicit/tests
+          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-implicit/lenskit lenskit-implicit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -388,7 +388,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-implicit/lenskit lenskit/tests lenskit-implicit/tests
+          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-implicit/lenskit lenskit/tests lenskit-implicit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -432,7 +432,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-hpf/lenskit lenskit-hpf/tests
+          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-hpf/lenskit lenskit-hpf/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -476,7 +476,7 @@ jobs:
           python -m lenskit.data.fetch ml-100k ml-20m
       - name: Run Eval Tests
         run: |
-          python -m pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit --cov=lenskit-hpf/lenskit -m 'eval or realdata' --log-file test-eval.log */tests
+          pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit --cov=lenskit-hpf/lenskit -m 'eval or realdata' --log-file test-eval.log */tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -520,7 +520,7 @@ jobs:
           python -m lenskit.data.fetch ml-100k ml-1m ml-10m ml-20m
       - name: "📕 Validate documentation examples"
         run: |
-          python -m pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit --cov=lenskit-hpf/lenskit --nbval-lax --doctest-glob='*.rst' --log-file test-docs.log docs */lenskit
+          pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit --cov=lenskit-hpf/lenskit --nbval-lax --doctest-glob='*.rst' --log-file test-docs.log docs */lenskit
       - name: "📐 Coverage results"
         run: |
           coverage xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -113,7 +113,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -159,7 +159,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 -m 'not slow' --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 -m 'not slow' --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
         env:
           NUMBA_DISABLE_JIT: 1
           PYTORCH_JIT: 0
@@ -208,7 +208,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -252,7 +252,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-funksvd/lenskit lenskit-funksvd/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-funksvd/lenskit lenskit-funksvd/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -298,7 +298,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -342,7 +342,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-implicit/lenskit lenskit-implicit/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-implicit/lenskit lenskit-implicit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -388,7 +388,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-implicit/lenskit lenskit/tests lenskit-implicit/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-implicit/lenskit lenskit/tests lenskit-implicit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -432,7 +432,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-hpf/lenskit lenskit-hpf/tests
+          python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-hpf/lenskit lenskit-hpf/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -113,7 +113,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -159,7 +159,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 -m 'not slow' --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 -m 'not slow' --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
         env:
           NUMBA_DISABLE_JIT: 1
           PYTORCH_JIT: 0
@@ -208,7 +208,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -252,7 +252,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-funksvd/lenskit lenskit-funksvd/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-funksvd/lenskit lenskit-funksvd/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -298,7 +298,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -342,7 +342,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-implicit/lenskit lenskit-implicit/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-implicit/lenskit lenskit-implicit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -388,7 +388,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-implicit/lenskit lenskit/tests lenskit-implicit/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-implicit/lenskit lenskit/tests lenskit-implicit/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml
@@ -432,7 +432,7 @@ jobs:
           python -m lenskit.util.envcheck
       - name: "🏃🏻‍➡️ Test LKPY"
         run: |
-          pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-hpf/lenskit lenskit-hpf/tests
+          python -m pytest pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-hpf/lenskit lenskit-hpf/tests
       - name: "📐 Coverage results"
         run: |
           coverage xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -570,6 +570,8 @@ jobs:
           log-level: vv
           locked: false
           frozen: true
+      - name: "🔨 Build _version.py"
+        run: pipx run build lenskit
       - name: "📥 Download test artifacts"
         uses: actions/download-artifact@v4
         with:
@@ -593,7 +595,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           diff-cover --json-report diff-cover.json --markdown-report diff-cover.md \
-              coverage.xml |tee diff-cover.txt
+            coverage.xml |tee diff-cover.txt
       - name: ± Measure and report coverage
         run: |
           echo $PR_NUMBER > ./lenskit-coverage/pr-number

--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -17,3 +17,4 @@ Scikit-Learn
 unpickle
 rerankers
 LKPY
+FunkSVD

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ correct modified version of LensKit until your changes make it in to a release.
 ## Resources
 
 - [Documentation](https://lkpy.lenskit.org)
-- [Mailing list, etc.](https://lenskit.org/connect)
+- [Discussion and Announcements](https://github.com/orgs/lenskit/discussions)
 
 ## Acknowledgements
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Throughout this documentation, we use the notation of :cite:t:`ekstrand:notation
 Resources
 ---------
 
-- `Mailing list, etc. <https://lenskit.org/connect>`_
+- `Discussion and Announcements <https://github.com/orgs/lenskit/discussions>`_
 - `Source and issues on GitHub <https://github.com/lenskit/lkpy>`_
 
 .. toctree::

--- a/lenskit-funksvd/README.md
+++ b/lenskit-funksvd/README.md
@@ -1,0 +1,1 @@
+# FunkSVD package for LensKit

--- a/lenskit-funksvd/pyproject.toml
+++ b/lenskit-funksvd/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling ~=1.0", "hatch-vcs ~=0.4.0"]
+build-backend = "hatchling.build"
 
 [project]
 name = "lenskit-funksvd"
@@ -26,9 +26,15 @@ documentation = "https://lkpy.lenskit.org"
 source = "https://github.com/lenskit/lkpy"
 
 # configure build tools
-[tool.setuptools.packages.find]
-include = ["lenskit*"]
+[tool.hatch.metadata]
+allow-direct-references = true
 
-[tool.setuptools_scm]
-version_scheme = "release-branch-semver"
-root = ".."
+[tool.hatch.build.targets.sdist]
+include = ["/lenskit", "LICENSE.md", "README.md"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["lenskit"]
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { root = "..", version_scheme = "release-branch-semver" }

--- a/lenskit-hpf/LICENSE.md
+++ b/lenskit-hpf/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2018–2023 Boise State University
+Copyright (c) 2023-2024 Drexel University and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lenskit-hpf/pyproject.toml
+++ b/lenskit-hpf/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling ~=1.0", "hatch-vcs ~=0.4.0"]
+build-backend = "hatchling.build"
 
 [project]
 name = "lenskit-hpf"
@@ -22,9 +22,15 @@ homepage = "https://lenskit.org"
 documentation = "https://lkpy.lenskit.org"
 source = "https://github.com/lenskit/lkpy"
 
-[tool.setuptools.packages.find]
-include = ["lenskit*"]
+[tool.hatch.metadata]
+allow-direct-references = true
 
-[tool.setuptools_scm]
-version_scheme = "release-branch-semver"
-root = ".."
+[tool.hatch.build.targets.sdist]
+include = ["/lenskit", "LICENSE.md", "README.md"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["lenskit"]
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { root = "..", version_scheme = "release-branch-semver" }

--- a/lenskit-implicit/LICENSE.md
+++ b/lenskit-implicit/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2018–2023 Boise State University
+Copyright (c) 2023-2024 Drexel University and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lenskit-implicit/pyproject.toml
+++ b/lenskit-implicit/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling ~=1.0", "hatch-vcs ~=0.4.0"]
+build-backend = "hatchling.build"
 
 [project]
 name = "lenskit-implicit"
@@ -23,9 +23,15 @@ documentation = "https://lkpy.lenskit.org"
 source = "https://github.com/lenskit/lkpy"
 
 # configure build tools
-[tool.setuptools.packages.find]
-include = ["lenskit*"]
+[tool.hatch.metadata]
+allow-direct-references = true
 
-[tool.setuptools_scm]
-version_scheme = "release-branch-semver"
-root = ".."
+[tool.hatch.build.targets.sdist]
+include = ["/lenskit", "LICENSE.md", "README.md"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["lenskit"]
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { root = "..", version_scheme = "release-branch-semver" }

--- a/lenskit/.gitignore
+++ b/lenskit/.gitignore
@@ -1,0 +1,1 @@
+lenskit/_version.py

--- a/lenskit/README.md
+++ b/lenskit/README.md
@@ -69,7 +69,7 @@ That will create an environment named `lkpy` with all the LensKit dependencies.
 
 You should always test your changes by running the LensKit test suite:
 
-    python -m pytest
+    pytest */tests
 
 If you want to use your changes in a LensKit experiment, you can locally install
 your modified LensKit into your experiment's environment.  We recommend using

--- a/lenskit/README.md
+++ b/lenskit/README.md
@@ -41,58 +41,6 @@ To use the latest development version, install directly from GitHub:
 
 Then see [Getting Started](https://lkpy.lenskit.org/en/latest/GettingStarted.html)
 
-## Developing
-
-[issues]: https://github.com/lenskit/lkpy/issues
-[workflow]: https://github.com/lenskit/lkpy/wiki/DevWorkflow
-
-To contribute to LensKit, clone or fork the repository, get to work, and submit
-a pull request.  We welcome contributions from anyone; if you are looking for a
-place to get started, see the [issue tracker][issues].
-
-Our development workflow is documented in [the wiki][workflow]; the wiki also
-contains other information on *developing* LensKit. User-facing documentation is
-at <https://lkpy.lenskit.org>.
-
-[conda-lock]: https://github.com/conda-incubator/conda-lock
-[lkdev]: https://github.com/lenskit/lkdev
-
-We recommend using an Anaconda environment for developing LensKit.  We provide a
-tool to automate setting up Conda environments from the LensKit dependencies; to
-create a dev environment, checkout LensKit, then run:
-
-    pipx ./utils/conda-tool.py --env -n lkpy pyproject.toml dev-requirements.txt
-
-That will create an environment named `lkpy` with all the LensKit dependencies.
-
-## Testing Changes
-
-You should always test your changes by running the LensKit test suite:
-
-    pytest */tests
-
-If you want to use your changes in a LensKit experiment, you can locally install
-your modified LensKit into your experiment's environment.  We recommend using
-separate environments for LensKit development and for each experiment; you will
-need to install the modified LensKit into your experiment's repository:
-
-    conda activate my-exp
-    conda install -c conda-forge
-    cd /path/to/lkpy
-    pip install -e . --no-deps
-
-You may need to first uninstall LensKit from your experiment repo; make sure that
-LensKit's dependencies are all still installed.
-
-Once you have pushed your code to a GitHub branch, you can use a Git repository as
-a Pip dependency in an `environment.yml` for your experiment, to keep using the
-correct modified version of LensKit until your changes make it in to a release.
-
-## Resources
-
-- [Documentation](https://lkpy.lenskit.org)
-- [Mailing list, etc.](https://lenskit.org/connect)
-
 ## Acknowledgements
 
 This material is based upon work supported by the National Science Foundation

--- a/lenskit/pyproject.toml
+++ b/lenskit/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling ~=1.0", "hatch-vcs ~=0.4.0"]
+build-backend = "hatchling.build"
 
 [project]
 name = "lenskit"
@@ -49,9 +49,18 @@ documentation = "https://lkpy.lenskit.org"
 source = "https://github.com/lenskit/lkpy"
 
 # configure build tools
-[tool.setuptools.packages.find]
-include = ["lenskit*"]
+[tool.hatch.metadata]
+allow-direct-references = true
 
-[tool.setuptools_scm]
-version_scheme = "release-branch-semver"
-root = ".."
+[tool.hatch.build.targets.sdist]
+include = ["/lenskit", "LICENSE.md", "README.md"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["lenskit"]
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { root = "..", version_scheme = "release-branch-semver" }
+
+[tool.hatch.build.hooks.vcs]
+version-file = "lenskit/_version.py"

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import re
 from types import NoneType
 
 import numpy as np
@@ -107,7 +108,9 @@ def test_config_single_node():
     assert len(cfg.inputs) == 1
     assert len(cfg.components) == 1
 
-    assert cfg.components["return"].code == "lenskit.tests.pipeline.test_save_load:msg_ident"
+    assert re.match(
+        r"((lenskit\.)?tests\.)?pipeline\.test_save_load:msg_ident", cfg.components["return"].code
+    )
     assert cfg.components["return"].config is None
     assert cfg.components["return"].inputs == {"msg": "msg"}
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -811,6 +811,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dunamai-1.22.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval-type-backport-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.0-pyha770c72_0.conda
@@ -841,6 +842,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-vcs-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hpfrec-0.2.13-py311h9ecbd09_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
@@ -1072,7 +1075,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools_scm-8.1.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.7-h1b44611_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
@@ -1108,6 +1110,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20241003-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -1231,6 +1234,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dunamai-1.22.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval-type-backport-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.0-pyha770c72_0.conda
@@ -1250,6 +1254,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.1.1-py311h3f08180_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-vcs-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hpfrec-0.2.13-py311hc0b9fc8_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
@@ -1450,7 +1456,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools_scm-8.1.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.7-h7783ee8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
@@ -1483,6 +1488,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311h460d6c5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20241003-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -1598,6 +1604,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dunamai-1.22.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval-type-backport-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.0-pyha770c72_0.conda
@@ -1627,6 +1634,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-vcs-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
@@ -1850,7 +1859,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools_scm-8.1.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.7-h1b44611_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
@@ -1884,6 +1892,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20241003-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -2004,6 +2013,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dunamai-1.22.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval-type-backport-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.0-pyha770c72_0.conda
@@ -2023,6 +2033,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.1.1-py312hde4cb15_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-vcs-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
@@ -2216,7 +2228,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools_scm-8.1.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.7-h7783ee8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
@@ -2249,6 +2260,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20241003-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -2344,6 +2356,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dunamai-1.22.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval-type-backport-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.0-pyha770c72_0.conda
@@ -2368,6 +2381,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-vcs-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
@@ -2561,7 +2576,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools_scm-8.1.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
@@ -2594,6 +2608,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py312h4389bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20241003-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -2713,6 +2728,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dunamai-1.22.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval-type-backport-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.0-pyha770c72_0.conda
@@ -2743,6 +2759,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-vcs-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hpfrec-0.2.13-py312hc0a28a1_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
@@ -2974,7 +2992,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools_scm-8.1.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.7-h1b44611_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
@@ -3010,6 +3027,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20241003-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -3133,6 +3151,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dunamai-1.22.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval-type-backport-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.0-pyha770c72_0.conda
@@ -3152,6 +3171,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.1.1-py312hde4cb15_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-vcs-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hpfrec-0.2.13-py312h3953c12_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
@@ -3352,7 +3373,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools_scm-8.1.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.7-h7783ee8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
@@ -3385,6 +3405,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20241003-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -10069,6 +10090,23 @@ packages:
   size: 28979
   timestamp: 1723108568411
 - kind: conda
+  name: editables
+  version: '0.5'
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
+  sha256: de160a7494e7bc72360eea6a29cbddf194d0a79f45ff417a4de20e6858cf79a9
+  md5: 9873878e2a069bc358b69e9a29c1ecd5
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/editables?source=hash-mapping
+  size: 10988
+  timestamp: 1705857085102
+- kind: conda
   name: entrypoints
   version: '0.4'
   build: pyhd8ed1ab_0
@@ -11030,6 +11068,49 @@ packages:
   purls: []
   size: 1603653
   timestamp: 1721186240105
+- kind: conda
+  name: hatch-vcs
+  version: 0.4.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hatch-vcs-0.4.0-pyhd8ed1ab_0.conda
+  sha256: a40c25caa3ea97e722f8b3e07a220f58d600b263f5812f4f77707c1eb37f8906
+  md5: 0153b5c02cb13091f4821c7376d83db8
+  depends:
+  - hatchling >=1.1.0
+  - python >=3.8
+  - setuptools-scm >=6.4.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hatch-vcs?source=hash-mapping
+  size: 13155
+  timestamp: 1701697219032
+- kind: conda
+  name: hatchling
+  version: 1.25.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
+  sha256: fb8a16a913f909d8f7d2ae95c18a1aeb7be3eebfb1b7a4246500c06d54498f89
+  md5: 7571d6e5561b04aef679a11904dfcebf
+  depends:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hatchling?source=hash-mapping
+  size: 64580
+  timestamp: 1719090878694
 - kind: conda
   name: hpack
   version: 4.0.0
@@ -12554,34 +12635,34 @@ packages:
   timestamp: 1727304687962
 - kind: pypi
   name: lenskit
-  version: 0.15.0.dev1352+g58e23233.d20241025
+  version: 0.15.0.dev1369+g279756dd.d20241026
   path: lenskit
-  sha256: a2b42c1afe1e1bc1edb1226bf5fc9b4052e0cfde92eb96486a1593f42e240b5b
+  sha256: 81f6740798a8a424f07e1c11fb0d9eab063a9dd6fe1fffba7ee5d486b93f8628
   requires_dist:
-  - pandas~=2.0
-  - numpy>=1.24
-  - scipy>=1.10.0
-  - torch~=2.1
-  - threadpoolctl>=3.0
-  - pydantic<3,>=2.8
-  - seedbank>=0.2.0a2
-  - progress-api>=0.1.0a9
   - manylog @ git+https://github.com/mdekstrand/manylog.git
+  - numpy>=1.24
+  - pandas~=2.0
+  - progress-api>=0.1.0a9
+  - pydantic<3,>=2.8
+  - scipy>=1.10.0
+  - seedbank>=0.2.0a2
+  - threadpoolctl>=3.0
+  - torch~=2.1
   - scikit-learn>=1.1 ; extra == 'sklearn'
-  - pytest<9,>=8.2 ; extra == 'test'
-  - pytest-doctestplus<2,>=1.2.1 ; extra == 'test'
-  - pytest-cov>=2.12 ; extra == 'test'
-  - pytest-benchmark==4.* ; extra == 'test'
-  - pytest-repeat>=0.9 ; extra == 'test'
   - hypothesis>=6.16 ; extra == 'test'
   - pyprojroot==0.3.* ; extra == 'test'
+  - pytest-benchmark==4.* ; extra == 'test'
+  - pytest-cov>=2.12 ; extra == 'test'
+  - pytest-doctestplus<2,>=1.2.1 ; extra == 'test'
+  - pytest-repeat>=0.9 ; extra == 'test'
+  - pytest<9,>=8.2 ; extra == 'test'
   requires_python: '>=3.11'
   editable: true
 - kind: pypi
   name: lenskit-funksvd
-  version: 0.15.0.dev1303+ga8fbb0f6
+  version: 0.15.0.dev1369+g279756dd.d20241026
   path: lenskit-funksvd
-  sha256: 2d7ce7c471c36feb16e87aa011bf5ce7c2a797e3424eeada8f805a8f0f06f8b8
+  sha256: f205043df831d2a7a9345beb588a0da37221c75b40ca4e709082ca932b95ca76
   requires_dist:
   - lenskit
   - numba>=0.56
@@ -12589,22 +12670,22 @@ packages:
   editable: true
 - kind: pypi
   name: lenskit-hpf
-  version: 0.15.0.dev1303+ga8fbb0f6
+  version: 0.15.0.dev1369+g279756dd.d20241026
   path: lenskit-hpf
-  sha256: 838b2c8ebe46c463eb583bc52398a22345eb74bcb854dcff77f90fdb63f15f19
+  sha256: d3288a8e16f88803ee3158c416e943898e781884db0fb1b2493b6e54066c71c1
   requires_dist:
-  - lenskit
   - hpfrec==0.2.*
+  - lenskit
   requires_python: '>=3.11'
   editable: true
 - kind: pypi
   name: lenskit-implicit
-  version: 0.15.0.dev1303+ga8fbb0f6
+  version: 0.15.0.dev1369+g279756dd.d20241026
   path: lenskit-implicit
-  sha256: ba1bf14d262a1bf0ba018fe98359cf801b7fec503fc9f11fbf10559e2da37b86
+  sha256: 4b2641b5b3421e4f803dcf16cf5fce27c068957b4b25bc74c75f1cb6c910d301
   requires_dist:
-  - lenskit
   - implicit>=0.6.1
+  - lenskit
   requires_python: '>=3.11'
   editable: true
 - kind: conda
@@ -16082,34 +16163,6 @@ packages:
   purls: []
   size: 31928
   timestamp: 1608166099896
-- kind: pypi
-  name: manylog
-  version: 0.2.0.dev3+g0592011
-  url: git+https://github.com/mdekstrand/manylog.git@0592011daa8acdbdbf9632466cb39cc50ab4756c
-  requires_dist:
-  - progress-api>=0.1.0a5
-  - pyzmq
-  - typing-extensions~=4.11
-  - msgpack==1.*
-  - setuptools>=64 ; extra == 'dev'
-  - setuptools-scm>=8 ; extra == 'dev'
-  - wheel ; extra == 'dev'
-  - build==1.* ; extra == 'dev'
-  - ruff>=0.2 ; extra == 'dev'
-  - pyright ; extra == 'dev'
-  - copier==9.* ; extra == 'dev'
-  - unbeheader~=1.3 ; extra == 'dev'
-  - ipython ; extra == 'dev'
-  - pyproject2conda ; extra == 'dev'
-  - sphinx-autobuild ; extra == 'dev'
-  - msgpack-types ; extra == 'dev'
-  - sphinx>=4.2 ; extra == 'doc'
-  - sphinxext-opengraph>=0.5 ; extra == 'doc'
-  - furo ; extra == 'doc'
-  - pytest>=7 ; extra == 'test'
-  - pytest-cov>=2.12 ; extra == 'test'
-  - coverage>=5 ; extra == 'test'
-  requires_python: '>=3.10'
 - kind: pypi
   name: manylog
   version: 0.2.0.dev3+g0592011
@@ -22025,22 +22078,6 @@ packages:
   size: 37824
   timestamp: 1715083339319
 - kind: conda
-  name: setuptools_scm
-  version: 8.1.0
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools_scm-8.1.0-hd8ed1ab_0.conda
-  sha256: 00e736790575001fe50d69bb463c04ecdc470b9e104ee7728a54b6a1e59404f5
-  md5: 7ed7b077f6c6ebcb5fc66f23985df487
-  depends:
-  - setuptools-scm >=8.1.0,<8.1.1.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 6202
-  timestamp: 1715083343236
-- kind: conda
   name: six
   version: 1.16.0
   build: pyh6c4a22f_0
@@ -23094,6 +23131,23 @@ packages:
   - pkg:pypi/traitlets?source=hash-mapping
   size: 110187
   timestamp: 1713535244513
+- kind: conda
+  name: trove-classifiers
+  version: 2024.10.21.16
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_0.conda
+  sha256: 591e4ffdc95660b9e596c15b65cad35a70b36235f02dbd089ccc198dd5af0e71
+  md5: 501f6d3288160a31d99a2f1321e77393
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/trove-classifiers?source=hash-mapping
+  size: 18429
+  timestamp: 1729552033760
 - kind: conda
   name: types-python-dateutil
   version: 2.9.0.20241003

--- a/pixi.toml
+++ b/pixi.toml
@@ -68,8 +68,8 @@ myst-nb = ">=0.13"
 just = ">=1.2"
 
 [feature.dev.dependencies]
-setuptools = ">=64"
-setuptools_scm = ">=8"
+hatchling = "~=1.24"
+hatch-vcs = "~=0.4.0"
 python-build = "~=1.0"
 ruff = ">=0.2"
 pyright = ">=1.1"

--- a/workflows/test.ts
+++ b/workflows/test.ts
@@ -100,13 +100,14 @@ export const results: WorkflowJob = {
     {
       name: "Add upstream remote & author config",
       run: script(`
-                git remote add upstream https://github.com/lenskit/lkpy.git
-                git fetch upstream
-                git config user.name "LensKit Bot"
-                git config user.email lkbot@lenskit.org
-            `),
+        git remote add upstream https://github.com/lenskit/lkpy.git
+        git fetch upstream
+        git config user.name "LensKit Bot"
+        git config user.email lkbot@lenskit.org
+      `),
     },
     ...condaSetup("report"),
+    { name: "🔨 Build _version.py", run: "pipx run build lenskit" },
     {
       name: "📥 Download test artifacts",
       uses: "actions/download-artifact@v4",
@@ -122,37 +123,37 @@ export const results: WorkflowJob = {
     {
       name: "🔧 Fix coverage databases",
       run: script(`
-                for dbf in test-logs/*/coverage.db; do
-                    echo "fixing $dbf"
-                    sqlite3 -echo "$dbf" "UPDATE file SET path = replace(path, '\\', '/');"
-                done
-            `),
+        for dbf in test-logs/*/coverage.db; do
+            echo "fixing $dbf"
+            sqlite3 -echo "$dbf" "UPDATE file SET path = replace(path, '\\', '/');"
+        done
+      `),
     },
     // inspired by https://hynek.me/articles/ditch-codecov-python/
     {
       name: "⛙ Merge and report",
       run: script(`
-                coverage combine --keep test-logs/*/coverage.db
-                coverage xml
-                coverage html -d lenskit-coverage
-                coverage report --format=markdown >coverage.md
-            `),
+        coverage combine --keep test-logs/*/coverage.db
+        coverage xml
+        coverage html -d lenskit-coverage
+        coverage report --format=markdown >coverage.md
+      `),
     },
     {
       name: "Analyze diff coverage",
       if: "github.event_name == 'pull_request'",
       run: script(`
-                diff-cover --json-report diff-cover.json --markdown-report diff-cover.md \\
-                    coverage.xml |tee diff-cover.txt
-            `),
+        diff-cover --json-report diff-cover.json --markdown-report diff-cover.md \\
+          coverage.xml |tee diff-cover.txt
+      `),
     },
     {
       name: "± Measure and report coverage",
       run: script(`
-                echo $PR_NUMBER > ./lenskit-coverage/pr-number
-                tclsh ./utils/measure-coverage.tcl
-                cat lenskit-coverage/report.md >$GITHUB_STEP_SUMMARY
-            `),
+        echo $PR_NUMBER > ./lenskit-coverage/pr-number
+        tclsh ./utils/measure-coverage.tcl
+        cat lenskit-coverage/report.md >$GITHUB_STEP_SUMMARY
+      `),
       env: {
         PR_NUMBER: "${{ github.event.number }}",
         GH_TOKEN: "${{secrets.GITHUB_TOKEN}}",

--- a/workflows/test/common.ts
+++ b/workflows/test/common.ts
@@ -43,7 +43,7 @@ export function testJob(
 
 export function testSteps(options: TestJobSpec): WorkflowStep[] {
   let test_cmd =
-    "python -m pytest pytest --verbose --log-file=test.log --durations=25";
+    "python -m pytest --verbose --log-file=test.log --durations=25";
   if (options.test_args) {
     test_cmd += " " + options.test_args.join(" ");
   }

--- a/workflows/test/common.ts
+++ b/workflows/test/common.ts
@@ -9,98 +9,97 @@ import { isVanillaSpec, vanillaSetup, VanillaTestOpts } from "./vanilla.ts";
 export function testJob(options: VanillaTestOpts): WorkflowJob;
 export function testJob(options: CondaTestOpts): WorkflowJob;
 export function testJob(
-    options: TestJobSpec,
+  options: TestJobSpec,
 ): WorkflowJob {
-    const strategy = options.matrix
-        ? {
-            "fail-fast": false,
-            matrix: options.matrix,
-        }
-        : undefined;
-
-    let setup;
-    if (isVanillaSpec(options)) {
-        setup = vanillaSetup(options);
-    } else if (isCondaSpec(options)) {
-        setup = condaSetup(options);
-    } else {
-        throw new Error(`unknown install type ${options.install}`);
+  const strategy = options.matrix
+    ? {
+      "fail-fast": false,
+      matrix: options.matrix,
     }
+    : undefined;
 
-    return {
-        name: options.name,
-        "runs-on": testPlatform(options),
-        "timeout-minutes": 30,
-        strategy,
-        steps: [
-            checkoutStep(),
-            ...setup,
-            inspectStep(),
-            ...testSteps(options),
-        ],
-    };
+  let setup;
+  if (isVanillaSpec(options)) {
+    setup = vanillaSetup(options);
+  } else if (isCondaSpec(options)) {
+    setup = condaSetup(options);
+  } else {
+    throw new Error(`unknown install type ${options.install}`);
+  }
+
+  return {
+    name: options.name,
+    "runs-on": testPlatform(options),
+    "timeout-minutes": 30,
+    strategy,
+    steps: [
+      checkoutStep(),
+      ...setup,
+      inspectStep(),
+      ...testSteps(options),
+    ],
+  };
 }
 
 export function testSteps(options: TestJobSpec): WorkflowStep[] {
-    let test_cmd =
-        "python -m pytest --verbose --log-file=test.log --durations=25";
-    if (options.test_args) {
-        test_cmd += " " + options.test_args.join(" ");
-    }
-    for (const pkg of packages(options) ?? []) {
-        test_cmd += ` --cov=${pkg}/lenskit`;
-    }
-    for (const pkg of packages(options) ?? []) {
-        test_cmd += ` ${pkg}/tests`;
-    }
+  let test_cmd = "pytest --verbose --log-file=test.log --durations=25";
+  if (options.test_args) {
+    test_cmd += " " + options.test_args.join(" ");
+  }
+  for (const pkg of packages(options) ?? []) {
+    test_cmd += ` --cov=${pkg}/lenskit`;
+  }
+  for (const pkg of packages(options) ?? []) {
+    test_cmd += ` ${pkg}/tests`;
+  }
 
-    return [{
-        name: "🏃🏻‍➡️ Test LKPY",
-        run: script(test_cmd),
-        env: options.test_env,
-    }, ...coverageSteps(options)];
+  return [{
+    name: "🏃🏻‍➡️ Test LKPY",
+    run: script(test_cmd),
+    env: options.test_env,
+  }, ...coverageSteps(options)];
 }
 
 export function coverageSteps(options: TestJobSpec): WorkflowStep[] {
-    return [
-        {
-            name: "📐 Coverage results",
-            run: script(`
+  return [
+    {
+      name: "📐 Coverage results",
+      run: script(`
                 coverage xml
                 coverage report
                 cp .coverage coverage.db
             `),
-        },
-        {
-            name: "📤 Upload test results",
-            uses: "actions/upload-artifact@v4",
-            if: "always()",
-            with: {
-                name: testArtifactName(options),
-                path: script(`
+    },
+    {
+      name: "📤 Upload test results",
+      uses: "actions/upload-artifact@v4",
+      if: "always()",
+      with: {
+        name: testArtifactName(options),
+        path: script(`
                     test*.log
                     coverage.db
                     coverage.xml
                 `),
-            },
-        },
-    ];
+      },
+    },
+  ];
 }
 
 function testArtifactName(options: TestJobSpec): string {
-    let name = `test-${options.key}`;
-    if (options.matrix) {
-        if (options.matrix.platform) {
-            name += "-${{matrix.platform}}";
-        }
-        if (options.matrix.python) {
-            name += "-py${{matrix.python}}";
-        }
-        for (const key of Object.keys(options.matrix)) {
-            if (key != "platform" && key != "python") {
-                name += "-${{matrix." + key + "}}";
-            }
-        }
+  let name = `test-${options.key}`;
+  if (options.matrix) {
+    if (options.matrix.platform) {
+      name += "-${{matrix.platform}}";
     }
-    return name;
+    if (options.matrix.python) {
+      name += "-py${{matrix.python}}";
+    }
+    for (const key of Object.keys(options.matrix)) {
+      if (key != "platform" && key != "python") {
+        name += "-${{matrix." + key + "}}";
+      }
+    }
+  }
+  return name;
 }

--- a/workflows/test/common.ts
+++ b/workflows/test/common.ts
@@ -42,7 +42,8 @@ export function testJob(
 }
 
 export function testSteps(options: TestJobSpec): WorkflowStep[] {
-  let test_cmd = "pytest --verbose --log-file=test.log --durations=25";
+  let test_cmd =
+    "python -m pytest pytest --verbose --log-file=test.log --durations=25";
   if (options.test_args) {
     test_cmd += " " + options.test_args.join(" ");
   }

--- a/workflows/test/test-eval.ts
+++ b/workflows/test/test-eval.ts
@@ -25,9 +25,9 @@ export function evalTestJob(): WorkflowJob {
       ...mlDataSteps(["ml-100k", "ml-20m"]),
       {
         "name": "Run Eval Tests",
-        "run": script(`
-                    python -m pytest ${cov} -m 'eval or realdata' --log-file test-eval.log */tests
-                `),
+        "run": script(
+          `pytest ${cov} -m 'eval or realdata' --log-file test-eval.log */tests`,
+        ),
       },
       ...coverageSteps(options),
     ],

--- a/workflows/test/test-examples.ts
+++ b/workflows/test/test-examples.ts
@@ -25,9 +25,9 @@ export function exampleTestJob(): WorkflowJob {
       ...mlDataSteps(["ml-100k", "ml-1m", "ml-10m", "ml-20m"]),
       {
         "name": "📕 Validate documentation examples",
-        "run": script(`
-                    python -m pytest ${cov} --nbval-lax --doctest-glob='*.rst' --log-file test-docs.log docs */lenskit
-                `),
+        "run": script(
+          `pytest ${cov} --nbval-lax --doctest-glob='*.rst' --log-file test-docs.log docs */lenskit`,
+        ),
       },
       ...coverageSteps(options),
     ],


### PR DESCRIPTION
Due to problems with setuptools editable installs and static analysis engines, this switches the LensKit packages to build with Hatchling instead of Setuptools. Since this is abstracted behind Git, nothing changes for users.