### PR TITLE
Support scalar scores in ItemList

### DIFF
--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -133,7 +133,13 @@ class ItemList:
         item_nums: NDArray[np.int32] | pd.Series[int] | Sequence[int] | ArrayLike | None = None,
         vocabulary: Vocabulary | None = None,
         ordered: bool | None = None,
-        scores: NDArray[np.generic] | torch.Tensor | ArrayLike | Literal[False] | None = None,
+        scores: NDArray[np.generic]
+        | torch.Tensor
+        | ArrayLike
+        | Literal[False]
+        | np.floating
+        | float
+        | None = None,
         **fields: NDArray[np.generic] | torch.Tensor | ArrayLike | Literal[False],
     ):
         if isinstance(source, ItemList):
@@ -208,6 +214,8 @@ class ItemList:
         elif scores is not None:
             if "score" in fields:  # pragma: nocover
                 raise ValueError("cannot specify both scores= and score=")
+            if np.isscalar(scores):
+                scores = np.full(self._len, scores)
             self._fields["score"] = MTArray(scores)
 
     @classmethod

--- a/lenskit/tests/data/test_itemlist.py
+++ b/lenskit/tests/data/test_itemlist.py
@@ -420,6 +420,15 @@ def test_copy_ctor():
     assert np.all(x == extra)
 
 
+def test_copy_na_scores():
+    il = ItemList(item_nums=np.arange(5), vocabulary=VOCAB)
+    il2 = ItemList(il, scores=np.nan)
+
+    scores = il2.scores()
+    assert scores is not None
+    assert np.all(np.isnan(scores))
+
+
 def test_copy_ctor_remove_scores():
     data = np.random.randn(5)
     extra = np.random.randn(5)


### PR DESCRIPTION
This modifies `ItemList` to accept scalars as the parameter to `scores`, creating a score field filled with a single value.