### PR TITLE
Add run metric suite and run evaluation support

### DIFF
--- a/lenskit-funksvd/tests/test_funksvd.py
+++ b/lenskit-funksvd/tests/test_funksvd.py
@@ -16,6 +16,7 @@ from pytest import approx, mark
 import lenskit.funksvd as svd
 import lenskit.util.test as lktu
 from lenskit.data import Dataset, from_interactions_df
+from lenskit.metrics import call_metric
 
 _log = logging.getLogger(__name__)
 
@@ -224,7 +225,7 @@ def test_fsvd_batch_accuracy(ml_100k: pd.DataFrame):
 
     folds = xf.partition_users(ml_100k, 5, xf.SampleFrac(0.2))
     preds = pd.concat(eval(train, test) for (train, test) in folds)
-    mae = pm.MAE(preds)
+    mae = call_metric(pm.MAE, preds)
     assert mae == approx(0.74, abs=0.025)
 
     user_rmse = pm.measure_user_predictions(preds, pm.RMSE)

--- a/lenskit/lenskit/batch/_predict.py
+++ b/lenskit/lenskit/batch/_predict.py
@@ -41,7 +41,7 @@ def predict(algo, pairs, *, n_jobs=None, **kwargs):
     To use this function, provide a pre-fit algorithm:
 
         >>> from lenskit.algorithms.bias import Bias
-        >>> from lenskit.metrics.predict import RMSE
+        >>> from lenskit.metrics import call_metric, RMSE
         >>> from lenskit.data import from_interactions_df
         >>> from lenskit.data.movielens import load_movielens_df
         >>> ratings = load_movielens_df('data/ml-latest-small')
@@ -56,7 +56,7 @@ def predict(algo, pairs, *, n_jobs=None, **kwargs):
         99006   664  8529     4.0  1393891173    3.573008
         99007   664  8636     4.0  1393891175    3.846268
         99008   664  8641     4.5  1393890852    3.710635
-        >>> RMSE(preds)
+        >>> call_metric(RMSE, preds)
         0.832699...
 
     Args:

--- a/lenskit/lenskit/data/bulk.py
+++ b/lenskit/lenskit/data/bulk.py
@@ -1,0 +1,47 @@
+"""
+Functions for working with bulk per-user data.
+
+.. note::
+
+    This is a provisional API to enable incremental forward development while
+    we develop more flexible abstractions for collections of data indexed by
+    user or other keys.
+"""
+
+import pandas as pd
+
+from .items import ItemList
+from .types import EntityId
+
+
+def dict_to_df(data: dict[EntityId, ItemList], column: str = "user_id") -> pd.DataFrame:
+    """
+    Convert a dictionary mapping user IDs to item lists into a data frame.
+
+    Args:
+        data:
+            The dictionary of data.
+        column:
+            The column, to support dictionaries mapped by things other than user IDs.
+    """
+
+    df = pd.concat(
+        {u: il.to_df(numbers=False) for (u, il) in data.items()},
+        names=[column],
+    )
+    df = df.reset_index(column)
+    df = df.reset_index(drop=True)
+    return df
+
+
+def dict_from_df(df: pd.DataFrame, column: str = "user_id") -> dict[EntityId, ItemList]:
+    """
+    Convert a dictionary mapping user IDs to item lists into a data frame.
+
+    Args:
+        df:
+            The data frame.
+        column:
+            The column, to support dictionaries mapped by things other than user IDs.
+    """
+    return {u: ItemList.from_df(udf) for (u, udf) in df.groupby(column)}  # type: ignore

--- a/lenskit/lenskit/data/bulk.py
+++ b/lenskit/lenskit/data/bulk.py
@@ -13,11 +13,17 @@ from typing import Iterator, cast, overload
 import pandas as pd
 
 from .items import ItemList
-from .schemas import ITEM_COMPAT_COLUMN, USER_COMPAT_COLUMN, column_name, normalize_columns
+from .schemas import (
+    ITEM_COMPAT_COLUMN,
+    USER_COLUMN,
+    USER_COMPAT_COLUMN,
+    column_name,
+    normalize_columns,
+)
 from .types import Column, EntityId
 
 
-def dict_to_df(data: dict[EntityId, ItemList], *, column: str = "user_id") -> pd.DataFrame:
+def dict_to_df(data: dict[EntityId, ItemList], *, column: str = USER_COLUMN) -> pd.DataFrame:
     """
     Convert a dictionary mapping user IDs to item lists into a data frame.
 
@@ -37,7 +43,9 @@ def dict_to_df(data: dict[EntityId, ItemList], *, column: str = "user_id") -> pd
     return df
 
 
-def dict_from_df(df: pd.DataFrame, *, column: str = "user_id") -> dict[EntityId, ItemList]:
+def dict_from_df(
+    df: pd.DataFrame, *, column: Column = USER_COMPAT_COLUMN, item_col: Column = ITEM_COMPAT_COLUMN
+) -> dict[EntityId, ItemList]:
     """
     Convert a dictionary mapping user IDs to item lists into a data frame.
 
