### PR TITLE
Improve test coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,14 +60,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: 'test-conda-${{matrix.platform}}-py${{matrix.python}}'
           path: |
@@ -116,14 +116,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: 'test-vanilla-${{matrix.platform}}-py${{matrix.python}}'
           path: |
@@ -158,14 +158,14 @@ jobs:
           NUMBA_DISABLE_JIT: 1
           PYTORCH_JIT: 0
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: test-nojit
           path: |
@@ -205,14 +205,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: test-mindep
           path: |
@@ -250,14 +250,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-funksvd/lenskit lenskit-funksvd/tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: 'test-funksvd-py${{matrix.python}}'
           path: |
@@ -297,14 +297,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: test-mindep-funksvd
           path: |
@@ -342,14 +342,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-implicit/lenskit lenskit-implicit/tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: 'test-implicit-py${{matrix.python}}'
           path: |
@@ -389,14 +389,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-implicit/lenskit lenskit/tests lenskit-implicit/tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: test-mindep-implicit
           path: |
@@ -434,14 +434,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-hpf/lenskit lenskit-hpf/tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: 'test-hpf-py${{matrix.python}}'
           path: |
@@ -479,14 +479,14 @@ jobs:
         run: |
           pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit --cov=lenskit-hpf/lenskit -m 'eval or realdata' --log-file test-eval.log */tests
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: test-eval-tests
           path: |
@@ -524,14 +524,14 @@ jobs:
         run: |
           pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit --cov=lenskit-hpf/lenskit --nbval-lax --doctest-glob='*.rst' --log-file test-docs.log docs */lenskit
       - name: "📐 Coverage results"
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: test-examples
           path: |
@@ -553,7 +553,7 @@ jobs:
       - hpf
       - eval-tests
       - doc-tests
-    if: '${{ !canceled() }}'
+    if: '${{ !cancelled() }}'
     steps:
       - name: "🛒 Checkout"
         uses: actions/checkout@v4
@@ -608,7 +608,7 @@ jobs:
           GH_TOKEN: '${{secrets.GITHUB_TOKEN}}'
       - name: "📤 Upload coverage report"
         uses: actions/upload-artifact@v4
-        if: '${{ !canceled() }}'
+        if: '${{ !cancelled() }}'
         with:
           name: coverage-report
           path: lenskit-coverage/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,23 +137,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: "🐍 Set up Python"
-        id: install-python
-        uses: actions/setup-python@v5
+      - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          python-version: '3.11'
-      - name: "🕶️ Set up uv"
-        run: |
-          pip install -U 'uv>=0.1.15'
-      - name: "📦 Set up Python dependencies"
-        id: install-deps
-        run: |
-          uv pip install --python $PYTHON "./lenskit[test]" "./lenskit-funksvd"
-        shell: bash
-        env:
-          PYTHON: '${{steps.install-python.outputs.python-path}}'
-          UV_EXTRA_INDEX_URL: 'https://download.pytorch.org/whl/cpu'
-          UV_INDEX_STRATEGY: unsafe-first-match
+          pixi-version: latest
+          activate-environment: true
+          environments: test-py311-funksvd
+          cache-write: false
+          log-level: vv
+          locked: false
+          frozen: true
       - name: "🔍 Inspect environment"
         run: |
           python -m lenskit.util.envcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -615,6 +615,6 @@ jobs:
       - name: "📤 Upload coverage to CodeCov"
         uses: codecov/codecov-action@v4.2.0
         env:
-          CODECOV_TOKEN: '${{ env.CODECOV_TOKEN }}'
+          CODECOV_TOKEN: '${{ vars.CODECOV_TOKEN }}'
       - name: "🚫 Fail if coverage is too low"
         run: coverage report --fail-under=90

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -615,6 +615,6 @@ jobs:
       - name: "📤 Upload coverage to CodeCov"
         uses: codecov/codecov-action@v4.2.0
         env:
-          CODECOV_TOKEN: '${{ vars.CODECOV_TOKEN }}'
+          CODECOV_TOKEN: ab58c9cf-25b8-4283-a485-0b6382dc9a61
       - name: "🚫 Fail if coverage is too low"
         run: coverage report --fail-under=90

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -570,8 +570,6 @@ jobs:
           log-level: vv
           locked: false
           frozen: true
