### PR TITLE
Fix item list data frame round-trip bugs

### DIFF
--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -154,6 +154,8 @@ class ItemList:
             self.ordered = False
 
         if vocabulary is not None:
+            if not isinstance(vocabulary, Vocabulary):  # pragma: nocover
+                raise TypeError(f"expected Vocabulary, got {type(vocabulary)}")
             self._vocab = vocabulary
 
         # handle aliases for item ID/number columns

--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -222,7 +222,7 @@ class ItemList:
 
     @classmethod
     def from_df(
-        cls, df: pd.DataFrame, *, vocabulary=Vocabulary, keep_user: bool = False
+        cls, df: pd.DataFrame, *, vocabulary: Vocabulary | None = None, keep_user: bool = False
     ) -> ItemList:
         """
         Create a item list from a Pandas data frame.  The frame should have
@@ -264,7 +264,7 @@ class ItemList:
         items = cls(
             item_ids=ids,  # type: ignore
             item_nums=nums,  # type: ignore
-            vocabulary=vocabulary,  # type: ignore
+            vocabulary=vocabulary,
             ordered=ranks is not None,
             **fields,  # type: ignore
         )

--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -461,9 +461,9 @@ class ItemList:
         * all other defined fields, using their field names
         """
         cols = {}
-        if ids and self._ids is not None or self._vocab is not None:
+        if ids and (self._ids is not None or self._vocab is not None):
             cols["item_id"] = self.ids()
-        if numbers and self._numbers is not None or self._vocab is not None:
+        if numbers and (self._numbers is not None or self._vocab is not None):
             cols["item_num"] = self.numbers()
         # we need to have numbers or ids, or it makes no sense
         if "item_id" not in cols and "item_num" not in cols:

--- a/lenskit/tests/data/test_itemlist.py
+++ b/lenskit/tests/data/test_itemlist.py
@@ -238,6 +238,16 @@ def test_pandas_df_ordered():
     assert np.all(df["rank"] == np.arange(1, 6))
 
 
+def test_pandas_df_no_numbers():
+    data = np.random.randn(5)
+    il = ItemList(item_ids=ITEMS, vocabulary=VOCAB, scores=data, ordered=True)
+    df = il.to_df(numbers=False)
+    assert "item_id" in df.columns
+
+    # even with a vocabulary, we should have no numbers
+    assert "item_num" not in df.columns
+
+
 def test_item_list_pickle_compact(ml_ds: Dataset):
     nums = [1, 0, 308, 24, 72]
     il = ItemList(item_nums=nums, vocabulary=ml_ds.items)


### PR DESCRIPTION
A couple bugs in ItemList:

- if there is a vocabulary, the `numbers=False` option to `to_df` was ignored (same for ids)
- `from_df` had a type error, assigning the vocabulary class to `vocabulary`