@@ -47,21 +55,40 @@ def dict_from_df(df: pd.DataFrame, *, column: str = "user_id") -> dict[EntityId,
         column:
             The column, to support dictionaries mapped by things other than user IDs.
     """
-    return {u: ItemList.from_df(udf) for (u, udf) in df.groupby(column)}  # type: ignore
+    df = normalize_columns(df, column, item_col)
+    return {u: ItemList.from_df(udf) for (u, udf) in df.groupby(column_name(column))}  # type: ignore
 
 
-def group_df(
-    df: pd.DataFrame, *, column: Column = USER_COMPAT_COLUMN, require_cols=[ITEM_COMPAT_COLUMN]
-):
+def group_df(df: pd.DataFrame, *, column: Column = USER_COMPAT_COLUMN, item_col=ITEM_COMPAT_COLUMN):
     """
     Group a data frame by a specified column, possibly checking for and
     normalizing the names of other columns as well.  The default options group
     by ``user_id`` and require an ``item_id`` column, allowing the compatibility
     aliases ``user`` and ``item``.
     """
-    df = normalize_columns(df, column, *require_cols)
+    df = normalize_columns(df, column, item_col)
     col = column_name(column)
     return df.groupby(col)
+
+
+@overload
+def count_item_lists(data: dict[EntityId, ItemList]) -> int: ...
+@overload
+def count_item_lists(
+    data: pd.DataFrame | dict[EntityId, ItemList],
+    *,
+    column: Column = USER_COMPAT_COLUMN,
+) -> int: ...
+def count_item_lists(
+    data: pd.DataFrame | dict[EntityId, ItemList],
+    *,
+    column: Column = USER_COMPAT_COLUMN,
+) -> int:
+    if isinstance(data, dict):
+        return len(data)
+    else:
+        data = normalize_columns(data, column)
+        return data[column_name(column)].nunique()
 
 
 @overload
@@ -71,13 +98,13 @@ def iter_item_lists(
     data: pd.DataFrame | dict[EntityId, ItemList],
     *,
     column: Column = USER_COMPAT_COLUMN,
-    required_cols=[ITEM_COMPAT_COLUMN],
+    item_col=ITEM_COMPAT_COLUMN,
 ) -> Iterator[tuple[EntityId, ItemList]]: ...
 def iter_item_lists(
     data: pd.DataFrame | dict[EntityId, ItemList],
     *,
     column: Column = USER_COMPAT_COLUMN,
-    required_cols=[ITEM_COMPAT_COLUMN],
+    item_col=ITEM_COMPAT_COLUMN,
 ) -> Iterator[tuple[EntityId, ItemList]]:
     """
     Iterate over item lists identified by keys.  When the input is a data frame,
@@ -86,7 +113,7 @@ def iter_item_lists(
     ``user`` and ``item``.
     """
     if isinstance(data, pd.DataFrame):
-        for key, df in group_df(data, column=column, require_cols=required_cols):
+        for key, df in group_df(data, column=column, item_col=item_col):
             yield cast(EntityId, key), ItemList.from_df(df)
 
     elif isinstance(data, dict):

--- a/lenskit/lenskit/data/bulk.py
+++ b/lenskit/lenskit/data/bulk.py
@@ -13,7 +13,7 @@ from typing import Iterator, cast, overload
 import pandas as pd
 
 from .items import ItemList
-from .schemas import USER_COMPAT_COLUMN, column_name, normalize_columns
+from .schemas import ITEM_COMPAT_COLUMN, USER_COMPAT_COLUMN, column_name, normalize_columns
 from .types import Column, EntityId
 
 
@@ -50,23 +50,43 @@ def dict_from_df(df: pd.DataFrame, *, column: str = "user_id") -> dict[EntityId,
     return {u: ItemList.from_df(udf) for (u, udf) in df.groupby(column)}  # type: ignore
 
 
-def group_df(df: pd.DataFrame, *, column: Column = USER_COMPAT_COLUMN):
-    df = normalize_columns(df, column)
+def group_df(
+    df: pd.DataFrame, *, column: Column = USER_COMPAT_COLUMN, require_cols=[ITEM_COMPAT_COLUMN]
+):
+    """
+    Group a data frame by a specified column, possibly checking for and
+    normalizing the names of other columns as well.  The default options group
+    by ``user_id`` and require an ``item_id`` column, allowing the compatibility
+    aliases ``user`` and ``item``.
+    """
+    df = normalize_columns(df, column, *require_cols)
     col = column_name(column)
     return df.groupby(col)
 
 
 @overload
-def iter_groups(data: dict[EntityId, ItemList]) -> Iterator[tuple[EntityId, ItemList]]: ...
+def iter_item_lists(data: dict[EntityId, ItemList]) -> Iterator[tuple[EntityId, ItemList]]: ...
 @overload
-def iter_groups(
-    data: pd.DataFrame | dict[EntityId, ItemList], *, column: Column = USER_COMPAT_COLUMN
+def iter_item_lists(
+    data: pd.DataFrame | dict[EntityId, ItemList],
+    *,
+    column: Column = USER_COMPAT_COLUMN,
+    required_cols=[ITEM_COMPAT_COLUMN],
 ) -> Iterator[tuple[EntityId, ItemList]]: ...
-def iter_groups(
-    data: pd.DataFrame | dict[EntityId, ItemList], *, column: Column = USER_COMPAT_COLUMN
+def iter_item_lists(
+    data: pd.DataFrame | dict[EntityId, ItemList],
+    *,
+    column: Column = USER_COMPAT_COLUMN,
+    required_cols=[ITEM_COMPAT_COLUMN],
 ) -> Iterator[tuple[EntityId, ItemList]]:
+    """
+    Iterate over item lists identified by keys.  When the input is a data frame,
+    the column names may be specified; the default options group by ``user_id``
+    and require an ``item_id`` column, allowing the compatibility aliases
+    ``user`` and ``item``.
+    """
     if isinstance(data, pd.DataFrame):
-        for key, df in group_df(data, column=column):
+        for key, df in group_df(data, column=column, require_cols=required_cols):
             yield cast(EntityId, key), ItemList.from_df(df)
 
     elif isinstance(data, dict):

--- a/lenskit/lenskit/data/schemas.py
+++ b/lenskit/lenskit/data/schemas.py
@@ -1,0 +1,51 @@
+"""
+Definitions and utilities related to LensKit data schemas.
+"""
+
+import warnings
+
+import pandas as pd
+
+from .types import AliasedColumn, Column
+
+USER_COLUMN = "user_id"
+ITEM_COLUMN = "item_id"
+USER_COMPAT_COLUMN = AliasedColumn(USER_COLUMN, ["user"], warn=True)
+ITEM_COMPAT_COLUMN = AliasedColumn(ITEM_COLUMN, ["item"], warn=True)
+
+
+def normalize_columns(df: pd.DataFrame, *columns: Column) -> pd.DataFrame:
+    """
+    Resolve column aliases to columns, pulling them out of the index if necessary.
+    """
+
+    for column in columns:
+        name = column if isinstance(column, str) else column.name
+        if name in df.columns:
+            continue
+        elif name in df.index.names:
+            df = df.reset_index(name)
+            continue
+
+        if not isinstance(column, AliasedColumn):
+            raise KeyError("column %s not found", name)
+
+        found = False
+        for alias in column.compat_aliases:
+            if alias in df.columns:
+                found = True
+                df = df.rename(columns={alias: name})
+                if column.warn:
+                    warnings.warn(f"found deprecated alias {alias} for {name}", DeprecationWarning)
+                break
+            elif alias in df.index.names:
+                found = True
+                df = df.reset_index(alias).rename(columns={alias: name})
+                if column.warn:
+                    warnings.warn(f"found deprecated alias {alias} for {name}", DeprecationWarning)
+                break
+
+        if not found:
+            raise KeyError("column %s not found")
+
+    return df

--- a/lenskit/lenskit/data/schemas.py
+++ b/lenskit/lenskit/data/schemas.py
@@ -14,13 +14,23 @@ USER_COMPAT_COLUMN = AliasedColumn(USER_COLUMN, ["user"], warn=True)
 ITEM_COMPAT_COLUMN = AliasedColumn(ITEM_COLUMN, ["item"], warn=True)
 
 
+def column_name(col: Column) -> str:
+    match col:
+        case str(name):
+            return name
+        case AliasedColumn(name=name):
+            return name
+        case _:  # pragma: nocover
+            raise TypeError(f"invalid column spec {col}")
+
+
 def normalize_columns(df: pd.DataFrame, *columns: Column) -> pd.DataFrame:
     """
     Resolve column aliases to columns, pulling them out of the index if necessary.
     """
 
     for column in columns:
-        name = column if isinstance(column, str) else column.name
+        name = column_name(column)
         if name in df.columns:
             continue
         elif name in df.index.names:

--- a/lenskit/lenskit/data/types.py
+++ b/lenskit/lenskit/data/types.py
@@ -12,6 +12,7 @@ Basic data types used in data representations.
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, NamedTuple, TypeAlias, TypeVar, cast
 
 import numpy as np
@@ -25,6 +26,20 @@ NPEntityId: TypeAlias = np.integer[Any] | np.str_ | np.bytes_ | np.object_
 "Allowable entity identifier types (NumPy version)"
 
 T = TypeVar("T")
+
+
+@dataclass
+class AliasedColumn:
+    name: str
+    "The column name."
+    compat_aliases: list[str] = field(default_factory=list)
+    "A list of aliases for the column."
+    warn: bool = False
+    "Whether to warn when using an alias."
+
+
+Column: TypeAlias = str | AliasedColumn
+
 
 if TYPE_CHECKING or sys.version_info >= (3, 11):
 

--- a/lenskit/lenskit/metrics/__init__.py
+++ b/lenskit/lenskit/metrics/__init__.py
@@ -5,5 +5,9 @@
 # SPDX-License-Identifier: MIT
 
 """
-Metrics for evaluating recommendations.
+Metrics for evaluating recommender outputs.
 """
+
+from ._base import LabeledMetric, Metric, MetricBase
+
+__all__ = ["Metric", "LabeledMetric", "MetricBase"]

--- a/lenskit/lenskit/metrics/__init__.py
+++ b/lenskit/lenskit/metrics/__init__.py
@@ -8,6 +8,63 @@
 Metrics for evaluating recommender outputs.
 """
 
+from typing import Callable, ParamSpec, cast, overload
+
+import pandas as pd
+
+from lenskit.data import ItemList
+
 from ._base import Metric, MetricFunction
+from .predict import PredictMetric
 
 __all__ = ["Metric", "MetricFunction"]
+
+P = ParamSpec("P")
+
+
+@overload
+def call_metric(
+    metric: Metric | MetricFunction | Callable[P, Metric],
+    outs: ItemList,
+    test: ItemList,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> float: ...
+@overload
+def call_metric(
+    metric: PredictMetric | Callable[P, PredictMetric],
+    outs: ItemList | pd.DataFrame,
+    test: ItemList | None = None,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> float: ...
+def call_metric(
+    metric: Metric | MetricFunction | Callable[P, Metric],
+    outs: ItemList | pd.DataFrame,
+    test: ItemList | None = None,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> float:
+    """
+    Call a metric, instantiating it if necessary.
+
+    Supports both the base :class:`Metric` protocol and the extensions in
+    :class:`PredictMetric`.
+
+    Args:
+        metric:
+            The metric to call.  Note that the type of ``Callable`` is slightly
+            too loose, it actually needs to be a class that subclasses
+            :class:`Metric`.
+        outs:
+            The output to measure.
+        test:
+            The test data to measure.
+    """
+
+    if isinstance(metric, type):
+        metric = metric(*args, **kwargs)
+
+    metric = cast(Metric | MetricFunction, metric)
+
+    return metric(outs, test)  # type: ignore

--- a/lenskit/lenskit/metrics/__init__.py
+++ b/lenskit/lenskit/metrics/__init__.py
@@ -15,9 +15,9 @@ import pandas as pd
 from lenskit.data import ItemList
 
 from ._base import Metric, MetricFunction
-from .predict import PredictMetric
+from .predict import MAE, RMSE, PredictMetric
 
-__all__ = ["Metric", "MetricFunction"]
+__all__ = ["Metric", "MetricFunction", "RMSE", "MAE"]
 
 P = ParamSpec("P")
 

--- a/lenskit/lenskit/metrics/__init__.py
+++ b/lenskit/lenskit/metrics/__init__.py
@@ -46,7 +46,10 @@ def call_metric(
     **kwargs: P.kwargs,
 ) -> float:
     """
-    Call a metric, instantiating it if necessary.
+    Call a metric, instantiating it if necessary.  This intended to be a quick
+    convenience when you just need to call a metric with its default settings
+    and don't want to mess around with object/class distinctions.  You usually
+    don't actually want to use it.
 
     Supports both the base :class:`Metric` protocol and the extensions in
     :class:`PredictMetric`.

--- a/lenskit/lenskit/metrics/__init__.py
+++ b/lenskit/lenskit/metrics/__init__.py
@@ -8,6 +8,6 @@
 Metrics for evaluating recommender outputs.
 """
 
-from ._base import LabeledMetric, Metric, MetricBase
+from ._base import Metric, MetricFunction
 
-__all__ = ["Metric", "LabeledMetric", "MetricBase"]
+__all__ = ["Metric", "MetricFunction"]

--- a/lenskit/lenskit/metrics/_base.py
+++ b/lenskit/lenskit/metrics/_base.py
@@ -1,0 +1,50 @@
+from abc import ABC, abstractmethod
+from typing import Protocol, runtime_checkable
+
+from lenskit.data import ItemList
+
+
+class Metric(Protocol):
+    """
+    Core protocol implemented by LensKit metrics.
+    """
+
+    @abstractmethod
+    def __call__(self, recs: ItemList, test: ItemList) -> float: ...
+
+
+@runtime_checkable
+class LabeledMetric(Metric, Protocol):
+    label: str
+    """
+    The metric's label.
+    """
+    mean_label: str
+    """
+    The label to use for the mean of the metric.
+    """
+
+
+class MetricBase(ABC, LabeledMetric):
+    """
+    Base class for LensKit metric classes, supporting configuration options and
+    labels.
+    """
+
+    @property
+    def label(self):
+        """
+        The metric's default label in output.
+
+        The base class implementation returns the class name by default.
+        """
+        return self.__name__
+
+    @property
+    def mean_label(self):
+        """
+        The label to use when aggregating the metric by taking the mean.
+
+        The base class implementation delegates to :attr:`label`.
+        """
+        return self.label

--- a/lenskit/lenskit/metrics/_base.py
+++ b/lenskit/lenskit/metrics/_base.py
@@ -10,7 +10,7 @@ class Metric(Protocol):
     """
 
     @abstractmethod
-    def __call__(self, recs: ItemList, test: ItemList) -> float: ...
+    def __call__(self, output: ItemList, test: ItemList, /) -> float: ...
 
 
 @runtime_checkable

--- a/lenskit/lenskit/metrics/_base.py
+++ b/lenskit/lenskit/metrics/_base.py
@@ -1,50 +1,57 @@
 from abc import ABC, abstractmethod
-from typing import Protocol, runtime_checkable
+from typing import ClassVar, Protocol
 
 from lenskit.data import ItemList
 
 
-class Metric(Protocol):
-    """
-    Core protocol implemented by LensKit metrics.
-    """
+class MetricFunction(Protocol):
+    "Interface for metrics implemented as simple functions."
 
     @abstractmethod
     def __call__(self, output: ItemList, test: ItemList, /) -> float: ...
 
 
-@runtime_checkable
-class LabeledMetric(Metric, Protocol):
-    label: str
+class Metric(ABC):
     """
-    The metric's label.
-    """
-    mean_label: str
-    """
-    The label to use for the mean of the metric.
+    Base class for LensKit metrics.
+
+    For simplicity in the analysis code, you cannot simply implement the
+    properties of this class on an arbitrary class in order to implement a
+    metric with all available behavior such as labeling and defaults; you must
+    actually extend this class.  This requirement may be relaxed in the future.
     """
 
-
-class MetricBase(ABC, LabeledMetric):
+    default: ClassVar[float | None] = 0.0
     """
-    Base class for LensKit metric classes, supporting configuration options and
-    labels.
+    The default value to infer when computing statistics over missing values.
+    If ``None``, no inference is done (necessary for metrics like RMSE, where
+    the missing value is theoretically infinite).
     """
 
     @property
-    def label(self):
+    def label(self) -> str:
         """
         The metric's default label in output.
 
-        The base class implementation returns the class name by default.
+        The base implementation returns the class name by default.
         """
-        return self.__name__
+        return self.__class__.__name__
 
     @property
-    def mean_label(self):
+    def mean_label(self) -> str:
         """
         The label to use when aggregating the metric by taking the mean.
 
-        The base class implementation delegates to :attr:`label`.
+        The base implementation delegates to :attr:`label`.
         """
         return self.label
+
+    @abstractmethod
+    def __call__(self, output: ItemList, test: ItemList, /) -> float:
+        """
+        Metrics should be callable to compute their values.
+        """
+        ...
+
+    def __str__(self):
+        return f"Metric {self.label}"

--- a/lenskit/lenskit/metrics/basic.py
+++ b/lenskit/lenskit/metrics/basic.py
@@ -1,3 +1,7 @@
+"""
+Basic set statistics.
+"""
+
 from lenskit.data.items import ItemList
 
 from ._base import MetricBase

--- a/lenskit/lenskit/metrics/basic.py
+++ b/lenskit/lenskit/metrics/basic.py
@@ -1,0 +1,25 @@
+from lenskit.data.items import ItemList
+
+from ._base import MetricBase
+
+
+class ListLength(MetricBase):
+    """
+    Report the length of the output (recommendation list or predictions).
+    """
+
+    label = "N"  # type: ignore
+
+    def __call__(self, recs: ItemList, test: ItemList) -> float:
+        return len(recs)
+
+
+class TestItemCount(MetricBase):
+    """
+    Report the number of test items.
+    """
+
+    label = "TestItemCount"  # type: ignore
+
+    def __call__(self, recs: ItemList, test: ItemList) -> float:
+        return len(test)

--- a/lenskit/lenskit/metrics/basic.py
+++ b/lenskit/lenskit/metrics/basic.py
@@ -4,10 +4,10 @@ Basic set statistics.
 
 from lenskit.data.items import ItemList
 
-from ._base import MetricBase
+from ._base import Metric
 
 
-class ListLength(MetricBase):
+class ListLength(Metric):
     """
     Report the length of the output (recommendation list or predictions).
     """
@@ -18,7 +18,7 @@ class ListLength(MetricBase):
         return len(recs)
 
 
-class TestItemCount(MetricBase):
+class TestItemCount(Metric):
     """
     Report the number of test items.
     """

--- a/lenskit/lenskit/metrics/bulk.py
+++ b/lenskit/lenskit/metrics/bulk.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TypeAlias
+
+import numpy as np
+import pandas as pd
+from progress_api import make_progress
+
+from lenskit.data import EntityId, ItemList
+from lenskit.data.bulk import count_item_lists, dict_from_df, iter_item_lists
+
+from ._base import LabeledMetric, Metric
+
+_log = logging.getLogger(__name__)
+ILSet: TypeAlias = dict[EntityId, ItemList] | pd.DataFrame
+
+
+@dataclass(frozen=True)
+class MetricWrapper:
+    """
+    Internal class for storing metrics.
+    """
+
+    metric: Metric
+    label: str
+    mean_label: str
+    default: float
+
+
+class RunAnalysisResult:
+    """
+    Results of a bulk metric computation.
+    """
+
+    list_scores: pd.DataFrame
+    """
+    The metric scores for each list.  The row indices are list (user) IDs, and
+    there is one column for each metric.
+    """
+
+    _defaults: dict[str, float]
+
+    def __init__(self, lscores: pd.DataFrame, defaults: dict[str, float]):
+        self.list_scores = lscores
+        self._defaults = defaults
+
+    def summary(self) -> pd.DataFrame:
+        """
+        Sumamry statistics for the per-list metrics.  Each metric is on its own row,
+        with columns reporting the following:
+
+        ``mean``:
+            The mean metric value.
+        ``median``:
+            The median metric value.
+        ``sd``:
+            The standard deviation of the metric.
+
+        Additional columns are added based on other options.
+        """
+        df = self.list_scores.fillna(self._defaults)
+        return pd.DataFrame({"mean": df.mean()})
+
+
+def _wrap_metric(
+    m: Metric, label: str | None = None, mean_label: str | None = None, default: float | None = None
+) -> MetricWrapper:
+    if label is None:
+        if isinstance(m, LabeledMetric):
+            wl = m.label
+        else:
+            wl = m.__name__  # type: ignore
+    else:
+        wl = label
+
+    if mean_label is None:
+        if label is not None:
+            wml = label
+        elif isinstance(m, LabeledMetric):
+            wml = m.mean_label
+        else:
+            wml = wl
+
+    if default is None:
+        default = getattr(m, "default", None)
+        if default is None:
+            default = 0.0
+        elif not isinstance(default, (float, int, np.floating, np.integer)):
+            raise TypeError(f"metric {m} has unsupported default {default}")
+
+    return MetricWrapper(m, wl, wml, default)
+
+
+class RunAnalysis:
+    """
+    Compute metrics over a collection of item lists composing a run.
+
+    Args:
+        metrics:
+            A list of metrics; you can also add them with :meth:`add_metric`,
+            which provides more flexibility.
+    """
+
+    metrics: list[MetricWrapper]
+    "The list of metrics to compute."
+
+    def __init__(self, *metrics: Metric):
+        self.metrics = [_wrap_metric(m) for m in metrics]
+
+    def add_metric(
+        self,
+        metric: Metric,
+        label: str | None = None,
+        mean_label: str | None = None,
+        default: float | None = None,
+    ):
+        """
+        Add a metric to this metric set.
+
+        Args:
+            metric:
+                The metric to add to the set.
+            label:
+                The label to use for the metric's results.  If unset, obtains
+                from the metric.
+            mean_label:
+                The label to use for the overall aggregate (mean) of the
+                metric's results.  If unset, obtains from the metric.
+            default:
+                The default value to use in aggregates when a user does not have
+                recommendations. If unset, obtains from the metric's ``default``
+                attribute (if specified), or 0.0.
+        """
+        self.metrics.append(_wrap_metric(metric, label, mean_label, default))
+
+    def compute(self, outputs: ILSet, test: ILSet) -> RunAnalysisResult:
+        if isinstance(test, pd.DataFrame):
+            test = dict_from_df(test)
+
+        columns = [m.label for m in self.metrics]
+        user_ids = []
+        rows = []
+
+        n = count_item_lists(outputs)
+        _log.info("computing metrics for %d output lists", n)
+        with make_progress(_log, "lists", n) as pb:
+            for uid, out in iter_item_lists(outputs):
+                u_t = test[uid]
+                row = [m.metric(out, u_t) for m in self.metrics]
+                user_ids.append(uid)
+                rows.append(row)
+                pb.update()
+
+        df = pd.DataFrame.from_records(rows, index=user_ids, columns=columns)
+        return RunAnalysisResult(df, {m.label: m.default for m in self.metrics})

--- a/lenskit/lenskit/metrics/bulk.py
+++ b/lenskit/lenskit/metrics/bulk.py
@@ -55,13 +55,13 @@ class RunAnalysisResult:
             The mean metric value.
         ``median``:
             The median metric value.
-        ``sd``:
-            The standard deviation of the metric.
+        ``std``:
+            The (sample) standard deviation of the metric.
 
         Additional columns are added based on other options.
         """
         df = self.list_scores.fillna(self._defaults)
-        return pd.DataFrame({"mean": df.mean()})
+        return df.agg(["mean", "median", "std"]).T
 
 
 def _wrap_metric(

--- a/lenskit/lenskit/metrics/bulk.py
+++ b/lenskit/lenskit/metrics/bulk.py
@@ -130,7 +130,7 @@ class RunAnalysis:
 
     def add_metric(
         self,
-        metric: Metric,
+        metric: Metric | MetricFunction | type[Metric],
         label: str | None = None,
         mean_label: str | None = None,
         default: float | None = None,

--- a/lenskit/lenskit/metrics/predict.py
+++ b/lenskit/lenskit/metrics/predict.py
@@ -111,7 +111,7 @@ def _mae(scores: ScoreArray, truth: ScoreArray) -> float:
 @overload
 def RMSE(
     predictions: ItemList,
-    truth: ItemList | None = None,
+    test: ItemList | None = None,
     missing_scores: MissingDisposition = "error",
     missing_truth: MissingDisposition = "error",
 ) -> float: ...
@@ -124,7 +124,7 @@ def RMSE(
 ) -> float: ...
 def RMSE(
     predictions: ItemList | pd.DataFrame,
-    truth: ItemList | None = None,
+    test: ItemList | None = None,
     missing_scores: MissingDisposition = "error",
     missing_truth: MissingDisposition = "error",
 ) -> float:
@@ -164,7 +164,7 @@ def RMSE(
         the root mean squared approximation error
     """
 
-    return _score_predictions(_rmse, predictions, truth, missing_scores, missing_truth)
+    return _score_predictions(_rmse, predictions, test, missing_scores, missing_truth)
 
 
 @overload
@@ -218,6 +218,11 @@ def MAE(
     """
 
     return _score_predictions(_mae, predictions, truth, missing_scores, missing_truth)
+
+
+# explicitly set defaults — these cannot fill in missing values
+RMSE.default = None
+MAE.default = None
 
 
 def measure_user_predictions(

--- a/lenskit/lenskit/metrics/ranking/__init__.py
+++ b/lenskit/lenskit/metrics/ranking/__init__.py
@@ -2,7 +2,7 @@
 LensKit ranking (and list) metrics.
 """
 
-from ._base import RankingMetric, RankingMetricBase
+from ._base import RankingMetricBase
 from ._dcg import NDCG
 from ._hit import Hit
 from ._pr import Precision, Recall

--- a/lenskit/lenskit/metrics/ranking/__init__.py
+++ b/lenskit/lenskit/metrics/ranking/__init__.py
@@ -10,7 +10,6 @@ from ._rbp import RBP
 from ._recip import RecipRank
 
 __all__ = [
-    "RankingMetric",
     "RankingMetricBase",
     "Hit",
     "Precision",

--- a/lenskit/lenskit/metrics/ranking/_base.py
+++ b/lenskit/lenskit/metrics/ranking/_base.py
@@ -1,9 +1,9 @@
 from lenskit.data import ItemList
 
-from .._base import MetricBase
+from .._base import Metric
 
 
-class RankingMetricBase(MetricBase):
+class RankingMetricBase(Metric):
     """
     Base class for most ranking metrics, implementing a ``k`` parameter for
     truncation.

--- a/lenskit/lenskit/metrics/ranking/_base.py
+++ b/lenskit/lenskit/metrics/ranking/_base.py
@@ -1,19 +1,9 @@
-from abc import ABC, abstractmethod
-from typing import Protocol
-
 from lenskit.data import ItemList
 
-
-class RankingMetric(Protocol):
-    """
-    Protocol implemented by ranking metrics.
-    """
-
-    @abstractmethod
-    def __call__(self, recs: ItemList, test: ItemList) -> float: ...
+from .._base import MetricBase
 
 
-class RankingMetricBase(ABC, RankingMetric):
+class RankingMetricBase(MetricBase):
     """
     Base class for most ranking metrics, implementing a ``k`` parameter for
     truncation.

--- a/lenskit/lenskit/metrics/ranking/_dcg.py
+++ b/lenskit/lenskit/metrics/ranking/_dcg.py
@@ -55,6 +55,13 @@ class NDCG(RankingMetricBase):
         self.discount = discount
         self.gain = gain
 
+    @property
+    def label(self):
+        if self.k is not None:
+            return f"NDCG@{self.k}"
+        else:
+            return "NDCG"
+
     def __call__(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)
         items = recs.ids()

--- a/lenskit/lenskit/metrics/ranking/_hit.py
+++ b/lenskit/lenskit/metrics/ranking/_hit.py
@@ -14,6 +14,20 @@ class Hit(RankingMetricBase):
     computes the *hit rate* :cite:p:`deshpande:iknn`.
     """
 
+    @property
+    def label(self):
+        if self.k is not None:
+            return f"Hit@{self.k}"
+        else:
+            return "Hit"
+
+    @property
+    def mean_label(self):
+        if self.k is not None:
+            return f"HitRate@{self.k}"
+        else:
+            return "HitRate"
+
     def __call__(self, recs: ItemList, test: ItemList) -> float:
         if len(test) == 0:
             return np.nan

--- a/lenskit/lenskit/metrics/ranking/_pr.py
+++ b/lenskit/lenskit/metrics/ranking/_pr.py
@@ -16,6 +16,13 @@ class Precision(RankingMetricBase):
     ``len(recs)`` as the denominator.
     """
 
+    @property
+    def label(self):
+        if self.k is not None:
+            return f"Precision@{self.k}"
+        else:
+            return "Precision"
+
     def __call__(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)
         nrecs = len(recs)
@@ -34,6 +41,13 @@ class Recall(RankingMetricBase):
     .. math::
         \\frac{|L \\cap I_u^{\\mathrm{test}}|}{\\operatorname{min}\\{|I_u^{\\mathrm{test}}|, k\\}}
     """
+
+    @property
+    def label(self):
+        if self.k is not None:
+            return f"Recall@{self.k}"
+        else:
+            return "Recall"
 
     def __call__(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)

--- a/lenskit/lenskit/metrics/ranking/_rbp.py
+++ b/lenskit/lenskit/metrics/ranking/_rbp.py
@@ -45,6 +45,13 @@ class RBP(RankingMetricBase):
         self.patience = patience
         self.normalize = normalize
 
+    @property
+    def label(self):
+        if self.k is not None:
+            return f"RBP@{self.k}"
+        else:
+            return "RBP"
+
     def __call__(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)
         k = len(recs)

--- a/lenskit/lenskit/metrics/ranking/_recip.py
+++ b/lenskit/lenskit/metrics/ranking/_recip.py
@@ -18,6 +18,20 @@ class RecipRank(RankingMetricBase):
     :cite:t:`deshpande:iknn` call this the “reciprocal hit rate”.
     """
 
+    @property
+    def label(self):
+        if self.k is not None:
+            return f"RecipRank@{self.k}"
+        else:
+            return "RecipRank"
+
+    @property
+    def mean_label(self):
+        if self.k is not None:
+            return f"MRR@{self.k}"
+        else:
+            return "MRR"
+
     def __call__(self, recs: ItemList, test: ItemList) -> float:
         if len(test) == 0:
             return np.nan

--- a/lenskit/lenskit/splitting/__init__.py
+++ b/lenskit/lenskit/splitting/__init__.py
@@ -10,5 +10,5 @@ Splitting data for train-test evaluation.
 
 from .holdout import LastFrac, LastN, SampleFrac, SampleN  # noqa: F401
 from .records import crossfold_records, sample_records  # noqa: F401
-from .split import TTSplit, dict_from_df, dict_to_df  # noqa: F401
+from .split import TTSplit  # noqa: F401
 from .users import crossfold_users, sample_users  # noqa: F401

--- a/lenskit/lenskit/splitting/records.py
+++ b/lenskit/lenskit/splitting/records.py
@@ -14,10 +14,11 @@ import pandas as pd
 from seedbank import numpy_rng
 
 from lenskit.data import Dataset
+from lenskit.data.bulk import dict_from_df
 from lenskit.data.matrix import MatrixDataset
 from lenskit.types import RandomSeed
 
-from .split import TTSplit, dict_from_df
+from .split import TTSplit
 
 _log = logging.getLogger(__name__)
 

--- a/lenskit/lenskit/splitting/split.py
+++ b/lenskit/lenskit/splitting/split.py
@@ -9,6 +9,7 @@ from typing import Literal, NamedTuple, TypeAlias
 import pandas as pd
 
 from lenskit.data import Dataset, EntityId, ItemList
+from lenskit.data.bulk import dict_to_df
 
 SplitTable: TypeAlias = Literal["matrix"]
 
@@ -48,24 +49,3 @@ class TTSplit(NamedTuple):
         Get the training data as a data frame.
         """
         return self.train.interaction_matrix("pandas", field="all")
-
-
-def dict_to_df(data: dict[EntityId, ItemList]) -> pd.DataFrame:
-    """
-    Convert a dictionary mapping user IDs to item lists into a data frame.
-    """
-
-    df = pd.concat(
-        {u: il.to_df(numbers=False) for (u, il) in data.items()},
-        names=["user_id"],
-    )
-    df = df.reset_index("user_id")
-    df = df.reset_index(drop=True)
-    return df
-
-
-def dict_from_df(df: pd.DataFrame) -> dict[EntityId, ItemList]:
-    """
-    Convert a dictionary mapping user IDs to item lists into a data frame.
-    """
-    return {u: ItemList.from_df(udf) for (u, udf) in df.groupby("user_id")}  # type: ignore

--- a/lenskit/tests/algorithms/test_als_explicit.py
+++ b/lenskit/tests/algorithms/test_als_explicit.py
@@ -17,6 +17,7 @@ import lenskit.util.test as lktu
 from lenskit import batch
 from lenskit.algorithms import als
 from lenskit.data import from_interactions_df, load_movielens_df
+from lenskit.metrics import call_metric
 
 _log = logging.getLogger(__name__)
 
@@ -286,8 +287,8 @@ def test_als_batch_accuracy(ml_100k):
     # _log.info("predictions:\n%s", preds.sort_values("abs_diff", ascending=False))
     # _log.info("diff summary:\n%s", preds.abs_diff.describe())
 
-    lu_mae = pm.MAE(preds, missing_scores="ignore")
+    lu_mae = call_metric(pm.MAE, preds, missing_scores="ignore")
     assert lu_mae == approx(0.73, abs=0.045)
 
-    user_rmse = pm.measure_user_predictions(preds, pm.RMSE, missing_scores="ignore")
+    user_rmse = pm.measure_user_predictions(preds, pm.RMSE(missing_scores="ignore"))
     assert user_rmse.mean() == approx(0.94, abs=0.05)

--- a/lenskit/tests/algorithms/test_knn_item_item.py
+++ b/lenskit/tests/algorithms/test_knn_item_item.py
@@ -25,6 +25,7 @@ from lenskit.algorithms.bias import Bias
 from lenskit.algorithms.ranking import TopN
 from lenskit.data import Vocabulary, from_interactions_df
 from lenskit.diagnostics import ConfigWarning, DataWarning
+from lenskit.metrics import call_metric
 from lenskit.util import clone
 from lenskit.util.test import ml_ds, ml_ratings  # noqa: F401
 
@@ -523,7 +524,7 @@ def test_ii_batch_accuracy(ml_100k):
     preds = pd.concat(
         (eval(train, test) for (train, test) in xf.partition_users(ml_100k, 5, xf.SampleFrac(0.2)))
     )
-    mae = pm.MAE(preds)
+    mae = call_metric(pm.MAE, preds)
     assert mae == approx(0.70, abs=0.025)
 
     user_rmse = pm.measure_user_predictions(preds, pm.RMSE)

--- a/lenskit/tests/algorithms/test_knn_user_user.py
+++ b/lenskit/tests/algorithms/test_knn_user_user.py
@@ -19,6 +19,7 @@ import lenskit.util.test as lktu
 from lenskit.algorithms import Recommender
 from lenskit.algorithms.ranking import TopN
 from lenskit.data import Dataset, from_interactions_df
+from lenskit.metrics import call_metric
 from lenskit.util import clone
 from lenskit.util.test import ml_ds, ml_ratings  # noqa: F401
 
@@ -288,7 +289,7 @@ def test_uu_batch_accuracy(ml_100k: pd.DataFrame):
     folds = xf.partition_users(ml_100k, 5, xf.SampleFrac(0.2))
     preds = [__batch_eval((algo, train, test)) for (train, test) in folds]
     preds = pd.concat(preds)
-    mae = pm.MAE(preds)
+    mae = call_metric(pm.MAE, preds)
     assert mae == approx(0.71, abs=0.05)
 
     user_rmse = pm.measure_user_predictions(preds, pm.RMSE)

--- a/lenskit/tests/algorithms/test_svd.py
+++ b/lenskit/tests/algorithms/test_svd.py
@@ -14,6 +14,7 @@ from pytest import approx, mark
 
 from lenskit.algorithms import svd
 from lenskit.data import Dataset, from_interactions_df
+from lenskit.metrics import call_metric
 from lenskit.util import clone
 
 _log = logging.getLogger(__name__)
@@ -119,7 +120,7 @@ def test_svd_batch_accuracy(ml_100k: pd.DataFrame):
 
     folds = xf.partition_users(ml_100k, 5, xf.SampleFrac(0.2))
     preds = pd.concat(eval(train, test) for (train, test) in folds)
-    mae = pm.MAE(preds)
+    mae = call_metric(pm.MAE, preds)
     assert mae == approx(0.74, abs=0.025)
 
     user_rmse = pm.measure_user_predictions(preds, pm.RMSE)

--- a/lenskit/tests/batch/test_batch_predict.py
+++ b/lenskit/tests/batch/test_batch_predict.py
@@ -129,6 +129,7 @@ def test_bias_batch_predict(ml_100k, ncpus):
     import lenskit.metrics.predict as pm
     from lenskit import batch
     from lenskit.algorithms import bias
+    from lenskit.metrics import call_metric
 
     algo = bias.Bias(damping=5)
 
@@ -144,6 +145,6 @@ def test_bias_batch_predict(ml_100k, ncpus):
     )
 
     _log.info("analyzing predictions")
-    rmse = pm.RMSE(preds)
+    rmse = call_metric(pm.RMSE, preds)
     _log.info("RMSE is %f", rmse)
     assert rmse == pytest.approx(0.95, abs=0.1)

--- a/lenskit/tests/data/test_bulk.py
+++ b/lenskit/tests/data/test_bulk.py
@@ -11,7 +11,7 @@ Test the data type utilities in splits.
 import numpy as np
 import pandas as pd
 
-from lenskit.data.bulk import dict_from_df
+from lenskit.data.bulk import dict_from_df, iter_item_lists
 
 
 def test_dict_from_df(rng, ml_ratings: pd.DataFrame):
@@ -28,3 +28,15 @@ def test_dict_from_df(rng, ml_ratings: pd.DataFrame):
 
     tot = sum(len(il) for il in users.values())
     assert tot == len(ml_ratings)
+
+
+def test_iter_df(ml_ratings: pd.DataFrame):
+    counts = {}
+    for key, il in iter_item_lists(ml_ratings):
+        counts[key] = len(il)
+
+    counts = pd.Series(counts)
+    in_counts = ml_ratings.value_counts("user")
+    assert len(counts) == len(in_counts)
+    counts, in_counts = counts.align(in_counts, join="outer")
+    assert np.all(counts == in_counts)

--- a/lenskit/tests/data/test_bulk_dict.py
+++ b/lenskit/tests/data/test_bulk_dict.py
@@ -11,7 +11,7 @@ Test the data type utilities in splits.
 import numpy as np
 import pandas as pd
 
-from lenskit.splitting.split import dict_from_df
+from lenskit.data.bulk import dict_from_df
 
 
 def test_dict_from_df(rng, ml_ratings: pd.DataFrame):

--- a/lenskit/tests/data/test_itemlist.py
+++ b/lenskit/tests/data/test_itemlist.py
@@ -368,6 +368,7 @@ def test_from_df():
     assert np.all(il.ids() == ITEMS)
     assert np.all(il.numbers() == np.arange(5))
     assert np.all(il.scores() == df["score"].values)
+    assert not il.ordered
 
 
 def test_from_df_user():
@@ -380,6 +381,24 @@ def test_from_df_user():
     assert np.all(il.numbers() == np.arange(5))
     assert np.all(il.scores() == df["score"].values)
     assert il.field("user_id") is None
+
+
+def test_from_df_ranked():
+    df = pd.DataFrame(
+        {
+            "item_id": ITEMS,
+            "item_num": np.arange(5),
+            "rank": np.arange(1, 6),
+            "score": np.random.randn(5),
+        }
+    )
+    il = ItemList.from_df(df, vocabulary=VOCAB)  # type: ignore
+    assert len(il) == 5
+    assert np.all(il.ids() == ITEMS)
+    assert np.all(il.numbers() == np.arange(5))
+    assert np.all(il.scores() == df["score"].values)
+    assert il.ordered
+    assert np.all(il.ranks() == np.arange(1, 6))
 
 
 def test_copy_ctor():

--- a/lenskit/tests/data/test_schemas.py
+++ b/lenskit/tests/data/test_schemas.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pandas as pd
+
+from pytest import raises, warns
+
+from lenskit.data.schemas import normalize_columns
+from lenskit.data.types import AliasedColumn
+
+SCROLLS = pd.DataFrame(
+    {"appearance": ["FOOBIE BLETCH", "HACKEM MUCHE"], "type": ["identify", "teleport"]}
+)
+
+
+def test_normalize_column_name():
+    df = normalize_columns(SCROLLS, "appearance")
+    assert np.all(df.columns == ["appearance", "type"])
+
+
+def test_normalize_column_from_index():
+    df = normalize_columns(SCROLLS.set_index("appearance"), "appearance")
+    assert np.all(df.columns == ["appearance", "type"])
+
+
+def test_normalize_missing_column():
+    with raises(KeyError):
+        normalize_columns(SCROLLS, "bob")
+
+
+def test_normalize_alias():
+    col = AliasedColumn("random", ["appearance"])
+    df = normalize_columns(SCROLLS, col)
+    assert np.all(df.columns == ["random", "type"])
+
+
+def test_normalize_alias_index():
+    col = AliasedColumn("random", ["appearance"])
+    df = normalize_columns(SCROLLS.set_index("appearance"), col)
+    assert np.all(df.columns == ["random", "type"])
+
+
+def test_normalize_missing_alias():
+    col = AliasedColumn("random", ["color"])
+    with raises(KeyError):
+        normalize_columns(SCROLLS, col)
+
+
+def test_normalize_alias_warn():
+    col = AliasedColumn("random", ["appearance"], warn=True)
+    with warns(DeprecationWarning):
+        df = normalize_columns(SCROLLS, col)
+    assert np.all(df.columns == ["random", "type"])
+
+
+def test_normalize_alias_index_warn():
+    col = AliasedColumn("random", ["appearance"], warn=True)
+    with warns(DeprecationWarning):
+        df = normalize_columns(SCROLLS.set_index("appearance"), col)
+    assert np.all(df.columns == ["random", "type"])

--- a/lenskit/tests/eval/test_bulk_metrics.py
+++ b/lenskit/tests/eval/test_bulk_metrics.py
@@ -4,6 +4,7 @@ from pytest import approx
 
 from lenskit.metrics.basic import ListLength
 from lenskit.metrics.bulk import RunAnalysis
+from lenskit.metrics.predict import RMSE
 from lenskit.metrics.ranking import NDCG, Precision
 from lenskit.util.test import demo_recs, ml_ratings
 
@@ -11,10 +12,12 @@ from lenskit.util.test import demo_recs, ml_ratings
 def test_bulk_measure_function(ml_ratings: pd.DataFrame):
     bms = RunAnalysis()
     bms.add_metric(ListLength(), "length")
+    bms.add_metric(RMSE)
 
-    metrics = bms.compute(ml_ratings, ml_ratings)
+    metrics = bms.compute(ml_ratings.rename(columns={"rating": "score"}), ml_ratings)
     stats = metrics.summary()
     assert stats.loc["length", "mean"] == approx(ml_ratings["user"].value_counts().mean())
+    assert stats.loc["RMSE", "mean"] == approx(0)
 
 
 def test_recs(demo_recs):

--- a/lenskit/tests/eval/test_bulk_metrics.py
+++ b/lenskit/tests/eval/test_bulk_metrics.py
@@ -26,7 +26,8 @@ def test_recs(demo_recs):
     bms.add_metric(NDCG())
 
     metrics = bms.compute(recs, test)
+    scores = metrics.list_scores()
     stats = metrics.summary()
     print(stats)
     for m in bms.metrics:
-        assert stats.loc[m.label, "mean"] == approx(metrics.list_scores[m.label].mean())
+        assert stats.loc[m.label, "mean"] == approx(scores[m.label].mean())

--- a/lenskit/tests/eval/test_bulk_metrics.py
+++ b/lenskit/tests/eval/test_bulk_metrics.py
@@ -27,5 +27,6 @@ def test_recs(demo_recs):
 
     metrics = bms.compute(recs, test)
     stats = metrics.summary()
+    print(stats)
     for m in bms.metrics:
         assert stats.loc[m.label, "mean"] == approx(metrics.list_scores[m.label].mean())

--- a/lenskit/tests/eval/test_bulk_metrics.py
+++ b/lenskit/tests/eval/test_bulk_metrics.py
@@ -1,0 +1,31 @@
+import pandas as pd  # noqa: 401
+
+from pytest import approx
+
+from lenskit.metrics.basic import ListLength
+from lenskit.metrics.bulk import RunAnalysis
+from lenskit.metrics.ranking import NDCG, Precision
+from lenskit.util.test import demo_recs, ml_ratings
+
+
+def test_bulk_measure_function(ml_ratings: pd.DataFrame):
+    bms = RunAnalysis()
+    bms.add_metric(ListLength(), "length")
+
+    metrics = bms.compute(ml_ratings, ml_ratings)
+    stats = metrics.summary()
+    assert stats.loc["length", "mean"] == approx(ml_ratings["user"].value_counts().mean())
+
+
+def test_recs(demo_recs):
+    train, test, recs = demo_recs
+
+    bms = RunAnalysis()
+    bms.add_metric(ListLength())
+    bms.add_metric(Precision())
+    bms.add_metric(NDCG())
+
+    metrics = bms.compute(recs, test)
+    stats = metrics.summary()
+    for m in bms.metrics:
+        assert stats.loc[m.label, "mean"] == approx(metrics.list_scores[m.label].mean())

--- a/lenskit/tests/eval/test_predict_metrics.py
+++ b/lenskit/tests/eval/test_predict_metrics.py
@@ -9,37 +9,44 @@ import pandas as pd
 
 from pytest import approx, mark, raises
 
-import lenskit.metrics.predict as pm
-import lenskit.util.test as lktu
 from lenskit.data import ItemList, from_interactions_df
+from lenskit.metrics import call_metric
+from lenskit.metrics.predict import MAE, RMSE, measure_user_predictions
 
 
 def test_rmse_one():
-    rmse = pm.RMSE(ItemList(["a"], scores=[1]), ItemList(["a"], rating=[1]))
+    rmse = call_metric(RMSE, ItemList(["a"], scores=[1]), ItemList(["a"], rating=[1]))
     assert isinstance(rmse, float)
     assert rmse == approx(0)
 
-    rmse = pm.RMSE(ItemList(["a"], scores=[1]), ItemList(["a"], rating=[2]))
+    rmse = call_metric(RMSE, ItemList(["a"], scores=[1]), ItemList(["a"], rating=[2]))
     assert rmse == approx(1)
 
-    rmse = pm.RMSE(ItemList(["a"], scores=[1]), ItemList(["a"], rating=[0.5]))
+    rmse = call_metric(RMSE, ItemList(["a"], scores=[1]), ItemList(["a"], rating=[0.5]))
     assert rmse == approx(0.5)
 
 
 def test_rmse_two():
-    rmse = pm.RMSE(ItemList(["a", "b"], scores=[1, 2]), ItemList(["a", "b"], rating=[1, 2]))
+    rmse = call_metric(
+        RMSE, ItemList(["a", "b"], scores=[1, 2]), ItemList(["a", "b"], rating=[1, 2])
+    )
     assert isinstance(rmse, float)
     assert rmse == approx(0)
 
-    rmse = pm.RMSE(ItemList(["a", "b"], scores=[1, 1]), ItemList(["a", "b"], rating=[2, 2]))
+    rmse = call_metric(
+        RMSE, ItemList(["a", "b"], scores=[1, 1]), ItemList(["a", "b"], rating=[2, 2])
+    )
     assert rmse == approx(1)
 
-    rmse = pm.RMSE(ItemList(["a", "b"], scores=[1, 3]), ItemList(["a", "b"], rating=[3, 1]))
+    rmse = call_metric(
+        RMSE, ItemList(["a", "b"], scores=[1, 3]), ItemList(["a", "b"], rating=[3, 1])
+    )
     assert rmse == approx(2)
 
 
 def test_rmse_series_subset_items():
-    rmse = pm.RMSE(
+    rmse = call_metric(
+        RMSE,
         ItemList(scores=[1, 3], item_ids=["a", "c"]),
         ItemList(rating=[3, 4, 1], item_ids=["a", "b", "c"]),
         missing_scores="ignore",
@@ -49,14 +56,16 @@ def test_rmse_series_subset_items():
 
 def test_rmse_series_missing_value_error():
     with raises(ValueError):
-        pm.RMSE(
+        call_metric(
+            RMSE,
             ItemList(scores=[1, 3], item_ids=["a", "d"]),
             ItemList(rating=[3, 4, 1], item_ids=["a", "b", "c"]),
         )
 
 
 def test_rmse_series_missing_value_ignore():
-    rmse = pm.RMSE(
+    rmse = call_metric(
+        RMSE,
         ItemList(scores=[1, 3], item_ids=["a", "d"]),
         ItemList(rating=[3, 4, 1], item_ids=["a", "b", "c"]),
         missing_scores="ignore",
@@ -66,17 +75,17 @@ def test_rmse_series_missing_value_ignore():
 
 
 def test_mae_two():
-    mae = pm.MAE(ItemList(["a", "b"], scores=[1, 2]), ItemList(["a", "b"], rating=[1, 2]))
+    mae = call_metric(MAE, ItemList(["a", "b"], scores=[1, 2]), ItemList(["a", "b"], rating=[1, 2]))
     assert isinstance(mae, float)
     assert mae == approx(0)
 
-    mae = pm.MAE(ItemList(["a", "b"], scores=[1, 1]), ItemList(["a", "b"], rating=[2, 2]))
+    mae = call_metric(MAE, ItemList(["a", "b"], scores=[1, 1]), ItemList(["a", "b"], rating=[2, 2]))
     assert mae == approx(1)
 
-    mae = pm.MAE(ItemList(["a", "b"], scores=[1, 3]), ItemList(["a", "b"], rating=[3, 1]))
+    mae = call_metric(MAE, ItemList(["a", "b"], scores=[1, 3]), ItemList(["a", "b"], rating=[3, 1]))
     assert mae == approx(2)
 
-    mae = pm.MAE(ItemList(["a", "b"], scores=[1, 3]), ItemList(["a", "b"], rating=[3, 2]))
+    mae = call_metric(MAE, ItemList(["a", "b"], scores=[1, 3]), ItemList(["a", "b"], rating=[3, 2]))
     assert mae == approx(1.5)
 
 
@@ -98,7 +107,7 @@ def test_batch_rmse(ml_100k):
         (eval(train, test) for (train, test) in xf.partition_users(ml_100k, 5, xf.SampleN(5)))
     )
 
-    user_rmse = pm.measure_user_predictions(results, pm.RMSE)
+    user_rmse = measure_user_predictions(results, RMSE)
 
     # we should have all users
     users = ml_100k.user.unique()


### PR DESCRIPTION
This moves forward #489 to provide item-list-based bulk evaluation of entire runs.

Right now it is probably a lot slower than the old code (no bulk optimizations), but it should be correct, and better-documented and more extensible.