-      - name: "🔨 Build _version.py"
-        run: pipx run build lenskit
       - name: "📥 Download test artifacts"
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,13 +60,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: 'test-conda-${{matrix.platform}}-py${{matrix.python}}'
           path: |
@@ -115,13 +116,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: 'test-vanilla-${{matrix.platform}}-py${{matrix.python}}'
           path: |
@@ -156,13 +158,14 @@ jobs:
           NUMBA_DISABLE_JIT: 1
           PYTORCH_JIT: 0
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: test-nojit
           path: |
@@ -202,13 +205,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit lenskit/tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: test-mindep
           path: |
@@ -246,13 +250,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-funksvd/lenskit lenskit-funksvd/tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: 'test-funksvd-py${{matrix.python}}'
           path: |
@@ -292,13 +297,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit lenskit/tests lenskit-funksvd/tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: test-mindep-funksvd
           path: |
@@ -336,13 +342,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-implicit/lenskit lenskit-implicit/tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: 'test-implicit-py${{matrix.python}}'
           path: |
@@ -382,13 +389,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit/lenskit --cov=lenskit-implicit/lenskit lenskit/tests lenskit-implicit/tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: test-mindep-implicit
           path: |
@@ -426,13 +434,14 @@ jobs:
         run: |
           python -m pytest --verbose --log-file=test.log --durations=25 --cov=lenskit-hpf/lenskit lenskit-hpf/tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: 'test-hpf-py${{matrix.python}}'
           path: |
@@ -470,13 +479,14 @@ jobs:
         run: |
           pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit --cov=lenskit-hpf/lenskit -m 'eval or realdata' --log-file test-eval.log */tests
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: test-eval-tests
           path: |
@@ -514,13 +524,14 @@ jobs:
         run: |
           pytest --cov=lenskit/lenskit --cov=lenskit-funksvd/lenskit --cov=lenskit-implicit/lenskit --cov=lenskit-hpf/lenskit --nbval-lax --doctest-glob='*.rst' --log-file test-docs.log docs */lenskit
       - name: "📐 Coverage results"
+        if: '${{ !canceled() }}'
         run: |
           coverage xml
           coverage report
           cp .coverage coverage.db
       - name: "📤 Upload test results"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: test-examples
           path: |
@@ -542,6 +553,7 @@ jobs:
       - hpf
       - eval-tests
       - doc-tests
+    if: '${{ !canceled() }}'
     steps:
       - name: "🛒 Checkout"
         uses: actions/checkout@v4
@@ -596,9 +608,13 @@ jobs:
           GH_TOKEN: '${{secrets.GITHUB_TOKEN}}'
       - name: "📤 Upload coverage report"
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '${{ !canceled() }}'
         with:
           name: coverage-report
           path: lenskit-coverage/
+      - name: "📤 Upload coverage to CodeCov"
+        uses: codecov/codecov-action@v4.2.0
+        env:
+          CODECOV_TOKEN: '${{ env.CODECOV_TOKEN }}'
       - name: "🚫 Fail if coverage is too low"
         run: coverage report --fail-under=90

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "deno.enable": true,
   "files.exclude": {
     "**/__pycache__": true,
     ".hypothesis/": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [tool.coverage.run]
 relative_files = "true"
+include = ["lenskit*/lenskit/"]
+omit = ["lenskit/lenskit/_version.py"]
 
 [tool.ruff]
 line-length = 100

--- a/workflows/test.ts
+++ b/workflows/test.ts
@@ -36,12 +36,13 @@ const test_matrix = {
     matrix: { "python": PYTHONS, "platform": VANILLA_PLATFORMS },
   }),
   nojit: testJob({
-    install: "vanilla",
+    install: "conda",
     key: "nojit",
     name: "Non-JIT test coverage",
     packages: ["lenskit", "lenskit-funksvd"],
     test_env: { "NUMBA_DISABLE_JIT": 1, "PYTORCH_JIT": 0 },
     test_args: ["-m", "'not slow'"],
+    variant: "funksvd",
   }),
   mindep: testJob({
     install: "vanilla",

--- a/workflows/test.ts
+++ b/workflows/test.ts
@@ -1,7 +1,5 @@
-import { Workflow, WorkflowJob } from "@lenskit/typeline/github";
+import { Workflow } from "@lenskit/typeline/github";
 
-import { checkoutStep } from "./lib/checkout.ts";
-import { script } from "./lib/script.ts";
 import {
   CONDA_PYTHONS,
   PLATFORMS,
@@ -11,7 +9,7 @@ import {
 import { testJob } from "./test/common.ts";
 import { evalTestJob } from "./test/test-eval.ts";
 import { exampleTestJob } from "./test/test-examples.ts";
-import { condaSetup } from "./test/conda.ts";
+import { aggregateResultsJob } from "./test/results.ts";
 
 const FILTER_PATHS = [
   "lenskit*/**.py",
@@ -92,89 +90,6 @@ const test_matrix = {
   "doc-tests": exampleTestJob(),
 };
 
-export const results: WorkflowJob = {
-  name: "Test suite results",
-  "runs-on": "ubuntu-latest",
-  needs: Object.keys(test_matrix),
-  steps: [
-    checkoutStep(),
-    {
-      name: "Add upstream remote & author config",
-      run: script(`
-        git remote add upstream https://github.com/lenskit/lkpy.git
-        git fetch upstream
-        git config user.name "LensKit Bot"
-        git config user.email lkbot@lenskit.org
-      `),
-    },
-    ...condaSetup("report"),
-    {
-      name: "📥 Download test artifacts",
-      uses: "actions/download-artifact@v4",
-      with: {
-        pattern: "test-*",
-        path: "test-logs",
-      },
-    },
-    {
-      name: "📋 List log files",
-      run: "ls -laR test-logs",
-    },
-    {
-      name: "🔧 Fix coverage databases",
-      run: script(`
-        for dbf in test-logs/*/coverage.db; do
-            echo "fixing $dbf"
-            sqlite3 -echo "$dbf" "UPDATE file SET path = replace(path, '\\', '/');"
-        done
-      `),
-    },
-    // inspired by https://hynek.me/articles/ditch-codecov-python/
-    {
-      name: "⛙ Merge and report",
-      run: script(`
-        coverage combine --keep test-logs/*/coverage.db
-        coverage xml
-        coverage html -d lenskit-coverage
-        coverage report --format=markdown >coverage.md
-      `),
-    },
-    {
-      name: "Analyze diff coverage",
-      if: "github.event_name == 'pull_request'",
-      run: script(`
-        diff-cover --json-report diff-cover.json --markdown-report diff-cover.md \\
-          coverage.xml |tee diff-cover.txt
-      `),
-    },
-    {
-      name: "± Measure and report coverage",
-      run: script(`
-        echo $PR_NUMBER > ./lenskit-coverage/pr-number
-        tclsh ./utils/measure-coverage.tcl
-        cat lenskit-coverage/report.md >$GITHUB_STEP_SUMMARY
-      `),
-      env: {
-        PR_NUMBER: "${{ github.event.number }}",
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}",
-      },
-    },
-    {
-      name: "📤 Upload coverage report",
-      uses: "actions/upload-artifact@v4",
-      if: "always()",
-      with: {
-        name: "coverage-report",
-        path: "lenskit-coverage/",
-      },
-    },
-    {
-      name: "🚫 Fail if coverage is too low",
-      run: "coverage report --fail-under=90",
-    },
-  ],
-};
-
 export const workflow: Workflow = {
   name: "Automatic Tests",
   on: {
@@ -187,6 +102,6 @@ export const workflow: Workflow = {
   },
   jobs: {
     ...test_matrix,
-    results,
+    results: aggregateResultsJob(Object.keys(test_matrix)),
   },
 };

--- a/workflows/test.ts
+++ b/workflows/test.ts
@@ -107,7 +107,6 @@ export const results: WorkflowJob = {
       `),
     },
     ...condaSetup("report"),
-    { name: "🔨 Build _version.py", run: "pipx run build lenskit" },
     {
       name: "📥 Download test artifacts",
       uses: "actions/download-artifact@v4",

--- a/workflows/test/common.ts
+++ b/workflows/test/common.ts
@@ -65,23 +65,24 @@ export function coverageSteps(options: TestJobSpec): WorkflowStep[] {
   return [
     {
       name: "📐 Coverage results",
+      if: "${{ !canceled() }}",
       run: script(`
-                coverage xml
-                coverage report
-                cp .coverage coverage.db
-            `),
+        coverage xml
+        coverage report
+        cp .coverage coverage.db
+      `),
     },
     {
       name: "📤 Upload test results",
       uses: "actions/upload-artifact@v4",
-      if: "always()",
+      if: "${{ !canceled() }}",
       with: {
         name: testArtifactName(options),
         path: script(`
-                    test*.log
-                    coverage.db
-                    coverage.xml
-                `),
+          test*.log
+          coverage.db
+          coverage.xml
+        `),
       },
     },
   ];

--- a/workflows/test/common.ts
+++ b/workflows/test/common.ts
@@ -65,7 +65,7 @@ export function coverageSteps(options: TestJobSpec): WorkflowStep[] {
   return [
     {
       name: "📐 Coverage results",
-      if: "${{ !canceled() }}",
+      if: "${{ !cancelled() }}",
       run: script(`
         coverage xml
         coverage report
@@ -75,7 +75,7 @@ export function coverageSteps(options: TestJobSpec): WorkflowStep[] {
     {
       name: "📤 Upload test results",
       uses: "actions/upload-artifact@v4",
-      if: "${{ !canceled() }}",
+      if: "${{ !cancelled() }}",
       with: {
         name: testArtifactName(options),
         path: script(`

--- a/workflows/test/results.ts
+++ b/workflows/test/results.ts
@@ -9,7 +9,7 @@ export function aggregateResultsJob(jobs: string[]): WorkflowJob {
     name: "Test suite results",
     "runs-on": "ubuntu-latest",
     needs: jobs,
-    if: "${{ !canceled() }}",
+    if: "${{ !cancelled() }}",
     steps: [
       checkoutStep(),
       {
@@ -76,7 +76,7 @@ export function aggregateResultsJob(jobs: string[]): WorkflowJob {
       {
         name: "📤 Upload coverage report",
         uses: "actions/upload-artifact@v4",
-        if: "${{ !canceled() }}",
+        if: "${{ !cancelled() }}",
         with: {
           name: "coverage-report",
           path: "lenskit-coverage/",

--- a/workflows/test/results.ts
+++ b/workflows/test/results.ts
@@ -2,33 +2,26 @@ import { WorkflowJob } from "@lenskit/typeline/github";
 
 import { checkoutStep } from "../lib/checkout.ts";
 import { script } from "../lib/script.ts";
-import { META_PYTHON } from "../lib/defs.ts";
+import { condaSetup } from "./conda.ts";
 
 export function aggregateResultsJob(jobs: string[]): WorkflowJob {
   return {
     name: "Test suite results",
     "runs-on": "ubuntu-latest",
     needs: jobs,
+    if: "${{ !canceled() }}",
     steps: [
       checkoutStep(),
       {
         name: "Add upstream remote & author config",
         run: script(`
-                git remote add upstream https://github.com/lenskit/lkpy.git
-                git fetch upstream
-                git config user.name "LensKit Bot"
-                git config user.email lkbot@lenskit.org
-            `),
+          git remote add upstream https://github.com/lenskit/lkpy.git
+          git fetch upstream
+          git config user.name "LensKit Bot"
+          git config user.email lkbot@lenskit.org
+        `),
       },
-      {
-        name: "🐍 Set up Python",
-        uses: "actions/setup-python@v5",
-        with: { "python-version": META_PYTHON },
-      },
-      {
-        name: "📦 Install reporting packages",
-        run: "python -m pip install -r requirements-reporting.txt",
-      },
+      ...condaSetup("report"),
       {
         name: "📥 Download test artifacts",
         uses: "actions/download-artifact@v4",
@@ -44,37 +37,37 @@ export function aggregateResultsJob(jobs: string[]): WorkflowJob {
       {
         name: "🔧 Fix coverage databases",
         run: script(`
-                for dbf in test-logs/*/coverage.db; do
-                    echo "fixing $dbf"
-                    sqlite3 -echo "$dbf" "UPDATE file SET path = replace(path, '\\', '/');"
-                done
-            `),
+          for dbf in test-logs/*/coverage.db; do
+              echo "fixing $dbf"
+              sqlite3 -echo "$dbf" "UPDATE file SET path = replace(path, '\\', '/');"
+          done
+        `),
       },
       // inspired by https://hynek.me/articles/ditch-codecov-python/
       {
         name: "⛙ Merge and report",
         run: script(`
-                coverage combine --keep test-logs/*/coverage.db
-                coverage xml
-                coverage html -d lenskit-coverage
-                coverage report --format=markdown >coverage.md
-            `),
+          coverage combine --keep test-logs/*/coverage.db
+          coverage xml
+          coverage html -d lenskit-coverage
+          coverage report --format=markdown >coverage.md
+        `),
       },
       {
         name: "Analyze diff coverage",
         if: "github.event_name == 'pull_request'",
         run: script(`
-                diff-cover --json-report diff-cover.json --markdown-report diff-cover.md \\
-                    coverage.xml |tee diff-cover.txt
-            `),
+          diff-cover --json-report diff-cover.json --markdown-report diff-cover.md \\
+            coverage.xml |tee diff-cover.txt
+        `),
       },
       {
         name: "± Measure and report coverage",
         run: script(`
-                echo $PR_NUMBER > ./lenskit-coverage/pr-number
-                tclsh ./utils/measure-coverage.tcl
-                cat lenskit-coverage/report.md >$GITHUB_STEP_SUMMARY
-            `),
+          echo $PR_NUMBER > ./lenskit-coverage/pr-number
+          tclsh ./utils/measure-coverage.tcl
+          cat lenskit-coverage/report.md >$GITHUB_STEP_SUMMARY
+        `),
         env: {
           PR_NUMBER: "${{ github.event.number }}",
           GH_TOKEN: "${{secrets.GITHUB_TOKEN}}",
@@ -83,10 +76,17 @@ export function aggregateResultsJob(jobs: string[]): WorkflowJob {
       {
         name: "📤 Upload coverage report",
         uses: "actions/upload-artifact@v4",
-        if: "always()",
+        if: "${{ !canceled() }}",
         with: {
           name: "coverage-report",
           path: "lenskit-coverage/",
+        },
+      },
+      {
+        name: "📤 Upload coverage to CodeCov",
+        uses: "codecov/codecov-action@v4.2.0",
+        env: {
+          CODECOV_TOKEN: "${{ env.CODECOV_TOKEN }}",
         },
       },
       {

--- a/workflows/test/results.ts
+++ b/workflows/test/results.ts
@@ -86,7 +86,7 @@ export function aggregateResultsJob(jobs: string[]): WorkflowJob {
         name: "📤 Upload coverage to CodeCov",
         uses: "codecov/codecov-action@v4.2.0",
         env: {
-          CODECOV_TOKEN: "${{ env.CODECOV_TOKEN }}",
+          CODECOV_TOKEN: "${{ vars.CODECOV_TOKEN }}",
         },
       },
       {

--- a/workflows/test/results.ts
+++ b/workflows/test/results.ts
@@ -4,6 +4,8 @@ import { checkoutStep } from "../lib/checkout.ts";
 import { script } from "../lib/script.ts";
 import { condaSetup } from "./conda.ts";
 
+const CODECOV_TOKEN = "ab58c9cf-25b8-4283-a485-0b6382dc9a61";
+
 export function aggregateResultsJob(jobs: string[]): WorkflowJob {
   return {
     name: "Test suite results",
@@ -86,7 +88,7 @@ export function aggregateResultsJob(jobs: string[]): WorkflowJob {
         name: "📤 Upload coverage to CodeCov",
         uses: "codecov/codecov-action@v4.2.0",
         env: {
-          CODECOV_TOKEN: "${{ vars.CODECOV_TOKEN }}",
+          CODECOV_TOKEN: CODECOV_TOKEN,
         },
       },
       {


### PR DESCRIPTION
This makes a couple of improvements to test coverage measurement:

- Use exclude rather than a pre-report build to handle coverage of `_version.py`
- Use Conda/Pixi for non-JIT test environment to restore coverage
- Bring back CodeCov for coverage analysis