### PR TITLE
Add ItemListCollection and use throughout eval & tests

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -18,3 +18,5 @@ unpickle
 rerankers
 LKPY
 FunkSVD
+RecSys
+PyArrow

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -34,6 +34,9 @@ Item Data
     :caption: Item Data
 
     ~lenskit.data.ItemList
+    ~lenskit.data.ItemListCollection
+    ~lenskit.data.UserIDKey
+    ~lenskit.data.GenericKey
 
 Recommendation Queries
 ----------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,6 +110,7 @@ todo_include_todos = True
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pandas": ("http://pandas.pydata.org/pandas-docs/stable/", None),
+    "pyarrow": ("https://arrow.apache.org/docs/python/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),

--- a/docs/guide/batch.rst
+++ b/docs/guide/batch.rst
@@ -49,9 +49,12 @@ Configure and train the model:
 
 Generate recommendations:
 
-    >>> recs = recommend(pop_pipe, split.test.keys())
-    >>> len(recs)
-    150
+    >>> recs = recommend(pop_pipe, split.test.keys(), n_jobs=1)
+    >>> recs.to_df()
+              user_id  item_id     score  rank
+    0 ...                                    1
+    ...
+    [3000 rows x 4 columns]
 
 And measure their results:
 

--- a/docs/guide/data.rst
+++ b/docs/guide/data.rst
@@ -1,5 +1,5 @@
-Data Management
-===============
+Datasets
+========
 
 .. py:currentmodule:: lenskit.data
 
@@ -70,7 +70,8 @@ Users and items have two identifiers:
 * The *identifier* as presented in the original source table(s).  It appears in
   LensKit data frames as ``user_id`` and ``item_id`` columns.  Identifiers can
   be integers, strings, or byte arrays, and are represented in LensKit by the
-  :data:`~lenskit.data.EntityId` type.
+  :data:`~lenskit.data.ID` type.
+
 * The *number* assigned by the dataset handling code.  This is a 0-based
   contiguous user or item number that is suitable for indexing into arrays or
   matrices, a common operation in recommendation models.  In data frames, this

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -17,6 +17,7 @@ guide to how to use LensKit for research, education, and other purposes.
     :maxdepth: 1
 
     data
+    item-lists
     pipeline
 
 .. toctree::

--- a/docs/guide/item-lists.rst
+++ b/docs/guide/item-lists.rst
@@ -1,0 +1,70 @@
+Item Lists and Collections
+==========================
+
+Throughout its data handling, components, and evaluation metrics, LensKit uses
+an abstraction of an “item list” (:class:`~lenskit.data.ItemList`).  An item
+list is a list of items along with additional fields, such as scores and
+ratings; it supports both item IDs and numbers, and can record a vocabulary to
+convert between them.  It is also backend-agnostic and can present fields
+(except for the item ID) as NumPy arrays, Pandas series (optionally indexed by
+item ID or number), and Torch tensors.
+
+Item lists are used to represent a user's history, the candidate items for
+scoring and/or ranking, recommendation results, test data, etc.
+
+.. todo::
+
+    Write more tutorial / user manual documentation for the item lists.
+
+.. _item-list-convert:
+
+Data Conversion
+~~~~~~~~~~~~~~~
+
+Item lists support round-tripping with Pandas :py:class:`data frames
+<pandas.DataFrame>` and PyArrow :py:class:`tables <pyarrow.Table>`::
+
+    >>> import pandas as pd
+    >>> from lenskit.data import ItemList
+    >>> il = ItemList(item_ids=['a', 'b'], scores=[1.5, 1.2], rating=[3, 5])
+    >>> il.to_df()
+        item_id     score   rating
+    0         a       1.5        3
+    1         b       1.2        5
+
+.. _item-list-collections:
+
+Collections
+~~~~~~~~~~~
+
+On top of the :class:`~lenskit.data.ItemList` we build the idea of an item list
+*collection* (`~lenskit.data.ItemListCollection`).  An item list collection is a
+list or dictionary of item lists, identified by keys (e.g. the user ID )
+
+Motivation
+~~~~~~~~~~
+
+Given that LensKit for Python's initial design guidelines :cite:p:`lkpy`
+emphasize the use of standard data structures, why did we introduce a new
+abstraction instead of continuing to use Pandas data frames?  There are a couple
+of reasons for this.
+
+*   Pandas data frames are not self-documenting; if a component returns a data
+    frame, that is not enough information to know what columns to expect
+    (without advanced type trickery that stretches or exceeds the limits of
+    Python's typing model).  We were duplicating that knowledge across the code
+    base, and things like autocomplete on the available data was not available.
+    Incorrect columns was also, in Michael's experience, a common source of bugs
+    and difficulties.
+
+*   Many components were only using Pandas at the interface, and internally were
+    converting to sparse matrices, tensors, etc.; by standardizing some of that
+    support, and only converting data formats when necessary, we can make data
+    conversions more consistent across LensKit and reduce the number of
+    conversions and CPU/GPU round-trips when chaining together components using
+    the same compute backend.
+
+*   The item ID / number logic specifically was duplicated across many modules,
+    and also was an early thing Michael needed to teach when teaching RecSys; a
+    standard, documented abstraction that handles that logic makes it easier to
+    both write components and teach recommendation concepts.

--- a/docs/releases/2025.rst
+++ b/docs/releases/2025.rst
@@ -71,7 +71,7 @@ Significant Changes
     package).  Classes and functions must be imported from appropriate
     subpackages.
 
-*   The ``Popular`` recommender has been removed in favor of :class:`~lenskit.algorithms.basic.PopScore`.
+*   The ``Popular`` recommender has been removed in favor of :class:`~lenskit.basic.PopScore`.
 
 New Features (incremental)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,8 +82,10 @@ New Features (incremental)
 Evaluation Changes
 ~~~~~~~~~~~~~~~~~~
 
-* The DCG metric has been removed, as it is basically never used and was not
-  useful as a part of the NDCG implementation.
+*  The DCG metric has been removed, as it is basically never used and was not
+   useful as a part of the NDCG implementation.
+
+*  Train-test split results are no longer tuples.
 
 Model Behavior Changes
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/lenskit/lenskit/batch/_predict.py
+++ b/lenskit/lenskit/batch/_predict.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from lenskit import util
 from lenskit.algorithms import Algorithm
-from lenskit.data import EntityId
+from lenskit.data import ID
 from lenskit.data.items import ItemList
 from lenskit.parallel import invoke_progress, invoker
 from lenskit.pipeline import Pipeline
@@ -24,7 +24,7 @@ _logger = logging.getLogger(__name__)
 
 def predict(
     pipeline: Pipeline, test: TestData, *, n_jobs: int | None = None, **kwargs
-) -> dict[EntityId, ItemList]:
+) -> dict[ID, ItemList]:
     """
     Convenience function to batch-generate rating predictions (or other per-item
     scores) from a pipeline.

--- a/lenskit/lenskit/batch/_predict.py
+++ b/lenskit/lenskit/batch/_predict.py
@@ -7,23 +7,27 @@ from __future__ import annotations
 
 import logging
 import warnings
+from typing import Mapping
 
 import pandas as pd
 
 from lenskit import util
 from lenskit.algorithms import Algorithm
-from lenskit.data import ID
-from lenskit.data.items import ItemList
+from lenskit.data import ID, GenericKey, ItemList, ItemListCollection
 from lenskit.parallel import invoke_progress, invoker
 from lenskit.pipeline import Pipeline
 
-from ._runner import BatchPipelineRunner, TestData
+from ._runner import BatchPipelineRunner
 
 _logger = logging.getLogger(__name__)
 
 
 def predict(
-    pipeline: Pipeline, test: TestData, *, n_jobs: int | None = None, **kwargs
+    pipeline: Pipeline,
+    test: ItemListCollection[GenericKey] | Mapping[ID, ItemList],
+    *,
+    n_jobs: int | None = None,
+    **kwargs,
 ) -> dict[ID, ItemList]:
     """
     Convenience function to batch-generate rating predictions (or other per-item

--- a/lenskit/lenskit/batch/_predict.py
+++ b/lenskit/lenskit/batch/_predict.py
@@ -28,7 +28,7 @@ def predict(
     *,
     n_jobs: int | None = None,
     **kwargs,
-) -> dict[ID, ItemList]:
+) -> ItemListCollection[GenericKey]:
     """
     Convenience function to batch-generate rating predictions (or other per-item
     scores) from a pipeline.

--- a/lenskit/lenskit/batch/_recommend.py
+++ b/lenskit/lenskit/batch/_recommend.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 from lenskit import util
 from lenskit.algorithms import Algorithm, Recommender
-from lenskit.data import ID, ItemList
+from lenskit.data import ID, ItemListCollection, UserIDKey
 from lenskit.parallel import invoke_progress, invoker
 from lenskit.pipeline import Pipeline
 
@@ -25,13 +25,13 @@ _logger = logging.getLogger(__name__)
 
 def recommend(
     pipeline: Pipeline,
-    users: Sequence[ID],
+    users: Sequence[ID | UserIDKey],
     n: int | None = None,
     candidates=None,
     *,
     n_jobs: int | None = None,
     **kwargs,
-) -> dict[ID, ItemList]:
+) -> ItemListCollection[UserIDKey]:
     """
     Convenience function to batch-generate recommendations from a pipeline.
     """
@@ -41,7 +41,7 @@ def recommend(
     runner = BatchPipelineRunner(n_jobs=n_jobs)
     runner.recommend(n=n)
     outs = runner.run(pipeline, users)
-    return {k.user_id: il for (k, il) in outs.output("recommendations")}  # type: ignore
+    return outs.output("recommendations")
 
 
 def _recommend_user(algo, req):

--- a/lenskit/lenskit/batch/_recommend.py
+++ b/lenskit/lenskit/batch/_recommend.py
@@ -40,8 +40,8 @@ def recommend(
 
     runner = BatchPipelineRunner(n_jobs=n_jobs)
     runner.recommend(n=n)
-    outs = runner.run(pipeline, {u: ItemList() for u in users})
-    return outs.output("recommendations")  # type: ignore
+    outs = runner.run(pipeline, users)
+    return {k.user_id: il for (k, il) in outs.output("recommendations")}  # type: ignore
 
 
 def _recommend_user(algo, req):

--- a/lenskit/lenskit/batch/_recommend.py
+++ b/lenskit/lenskit/batch/_recommend.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 from lenskit import util
 from lenskit.algorithms import Algorithm, Recommender
-from lenskit.data import EntityId, ItemList
+from lenskit.data import ID, ItemList
 from lenskit.parallel import invoke_progress, invoker
 from lenskit.pipeline import Pipeline
 
@@ -25,13 +25,13 @@ _logger = logging.getLogger(__name__)
 
 def recommend(
     pipeline: Pipeline,
-    users: Sequence[EntityId],
+    users: Sequence[ID],
     n: int | None = None,
     candidates=None,
     *,
     n_jobs: int | None = None,
     **kwargs,
-) -> dict[EntityId, ItemList]:
+) -> dict[ID, ItemList]:
     """
     Convenience function to batch-generate recommendations from a pipeline.
     """

--- a/lenskit/lenskit/batch/_results.py
+++ b/lenskit/lenskit/batch/_results.py
@@ -56,4 +56,7 @@ class BatchResults:
         if name not in self._data:
             self._data[name] = ItemListCollection(self._key_schema)
 
-        self._data[name].add(result, *key)
+        try:
+            self._data[name].add(result, *key)
+        except TypeError as e:
+            raise TypeError(f"invalid key {key} (for type {self._data[name].key_type})", e)

--- a/lenskit/lenskit/batch/_results.py
+++ b/lenskit/lenskit/batch/_results.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from lenskit.data import ID
+from typing import Sequence
+
+from lenskit.data import GenericKey, ItemListCollection
 
 
 class BatchResults:
@@ -10,12 +12,14 @@ class BatchResults:
     ``None``, if the pipeline produced no output for that user.
     """
 
-    _data: dict[str, dict[ID, object]]
+    _key_schema: type[tuple] | Sequence[str]
+    _data: dict[str, ItemListCollection[GenericKey]]
 
-    def __init__(self):
+    def __init__(self, key: type[tuple] | Sequence[str]):
         """
         Construct a new set of batch results.
         """
+        self._key_schema = key
         self._data = {}
 
     @property
@@ -25,7 +29,7 @@ class BatchResults:
         """
         return list(self._data.keys())
 
-    def output(self, name: str) -> dict[ID, object]:
+    def output(self, name: str) -> ItemListCollection[GenericKey]:
         """
         Get the item lists for a particular output component.
 
@@ -36,7 +40,7 @@ class BatchResults:
         """
         return self._data[name]
 
-    def add_result(self, name: str, user: ID, result: object):
+    def add_result(self, name: str, key: GenericKey, result: object):
         """
         Add a single result for one of the outputs.
 
@@ -50,6 +54,6 @@ class BatchResults:
         """
 
         if name not in self._data:
-            self._data[name] = {}
+            self._data[name] = ItemListCollection(self._key_schema)
 
-        self._data[name][user] = result
+        self._data[name].add(result, *key)

--- a/lenskit/lenskit/batch/_results.py
+++ b/lenskit/lenskit/batch/_results.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from lenskit.data import EntityId
+from lenskit.data import ID
 
 
 class BatchResults:
@@ -10,7 +10,7 @@ class BatchResults:
     ``None``, if the pipeline produced no output for that user.
     """
 
-    _data: dict[str, dict[EntityId, object]]
+    _data: dict[str, dict[ID, object]]
 
     def __init__(self):
         """
@@ -25,7 +25,7 @@ class BatchResults:
         """
         return list(self._data.keys())
 
-    def output(self, name: str) -> dict[EntityId, object]:
+    def output(self, name: str) -> dict[ID, object]:
         """
         Get the item lists for a particular output component.
 
@@ -36,7 +36,7 @@ class BatchResults:
         """
         return self._data[name]
 
-    def add_result(self, name: str, user: EntityId, result: object):
+    def add_result(self, name: str, user: ID, result: object):
         """
         Add a single result for one of the outputs.
 

--- a/lenskit/lenskit/batch/_runner.py
+++ b/lenskit/lenskit/batch/_runner.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Literal, Mapping, TypeAlias
 
-from lenskit.data import EntityId, ItemList
+from lenskit.data import ID, ItemList
 from lenskit.parallel import invoke_progress, invoker
 from lenskit.pipeline import Pipeline
 from lenskit.util import Stopwatch
@@ -23,7 +23,7 @@ ItemSource: TypeAlias = None | Literal["test-items"]
 """
 Types of items that can be returned.
 """
-TestData: TypeAlias = Mapping[EntityId, ItemList]
+TestData: TypeAlias = Mapping[ID, ItemList]
 """
 Test data format.
 """
@@ -141,8 +141,8 @@ class BatchPipelineRunner:
 
 
 def _run_pipeline(
-    ctx: tuple[Pipeline, list[InvocationSpec]], req: tuple[EntityId, ItemList]
-) -> tuple[EntityId, dict[str, object]]:
+    ctx: tuple[Pipeline, list[InvocationSpec]], req: tuple[ID, ItemList]
+) -> tuple[ID, dict[str, object]]:
     pipeline, invocations = ctx
     user, test_items = req
 

--- a/lenskit/lenskit/data/__init__.py
+++ b/lenskit/lenskit/data/__init__.py
@@ -9,6 +9,7 @@ Data abstractions and data set access.
 
 from __future__ import annotations
 
+from .collection import ItemListCollection, UserIDKey
 from .convert import from_interactions_df
 from .dataset import Dataset, FieldError
 from .items import ItemList
@@ -27,6 +28,8 @@ __all__ = [
     "UITuple",
     "FeedbackType",
     "ItemList",
+    "ItemListCollection",
+    "UserIDKey",
     "load_movielens",
     "load_movielens_df",
     "MTArray",

--- a/lenskit/lenskit/data/__init__.py
+++ b/lenskit/lenskit/data/__init__.py
@@ -15,15 +15,15 @@ from .items import ItemList
 from .movielens import load_movielens, load_movielens_df
 from .mtarray import MTArray, MTFloatArray, MTGenericArray, MTIntArray
 from .query import QueryInput, RecQuery
-from .types import EntityId, FeedbackType, NPEntityId, UITuple
+from .types import ID, NPID, FeedbackType, UITuple
 from .vocab import Vocabulary
 
 __all__ = [
     "Dataset",
     "FieldError",
     "from_interactions_df",
-    "EntityId",
-    "NPEntityId",
+    "ID",
+    "NPID",
     "UITuple",
     "FeedbackType",
     "ItemList",

--- a/lenskit/lenskit/data/__init__.py
+++ b/lenskit/lenskit/data/__init__.py
@@ -9,7 +9,7 @@ Data abstractions and data set access.
 
 from __future__ import annotations
 
-from .collection import ItemListCollection, UserIDKey
+from .collection import GenericKey, ItemListCollection, UserIDKey
 from .convert import from_interactions_df
 from .dataset import Dataset, FieldError
 from .items import ItemList
@@ -30,6 +30,7 @@ __all__ = [
     "ItemList",
     "ItemListCollection",
     "UserIDKey",
+    "GenericKey",
     "load_movielens",
     "load_movielens_df",
     "MTArray",

--- a/lenskit/lenskit/data/bulk.py
+++ b/lenskit/lenskit/data/bulk.py
@@ -21,12 +21,10 @@ from .schemas import (
     column_name,
     normalize_columns,
 )
-from .types import Column, EntityId
+from .types import ID, Column
 
 
-def dict_to_df(
-    data: Mapping[EntityId, ItemList | None], *, column: str = USER_COLUMN
-) -> pd.DataFrame:
+def dict_to_df(data: Mapping[ID, ItemList | None], *, column: str = USER_COLUMN) -> pd.DataFrame:
     """
     Convert a dictionary mapping user IDs to item lists into a data frame.
     Missing item lists are excluded.
@@ -50,7 +48,7 @@ def dict_to_df(
 
 def dict_from_df(
     df: pd.DataFrame, *, column: Column = USER_COMPAT_COLUMN, item_col: Column = ITEM_COMPAT_COLUMN
-) -> dict[EntityId, ItemList]:
+) -> dict[ID, ItemList]:
     """
     Convert a dictionary mapping user IDs to item lists into a data frame.
 
@@ -77,15 +75,15 @@ def group_df(df: pd.DataFrame, *, column: Column = USER_COMPAT_COLUMN, item_col=
 
 
 @overload
-def count_item_lists(data: Mapping[EntityId, ItemList | None]) -> int: ...
+def count_item_lists(data: Mapping[ID, ItemList | None]) -> int: ...
 @overload
 def count_item_lists(
-    data: pd.DataFrame | Mapping[EntityId, ItemList | None],
+    data: pd.DataFrame | Mapping[ID, ItemList | None],
     *,
     column: Column = USER_COMPAT_COLUMN,
 ) -> int: ...
 def count_item_lists(
-    data: pd.DataFrame | Mapping[EntityId, ItemList | None],
+    data: pd.DataFrame | Mapping[ID, ItemList | None],
     *,
     column: Column = USER_COMPAT_COLUMN,
 ) -> int:
@@ -98,21 +96,21 @@ def count_item_lists(
 
 @overload
 def iter_item_lists(
-    data: Mapping[EntityId, ItemList | None],
-) -> Iterator[tuple[EntityId, ItemList | None]]: ...
+    data: Mapping[ID, ItemList | None],
+) -> Iterator[tuple[ID, ItemList | None]]: ...
 @overload
 def iter_item_lists(
-    data: pd.DataFrame | Mapping[EntityId, ItemList | None],
+    data: pd.DataFrame | Mapping[ID, ItemList | None],
     *,
     column: Column = USER_COMPAT_COLUMN,
     item_col=ITEM_COMPAT_COLUMN,
-) -> Iterator[tuple[EntityId, ItemList | None]]: ...
+) -> Iterator[tuple[ID, ItemList | None]]: ...
 def iter_item_lists(
-    data: pd.DataFrame | Mapping[EntityId, ItemList | None],
+    data: pd.DataFrame | Mapping[ID, ItemList | None],
     *,
     column: Column = USER_COMPAT_COLUMN,
     item_col=ITEM_COMPAT_COLUMN,
-) -> Iterator[tuple[EntityId, ItemList | None]]:
+) -> Iterator[tuple[ID, ItemList | None]]:
     """
     Iterate over item lists identified by keys.  When the input is a data frame,
     the column names may be specified; the default options group by ``user_id``
@@ -121,7 +119,7 @@ def iter_item_lists(
     """
     if isinstance(data, pd.DataFrame):
         for key, df in group_df(data, column=column, item_col=item_col):
-            yield cast(EntityId, key), ItemList.from_df(df)
+            yield cast(ID, key), ItemList.from_df(df)
 
     else:
         yield from data.items()

--- a/lenskit/lenskit/data/collection.py
+++ b/lenskit/lenskit/data/collection.py
@@ -153,7 +153,7 @@ class ItemListCollection(Generic[K]):
         else:
             if isinstance(key, Column):
                 key = [key]
-            columns = list(key) + others  # type: ignore
+            columns = tuple(key) + others
             fields = [column_name(c) for c in key]
             key = _create_key_type(*fields)  # type: ignore
 

--- a/lenskit/lenskit/data/collection.py
+++ b/lenskit/lenskit/data/collection.py
@@ -1,0 +1,107 @@
+from collections import namedtuple
+from collections.abc import Sequence
+from typing import Generic, NamedTuple, TypeAlias, TypeVar
+
+from .items import ItemList
+from .types import ID
+
+K = TypeVar("K", bound=tuple)
+KeySchema: TypeAlias = type[K] | tuple[str, ...]
+KEY_CACHE: dict[tuple[str, ...], type[tuple]] = {}
+
+
+class UserIDKey(NamedTuple):
+    """
+    Key type for user IDs.  This is used for :class:`item list collections
+    <ItemListCollection>` that are keyed by user ID, a common setup for
+    recommendation runs and
+    """
+
+    user_id: ID
+
+
+class GenericKey(tuple):
+    """
+    A generic key.
+    """
+
+    _fields: tuple[str, ...]
+
+    def __init__(self, *values, fields: tuple[str, ...]):
+        super().__init__(*values)
+        self._fields = fields
+
+
+class ItemListCollection(Generic[K]):
+    """
+    A collection of item lists.
+
+    Item list collections are used to represent a variety of things, including
+    test data and the results of a batch run.  They are, at their heart
+    dictionary mapping collection keys (named tuples of identifiers) to item
+    lists.
+
+    The key schema can be specified either by a list of field names, or by
+    providing a named tuple class (created by either :func:`namedtuple` or
+    :class:`NamedTuple`) defining the key schema.
+
+    This class exists, instead of using raw dictionaries, to consistently handle
+    some of the nuances of multi-valued keys, and different collections having
+    different key fields; for example, if a run produces item lists with both
+    user IDs and sequence numbers, but your test data is only indexed by user
+    ID, the *projected lookup* capabilities make it easy to find the test data
+    to go with an item list in the run.
+    """
+
+    key_class: type[K]
+    data: dict[K, ItemList]
+
+    def __init__(self, key: type[K] | Sequence[str]):
+        """
+        Create a new item list collection.
+        """
+        if isinstance(key, type):
+            self.key_class = key
+        else:
+            self.key_class = _create_key_type(*key)  # type: ignore
+
+
+def _create_key(kt: KeySchema[K], *values: ID) -> K:
+    if isinstance(kt, type):
+        return kt(*values)  # type: ignore
+    else:
+        kt = _create_key_type(*kt)  # type: ignore
+        return kt(*values)  # type: ignore
+
+
+def _create_key_type(*fields: str) -> type[tuple[ID, ...]]:
+    """
+    Create a new key
+    """
+    assert isinstance(fields, tuple)
+    kt = KEY_CACHE.get(fields, None)
+    if kt is None:
+        ktn = f"LKILCKeyType{len(KEY_CACHE)+1}"
+        kt = namedtuple(ktn, fields)
+        kt.__reduce__ = _reduce_generic_key  # type: ignore
+        KEY_CACHE[fields] = kt
+    return kt
+
+
+def _reduce_generic_key(key):
+    args = (key._fields,) + key
+    return _create_key, args
+
+
+def project_key(key: tuple, target: type[K]) -> K:
+    """
+    Project a key onto a subset of its fields.  This is to enable keys to be
+    looked up in other collections that are keyed on a subset of their fields,
+    such as using a key consisting of a user ID and a sequence number to look up
+    test data in a collection keyed only by user ID.
+    """
+
+    try:
+        return target._make(getattr(key, f) for f in target._fields)  # type: ignore
+    except AttributeError as e:
+        raise TypeError(f"source key is missing field {e.name}")

--- a/lenskit/lenskit/data/collection.py
+++ b/lenskit/lenskit/data/collection.py
@@ -248,7 +248,7 @@ class ItemListCollection(Generic[K]):
 
 def _key_fields(kt: type[tuple]) -> tuple[str]:
     "extract the fields from a key type"
-    return kt.fields  # type: ignore
+    return kt._fields  # type: ignore
 
 
 @overload

--- a/lenskit/lenskit/data/collection.py
+++ b/lenskit/lenskit/data/collection.py
@@ -132,6 +132,11 @@ class ItemListCollection(Generic[K]):
         """
         Create an item list collection from a data frame.
 
+        .. note::
+
+            Keys with empty item lists will be silently excluded from the output
+            data.
+
         Args:
             df:
                 The data frame to convert.
@@ -172,7 +177,15 @@ class ItemListCollection(Generic[K]):
 
     @property
     def key_fields(self) -> tuple[str]:
+        "The names of the key fields."
         return _key_fields(self._key_class)
+
+    @property
+    def key_type(self) -> type[K]:
+        """
+        The type of collection keys.
+        """
+        return self._key_class
 
     def add(self, list, *fields: ID):
         key = self._key_class(*fields)  # type: ignore

--- a/lenskit/lenskit/data/collection.py
+++ b/lenskit/lenskit/data/collection.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+import warnings
 from collections import namedtuple
 from collections.abc import Sequence
-from typing import Generic, NamedTuple, TypeAlias, TypeVar
+from typing import Any, Generic, Mapping, NamedTuple, TypeAlias, TypeVar, overload
+
+from lenskit.diagnostics import DataWarning
 
 from .items import ItemList
 from .types import ID
@@ -36,34 +41,139 @@ class ItemListCollection(Generic[K]):
     """
     A collection of item lists.
 
-    Item list collections are used to represent a variety of things, including
-    test data and the results of a batch run.  They are, at their heart
-    dictionary mapping collection keys (named tuples of identifiers) to item
-    lists.
+    An item list collection consists of a sequence of item lists with associated
+    *keys* following a fixed schema.  Item list collections support iteration
+    (in order) and lookup by key. They are used to represent a variety of
+    things, including test data and the results of a batch run.
 
     The key schema can be specified either by a list of field names, or by
     providing a named tuple class (created by either :func:`namedtuple` or
-    :class:`NamedTuple`) defining the key schema.
+    :class:`NamedTuple`) defining the key schema.  Schemas should **not** be
+    nested: field values must be scalars, not tuples or lists.  Keys should also
+    be hashable.
 
-    This class exists, instead of using raw dictionaries, to consistently handle
-    some of the nuances of multi-valued keys, and different collections having
-    different key fields; for example, if a run produces item lists with both
-    user IDs and sequence numbers, but your test data is only indexed by user
-    ID, the *projected lookup* capabilities make it easy to find the test data
-    to go with an item list in the run.
+    This class exists, instead of using raw dictionaries or lists, to
+    consistently handle some of the nuances of multi-valued keys, and different
+    collections having different key fields; for example, if a run produces item
+    lists with both user IDs and sequence numbers, but your test data is only
+    indexed by user ID, the *projected lookup* capabilities make it easy to find
+    the test data to go with an item list in the run.
+
+    Item list collections support lookup by index, like a list, returning a
+    tuple of the key and list.  If they are constructed with ``index=True``,
+    they also support lookup by _key_, supplied as either a tuple or an instance
+    of the key type; in this case, the key is not returned.  If more than one
+    item with the same key is inserted into the collection, then the _last_ one
+    is returned (just like a dictionary).
+
+    Args:
+        key:
+            The type (a NamedTuple class) or list of field names specifying the
+            key schema.
+        index:
+            Whether or not to index lists by key to facilitate fast lookups.
     """
 
-    key_class: type[K]
-    data: dict[K, ItemList]
+    _key_class: type[K]
+    _lists: list[tuple[K, ItemList]]
+    _index: dict[K, int] | None = None
 
-    def __init__(self, key: type[K] | Sequence[str]):
+    def __init__(self, key: type[K] | Sequence[str], *, index: bool = True):
         """
         Create a new item list collection.
         """
         if isinstance(key, type):
-            self.key_class = key
+            self._key_class = key
         else:
-            self.key_class = _create_key_type(*key)  # type: ignore
+            self._key_class = _create_key_type(*key)  # type: ignore
+
+        self._lists = []
+        if index:
+            self._index = {}
+
+    @overload
+    @classmethod
+    def from_dict(
+        cls, data: Mapping[tuple[ID, ...] | ID, ItemList], key: type[K]
+    ) -> ItemListCollection[K]: ...
+    @overload
+    @classmethod
+    def from_dict(
+        cls, data: Mapping[tuple[ID, ...] | ID, ItemList], key: Sequence[str] | str | None = None
+    ) -> ItemListCollection[tuple[ID, ...]]: ...
+    @classmethod
+    def from_dict(
+        cls,
+        data: Mapping[tuple[ID, ...] | ID, ItemList],
+        key: type[K] | Sequence[str] | str | None = None,
+    ) -> ItemListCollection[Any]:
+        """
+        Create an item list collection from a dictionary.
+        """
+        if key is not None:
+            if isinstance(key, str):
+                key = (key,)
+            ilc = ItemListCollection(key)
+        else:
+            k = next(iter(data.keys()))
+            if isinstance(k, tuple) and getattr(k, "_fields"):
+                ilc = ItemListCollection(type(k))
+            else:
+                warnings.warn(
+                    "no key specified but data does not use named tuples, using default field 'id'",
+                    DataWarning,
+                )
+                ilc = ItemListCollection(["id"])
+
+        for k, il in data.items():
+            if isinstance(k, tuple):
+                ilc.add(il, *k)
+            else:
+                ilc.add(il, k)
+
+        return ilc
+
+    def add(self, list, *fields: ID):
+        key = self._key_class(*fields)  # type: ignore
+        self._lists.append((key, list))
+        if self._index is not None:
+            self._index[key] = len(self._lists) - 1
+
+    @overload
+    def lookup(self, key: tuple) -> ItemList: ...
+    @overload
+    def lookup(self, *key: ID, **kwkey: ID) -> ItemList: ...
+    def lookup(self, *args, **kwargs) -> ItemList:
+        """
+        Look up a list by key.  If multiple lists have the same key, this
+        returns the **last** (like a dictionary).
+
+        This method can be called with the key tuple as a single argument (and
+        this can be either the actual named tuple, or an ordinary tuple of the
+        same length), or with the individual key fields as positional or named
+        arguments.
+
+        Args:
+            key:
+                The key tuple or key tuple fields.
+        """
+        if self._index is None:
+            raise TypeError("cannot lookup on non-indexed collection")
+        if len(args) != 1 or not isinstance(args[0], tuple):
+            key = self._key_class(*args, **kwargs)
+        else:
+            key = args[0]
+
+        return self._lists[self._index[key]][1]  # type: ignore
+
+    def __len__(self):
+        return len(self._lists)
+
+    def __iter__(self):
+        return iter(self._lists)
+
+    def __getitem__(self, key: int) -> tuple[K, ItemList]:
+        return self._lists[key]
 
 
 def _create_key(kt: KeySchema[K], *values: ID) -> K:
@@ -83,6 +193,7 @@ def _create_key_type(*fields: str) -> type[tuple[ID, ...]]:
     if kt is None:
         ktn = f"LKILCKeyType{len(KEY_CACHE)+1}"
         kt = namedtuple(ktn, fields)
+        # support pickling
         kt.__reduce__ = _reduce_generic_key  # type: ignore
         KEY_CACHE[fields] = kt
     return kt

--- a/lenskit/lenskit/data/collection.py
+++ b/lenskit/lenskit/data/collection.py
@@ -187,8 +187,15 @@ class ItemListCollection(Generic[K]):
         """
         return self._key_class
 
-    def add(self, list, *fields: ID):
+    def add(self, list: ItemList, *fields: ID):
         key = self._key_class(*fields)  # type: ignore
+        self._add(key, list)
+
+    def add_from(self, other: ItemListCollection):
+        for key, list in other:
+            self._add(key, list)
+
+    def _add(self, key: K, list: ItemList):
         self._lists.append((key, list))
         if self._index is not None:
             self._index[key] = len(self._lists) - 1

--- a/lenskit/lenskit/data/dataset.py
+++ b/lenskit/lenskit/data/dataset.py
@@ -27,7 +27,7 @@ import torch
 
 from .items import ItemList
 from .tables import NumpyUserItemTable, TorchUserItemTable
-from .types import EntityId
+from .types import ID
 from .vocab import Vocabulary
 
 DF_FORMAT: TypeAlias = Literal["numpy", "pandas", "torch"]
@@ -360,13 +360,13 @@ class Dataset(ABC):
 
     @abstractmethod
     @overload
-    def user_row(self, user_id: EntityId) -> ItemList | None: ...
+    def user_row(self, user_id: ID) -> ItemList | None: ...
     @abstractmethod
     @overload
     def user_row(self, *, user_num: int) -> ItemList: ...
     @abstractmethod
     def user_row(
-        self, user_id: EntityId | None = None, *, user_num: int | None = None
+        self, user_id: ID | None = None, *, user_num: int | None = None
     ) -> ItemList | None:
         """
         Get a user's row from the interaction matrix.  Available fields are

--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -27,7 +27,7 @@ from typing_extensions import (
 
 from .checks import check_1d
 from .mtarray import MTArray, MTGenericArray
-from .types import NPID, IDArray, IDSequence
+from .types import IDArray, IDSequence
 from .vocab import Vocabulary
 
 Backend: TypeAlias = Literal["numpy", "torch"]
@@ -289,7 +289,7 @@ class ItemList:
         "Get the item list's vocabulary, if available."
         return self._vocab
 
-    def ids(self) -> NDArray[NPID]:
+    def ids(self) -> IDArray:
         """
         Get the item IDs.
 
@@ -303,7 +303,7 @@ class ItemList:
             if self._vocab is None:
                 raise RuntimeError("item IDs not available (no IDs or vocabulary provided)")
             assert self._numbers is not None
-            self._ids = cast(NDArray[NPID], self._vocab.ids(self._numbers.numpy()))
+            self._ids = self._vocab.ids(self._numbers.numpy())
 
         return self._ids
 

--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -27,7 +27,7 @@ from typing_extensions import (
 
 from .checks import check_1d
 from .mtarray import MTArray, MTGenericArray
-from .types import EntityId, NPEntityId
+from .types import NPID, IDArray, IDSequence
 from .vocab import Vocabulary
 
 Backend: TypeAlias = Literal["numpy", "torch"]
@@ -115,7 +115,7 @@ class ItemList:
     ordered: bool = False
     "Whether this list has a meaningful order."
     _len: int
-    _ids: np.ndarray[int, np.dtype[NPEntityId]] | None = None
+    _ids: IDArray | None = None
     _numbers: MTArray[np.int32] | None = None
     _vocab: Vocabulary | None = None
     _ranks: MTArray[np.int32] | None = None
@@ -123,13 +123,9 @@ class ItemList:
 
     def __init__(
         self,
-        source: ItemList
-        | NDArray[NPEntityId]
-        | pd.Series[EntityId]
-        | Sequence[EntityId]
-        | None = None,
+        source: ItemList | IDSequence | None = None,
         *,
-        item_ids: NDArray[NPEntityId] | pd.Series[EntityId] | Sequence[EntityId] | None = None,
+        item_ids: IDSequence | None = None,
         item_nums: NDArray[np.int32] | pd.Series[int] | Sequence[int] | ArrayLike | None = None,
         vocabulary: Vocabulary | None = None,
         ordered: bool | None = None,
@@ -293,7 +289,7 @@ class ItemList:
         "Get the item list's vocabulary, if available."
         return self._vocab
 
-    def ids(self) -> NDArray[NPEntityId]:
+    def ids(self) -> NDArray[NPID]:
         """
         Get the item IDs.
 
@@ -307,7 +303,7 @@ class ItemList:
             if self._vocab is None:
                 raise RuntimeError("item IDs not available (no IDs or vocabulary provided)")
             assert self._numbers is not None
-            self._ids = cast(NDArray[NPEntityId], self._vocab.ids(self._numbers.numpy()))
+            self._ids = cast(NDArray[NPID], self._vocab.ids(self._numbers.numpy()))
 
         return self._ids
 

--- a/lenskit/lenskit/data/matrix.py
+++ b/lenskit/lenskit/data/matrix.py
@@ -24,7 +24,7 @@ from typing_extensions import override
 from .dataset import Dataset, FieldError
 from .items import ItemList
 from .tables import NumpyUserItemTable, TorchUserItemTable
-from .types import EntityId
+from .types import ID
 from .vocab import Vocabulary
 
 _log = logging.getLogger(__name__)
@@ -369,7 +369,7 @@ class MatrixDataset(Dataset):
 
     @override
     def user_row(
-        self, user_id: EntityId | None = None, *, user_num: int | None = None
+        self, user_id: ID | None = None, *, user_num: int | None = None
     ) -> ItemList | None:
         if user_num is None:
             if user_id is None:  # pragma: nocover

--- a/lenskit/lenskit/data/query.py
+++ b/lenskit/lenskit/data/query.py
@@ -12,7 +12,7 @@ from typing_extensions import assert_never
 
 from lenskit.data.items import ItemList
 
-from .types import EntityId
+from .types import ID
 
 
 @dataclass
@@ -31,7 +31,7 @@ class RecQuery:
         to include context cues.
     """
 
-    user_id: EntityId | None = None
+    user_id: ID | None = None
     """
     The user's identifier.
     """
@@ -71,7 +71,7 @@ class RecQuery:
             assert_never(f"invalid type {type(data)}")
 
 
-QueryInput: TypeAlias = RecQuery | EntityId | ItemList | None
+QueryInput: TypeAlias = RecQuery | ID | ItemList | None
 """
 Types that can be converted to a query by :meth:`RecQuery.create`.
 """

--- a/lenskit/lenskit/data/query.py
+++ b/lenskit/lenskit/data/query.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import TypeAlias
 
 import numpy as np
-from typing_extensions import assert_never
 
 from lenskit.data.items import ItemList
 
@@ -68,7 +67,7 @@ class RecQuery:
         elif isinstance(data, int | str | bytes):
             return cls(user_id=data)
         else:  # pragma: nocover
-            assert_never(f"invalid type {type(data)}")
+            raise TypeError(f"invalid query input (type {type(data)})")
 
 
 QueryInput: TypeAlias = RecQuery | ID | ItemList | None

--- a/lenskit/lenskit/data/types.py
+++ b/lenskit/lenskit/data/types.py
@@ -13,17 +13,34 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generic, Literal, NamedTuple, TypeAlias, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Literal,
+    NamedTuple,
+    Sequence,
+    TypeAlias,
+    TypeVar,
+    cast,
+)
 
 import numpy as np
+import pandas as pd
 
 FeedbackType: TypeAlias = Literal["explicit", "implicit"]
 "Types of feedback supported."
 
-EntityId: TypeAlias = int | str | bytes | np.integer[Any] | np.string_
-"Allowable entity identifier types."
-NPEntityId: TypeAlias = np.integer[Any] | np.str_ | np.bytes_ | np.object_
-"Allowable entity identifier types (NumPy version)"
+CoreID: TypeAlias = int | str | bytes
+"Core (non-NumPy) identifier types."
+NPID: TypeAlias = np.integer[Any] | np.str_ | np.bytes_ | np.object_
+"NumPy entity identifier types."
+ID: TypeAlias = CoreID | NPID
+"Allowable identifier types."
+IDArray: TypeAlias = np.ndarray[tuple[int], np.dtype[NPID]]
+"NumPy arrays of identifiers."
+IDSequence: TypeAlias = Sequence[ID] | IDArray | pd.Series[CoreID]
+"Sequences of identifiers."
 
 T = TypeVar("T")
 

--- a/lenskit/lenskit/data/types.py
+++ b/lenskit/lenskit/data/types.py
@@ -39,7 +39,7 @@ ID: TypeAlias = CoreID | NPID
 "Allowable identifier types."
 IDArray: TypeAlias = np.ndarray[tuple[int], np.dtype[NPID]]
 "NumPy arrays of identifiers."
-IDSequence: TypeAlias = Sequence[ID] | IDArray | pd.Series[CoreID]
+IDSequence: TypeAlias = Sequence[ID] | IDArray | pd.Series
 "Sequences of identifiers."
 
 T = TypeVar("T")

--- a/lenskit/lenskit/data/types.py
+++ b/lenskit/lenskit/data/types.py
@@ -39,7 +39,7 @@ ID: TypeAlias = CoreID | NPID
 "Allowable identifier types."
 IDArray: TypeAlias = np.ndarray[tuple[int], np.dtype[NPID]]
 "NumPy arrays of identifiers."
-IDSequence: TypeAlias = Sequence[ID] | IDArray | pd.Series
+IDSequence: TypeAlias = Sequence[ID] | IDArray | "pd.Series[CoreID]"
 "Sequences of identifiers."
 
 T = TypeVar("T")

--- a/lenskit/lenskit/data/vocab.py
+++ b/lenskit/lenskit/data/vocab.py
@@ -53,7 +53,7 @@ class Vocabulary:
         elif isinstance(keys, np.ndarray) or isinstance(keys, list) or isinstance(keys, pd.Series):
             keys = pd.Index(np.unique(keys))  # type: ignore
         else:
-            keys = pd.Index(set(keys))  # type: ignore
+            keys = pd.Index(sorted(set(keys)))  # type: ignore
 
         self._index = keys.rename(name) if name is not None else keys
 

--- a/lenskit/lenskit/data/vocab.py
+++ b/lenskit/lenskit/data/vocab.py
@@ -17,6 +17,8 @@ import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike, NDArray
 
+from .types import ID, IDArray, IDSequence
+
 
 class Vocabulary:
     """
@@ -38,7 +40,9 @@ class Vocabulary:
     _index: pd.Index
 
     def __init__(
-        self, keys: pd.Index | ArrayLike | Iterable[Hashable] | None = None, name: str | None = None
+        self,
+        keys: IDSequence | pd.Index | Iterable[ID] | None = None,
+        name: str | None = None,
     ):
         self.name = name
         if keys is None:
@@ -49,7 +53,7 @@ class Vocabulary:
         elif isinstance(keys, np.ndarray) or isinstance(keys, list) or isinstance(keys, pd.Series):
             keys = pd.Index(np.unique(keys))  # type: ignore
         else:
-            keys = pd.Index(np.unique(list(set(keys))))  # type: ignore
+            keys = pd.Index(set(keys))  # type: ignore
 
         self._index = keys.rename(name) if name is not None else keys
 
@@ -98,9 +102,7 @@ class Vocabulary:
             raise IndexError("negative numbers not supported")
         return self._index[num]
 
-    def terms(
-        self, nums: list[int] | NDArray[np.integer] | pd.Series | None = None
-    ) -> NDArray[np.generic]:
+    def terms(self, nums: list[int] | NDArray[np.integer] | pd.Series | None = None) -> IDArray:
         """
         Get a list of terms, optionally for an array of term numbers.
 
@@ -125,9 +127,7 @@ class Vocabulary:
         "Alias for :meth:`term`  for greater readability for entity ID vocabularies."
         return self.term(num)
 
-    def ids(
-        self, nums: list[int] | NDArray[np.integer] | pd.Series | None = None
-    ) -> NDArray[np.generic]:
+    def ids(self, nums: list[int] | NDArray[np.integer] | pd.Series | None = None) -> IDArray:
         "Alias for :meth:`terms` for greater readability for entity ID vocabularies."
         return self.terms(nums)
 

--- a/lenskit/lenskit/metrics/bulk.py
+++ b/lenskit/lenskit/metrics/bulk.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TypeVar
 
 import numpy as np
 import pandas as pd
 from progress_api import make_progress
 
-from lenskit.data import GenericKey, ItemListCollection
+from lenskit.data import ItemListCollection
 
 from ._base import Metric, MetricFunction
 
 _log = logging.getLogger(__name__)
+K1 = TypeVar("K1", bound=tuple)
+K2 = TypeVar("K2", bound=tuple)
 
 
 @dataclass(frozen=True)
@@ -152,7 +155,7 @@ class RunAnalysis:
         self.metrics.append(_wrap_metric(metric, label, mean_label, default))
 
     def compute(
-        self, outputs: ItemListCollection[GenericKey], test: ItemListCollection[GenericKey]
+        self, outputs: ItemListCollection[K1], test: ItemListCollection[K2]
     ) -> RunAnalysisResult:
         index = pd.MultiIndex.from_tuples(outputs.keys())
         results = pd.DataFrame({m.label: np.nan for m in self.metrics}, index=index)

--- a/lenskit/lenskit/metrics/bulk.py
+++ b/lenskit/lenskit/metrics/bulk.py
@@ -8,13 +8,13 @@ import numpy as np
 import pandas as pd
 from progress_api import make_progress
 
-from lenskit.data import EntityId, ItemList
+from lenskit.data import ID, ItemList
 from lenskit.data.bulk import count_item_lists, dict_from_df, iter_item_lists
 
 from ._base import Metric, MetricFunction
 
 _log = logging.getLogger(__name__)
-ILSet: TypeAlias = Mapping[EntityId, ItemList | None] | pd.DataFrame
+ILSet: TypeAlias = Mapping[ID, ItemList | None] | pd.DataFrame
 
 
 @dataclass(frozen=True)

--- a/lenskit/lenskit/metrics/ranking/_dcg.py
+++ b/lenskit/lenskit/metrics/ranking/_dcg.py
@@ -75,7 +75,7 @@ class NDCG(RankingMetricBase):
                 gains = gains.nlargest(n=self.k)
             else:
                 gains = gains.sort_values(ascending=False)
-            ideal = array_dcg(gains.values, self.discount)
+            ideal = array_dcg(np.require(gains.values, np.float32), self.discount)
         else:
             scores = np.zeros_like(items, dtype=np.float32)
             scores[np.isin(items, test.ids())] = 1.0
@@ -84,7 +84,7 @@ class NDCG(RankingMetricBase):
                 n = self.k
             ideal = fixed_dcg(n, self.discount)
 
-        realized = array_dcg(scores, self.discount)
+        realized = array_dcg(np.require(scores, np.float32), self.discount)
         return realized / ideal
 
 

--- a/lenskit/lenskit/pipeline/common.py
+++ b/lenskit/lenskit/pipeline/common.py
@@ -10,7 +10,7 @@ from lenskit.basic import (
     UserTrainingHistoryLookup,
 )
 from lenskit.basic.topn import TopNRanker
-from lenskit.data import EntityId, ItemList, RecQuery
+from lenskit.data import ID, ItemList, RecQuery
 
 from . import Pipeline
 from .components import Component
@@ -85,7 +85,7 @@ class RecPipelineBuilder:
         """
         pipe = Pipeline(name=name)
 
-        query = pipe.create_input("query", RecQuery, EntityId, ItemList)
+        query = pipe.create_input("query", RecQuery, ID, ItemList)
 
         items = pipe.create_input("items", ItemList)
         n_n = pipe.create_input("n", int, None)

--- a/lenskit/lenskit/splitting/records.py
+++ b/lenskit/lenskit/splitting/records.py
@@ -99,8 +99,8 @@ def sample_records(
 
         >>> from lenskit.data import load_movielens
         >>> movielens = load_movielens('data/ml-latest-small')
-        >>> for train, test in sample_records(movielens, 1000, repeats=5):
-        ...     print(sum(len(il) for il in test.values()))
+        >>> for split in sample_records(movielens, 1000, repeats=5):
+        ...     print(sum(len(il) for il in split.test.lists()))
         1000
         1000
         1000
@@ -109,8 +109,8 @@ def sample_records(
 
     Sometimes for testing, it is useful to just get a single pair::
 
-        >>> train, test = sample_records(movielens, 1000)
-        >>> sum(len(il) for il in test.values())
+        >>> split = sample_records(movielens, 1000)
+        >>> sum(len(il) for il in split.test.lists())
         1000
 
     Args:

--- a/lenskit/lenskit/splitting/records.py
+++ b/lenskit/lenskit/splitting/records.py
@@ -13,8 +13,7 @@ import numpy as np
 import pandas as pd
 from seedbank import numpy_rng
 
-from lenskit.data import Dataset
-from lenskit.data.bulk import dict_from_df
+from lenskit.data import Dataset, ItemListCollection, UserIDKey
 from lenskit.data.matrix import MatrixDataset
 from lenskit.types import RandomSeed
 
@@ -171,7 +170,7 @@ def _make_pair(
     mask = np.zeros(len(df), np.bool_)
     mask[test_is] = True
 
-    test = dict_from_df(df[mask])
+    test = ItemListCollection.from_df(df[mask], UserIDKey)
     train = MatrixDataset(data.users, data.items, df[~mask])
 
     return TTSplit(train, test)

--- a/lenskit/lenskit/splitting/split.py
+++ b/lenskit/lenskit/splitting/split.py
@@ -4,19 +4,21 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-from typing import Literal, NamedTuple, TypeAlias
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeAlias, TypeVar
 
 import pandas as pd
 
-from lenskit.data import ID, Dataset, ItemList
-from lenskit.data.bulk import dict_to_df
+from lenskit.data import Dataset, ItemListCollection
 
 SplitTable: TypeAlias = Literal["matrix"]
+TK = TypeVar("TK", bound=tuple)
 
 
-class TTSplit(NamedTuple):
+@dataclass
+class TTSplit(Generic[TK]):
     """
-    A train-test pair from splitting.
+    A train-test set from splitting or other sources.
     """
 
     train: Dataset
@@ -24,7 +26,7 @@ class TTSplit(NamedTuple):
     The training data.
     """
 
-    test: dict[ID, ItemList]
+    test: ItemListCollection[TK]
     """
     The test data.
     """
@@ -34,14 +36,14 @@ class TTSplit(NamedTuple):
         """
         Get the number of test pairs.
         """
-        return sum(len(il) for il in self.test.values())
+        return sum(len(il) for il in self.test.lists())
 
     @property
     def test_df(self) -> pd.DataFrame:
         """
         Get the test data as a data frame.
         """
-        return dict_to_df(self.test)
+        return self.test.to_df()
 
     @property
     def train_df(self) -> pd.DataFrame:

--- a/lenskit/lenskit/splitting/split.py
+++ b/lenskit/lenskit/splitting/split.py
@@ -8,7 +8,7 @@ from typing import Literal, NamedTuple, TypeAlias
 
 import pandas as pd
 
-from lenskit.data import Dataset, EntityId, ItemList
+from lenskit.data import ID, Dataset, ItemList
 from lenskit.data.bulk import dict_to_df
 
 SplitTable: TypeAlias = Literal["matrix"]
@@ -24,7 +24,7 @@ class TTSplit(NamedTuple):
     The training data.
     """
 
-    test: dict[EntityId, ItemList]
+    test: dict[ID, ItemList]
     """
     The test data.
     """

--- a/lenskit/lenskit/splitting/users.py
+++ b/lenskit/lenskit/splitting/users.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from seedbank import numpy_rng
 
-from lenskit.data import Dataset, EntityId
+from lenskit.data import ID, Dataset
 from lenskit.data.matrix import MatrixDataset
 from lenskit.types import RandomSeed
 
@@ -156,7 +156,7 @@ def sample_users(
 
 
 def _make_split(
-    data: Dataset, df: pd.DataFrame, test_us: Iterable[EntityId], method: HoldoutMethod
+    data: Dataset, df: pd.DataFrame, test_us: Iterable[ID], method: HoldoutMethod
 ) -> TTSplit:
     # create the test sets for these users
     mask = pd.Series(True, index=df.index)

--- a/lenskit/lenskit/splitting/users.py
+++ b/lenskit/lenskit/splitting/users.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from seedbank import numpy_rng
 
-from lenskit.data import ID, Dataset
+from lenskit.data import ID, Dataset, ItemListCollection, UserIDKey
 from lenskit.data.matrix import MatrixDataset
 from lenskit.types import RandomSeed
 
@@ -160,16 +160,16 @@ def _make_split(
 ) -> TTSplit:
     # create the test sets for these users
     mask = pd.Series(True, index=df.index)
-    test = {}
+    test = ItemListCollection(UserIDKey)
 
     for u in test_us:
         row = data.user_row(u)
         assert row is not None
         u_test = method(row)
-        test[u] = u_test
+        test.add(u_test, u)
         assert all((u, i) in mask.index for i in u_test.ids())
         mask.loc[[(u, i) for i in u_test.ids()]] = False  # type: ignore
-        assert np.sum(mask.loc[u]) == len(row) - len(u_test)
+        assert np.sum(mask.loc[u]) == len(row) - len(u_test)  # type: ignore
 
     train_df = df[mask]
     train = MatrixDataset(data.users, data.items, train_df.reset_index())

--- a/lenskit/tests/basic/test_composite.py
+++ b/lenskit/tests/basic/test_composite.py
@@ -19,7 +19,7 @@ from lenskit.basic.composite import FallbackScorer
 from lenskit.basic.history import KnownRatingScorer
 from lenskit.data import Dataset
 from lenskit.data.items import ItemList
-from lenskit.data.types import EntityId
+from lenskit.data.types import ID
 from lenskit.pipeline import Pipeline
 from lenskit.util.test import ml_ds, ml_ratings  # noqa: F401
 

--- a/lenskit/tests/batch/test_batch_pipeline.py
+++ b/lenskit/tests/batch/test_batch_pipeline.py
@@ -14,7 +14,7 @@ from pytest import approx, fixture, mark
 
 from lenskit.basic import BiasScorer, PopScorer
 from lenskit.batch import BatchPipelineRunner, predict, recommend
-from lenskit.data import Dataset, ItemList, ItemListCollection, from_interactions_df
+from lenskit.data import Dataset, ItemList, UserIDKey, from_interactions_df
 from lenskit.data.convert import normalize_interactions_df
 from lenskit.metrics import NDCG, RBP, RMSE, RunAnalysis
 from lenskit.pipeline import Pipeline, topn_pipeline
@@ -54,7 +54,8 @@ def test_predict_single(mlb: MLB):
 
     assert len(res) == 1
     uid, result = next(iter(res))
-    assert uid == 1
+    assert isinstance(uid, UserIDKey)
+    assert uid.user_id == 1
     assert len(result) == 1
     assert result.ids()[0] == 31
 
@@ -71,7 +72,8 @@ def test_recommend_user(mlb: MLB):
     assert len(results) == 1
 
     uid, ranking = next(iter(results))
-    assert uid == user
+    assert isinstance(uid, UserIDKey)
+    assert uid.user_id == user
     assert isinstance(ranking, ItemList)
     assert ranking.ordered
     assert len(ranking) == 10

--- a/lenskit/tests/batch/test_batch_pipeline.py
+++ b/lenskit/tests/batch/test_batch_pipeline.py
@@ -14,7 +14,7 @@ from pytest import approx, fixture, mark
 
 from lenskit.basic import BiasScorer, PopScorer
 from lenskit.batch import BatchPipelineRunner, predict, recommend
-from lenskit.data import Dataset, ItemList, from_interactions_df
+from lenskit.data import Dataset, ItemList, ItemListCollection, from_interactions_df
 from lenskit.data.convert import normalize_interactions_df
 from lenskit.metrics import NDCG, RBP, RMSE, RunAnalysis
 from lenskit.pipeline import Pipeline, topn_pipeline
@@ -69,6 +69,7 @@ def test_recommend_user(mlb: MLB):
     results = recommend(mlb.pipeline, [user], n=10, n_jobs=1)
 
     assert len(results) == 1
+
     uid, ranking = next(iter(results))
     assert uid == user
     assert isinstance(ranking, ItemList)

--- a/lenskit/tests/batch/test_batch_pipeline.py
+++ b/lenskit/tests/batch/test_batch_pipeline.py
@@ -53,7 +53,7 @@ def test_predict_single(mlb: MLB):
     res = predict(mlb.pipeline, {1: ItemList([31])}, n_jobs=1)
 
     assert len(res) == 1
-    uid, result = next(iter(res.items()))
+    uid, result = next(iter(res))
     assert uid == 1
     assert len(result) == 1
     assert result.ids()[0] == 31
@@ -69,7 +69,7 @@ def test_recommend_user(mlb: MLB):
     results = recommend(mlb.pipeline, [user], n=10, n_jobs=1)
 
     assert len(results) == 1
-    uid, ranking = next(iter(results.items()))
+    uid, ranking = next(iter(results))
     assert uid == user
     assert isinstance(ranking, ItemList)
     assert ranking.ordered

--- a/lenskit/tests/data/test_collection.py
+++ b/lenskit/tests/data/test_collection.py
@@ -1,0 +1,40 @@
+import pickle
+
+from pytest import raises
+
+from lenskit.data.collection import UserIDKey, _create_key, project_key
+
+
+def test_generic_key():
+    usk = _create_key(("user_id", "seq_no"), "alphabet", 42)
+
+    assert isinstance(usk, tuple)
+    assert usk == ("alphabet", 42)
+    assert usk.user_id == "alphabet"  # type: ignore
+    assert usk.seq_no == 42  # type: ignore
+
+
+def test_pickle_generic():
+    usk = _create_key(("user_id", "seq_no"), "alphabet", 42)
+
+    bs = pickle.dumps(usk)
+    usk2 = pickle.loads(bs)
+
+    assert isinstance(usk2, tuple)
+    assert usk2 == usk
+
+
+def test_project_key():
+    usk = _create_key(("user_id", "seq_no"), "alphabet", 42)
+
+    uk = project_key(usk, UserIDKey)
+    assert isinstance(uk, UserIDKey)
+    assert uk.user_id == "alphabet"
+    assert uk == ("alphabet",)
+
+
+def test_project_missing_fails():
+    usk = _create_key(("seq_no",), 42)
+
+    with raises(TypeError, match="missing field"):
+        project_key(usk, UserIDKey)

--- a/lenskit/tests/data/test_collection.py
+++ b/lenskit/tests/data/test_collection.py
@@ -1,6 +1,7 @@
 import pickle
 
 import numpy as np
+import pandas as pd
 
 from pytest import raises
 
@@ -111,3 +112,30 @@ def test_lookup_projected():
     assert il is not None
     assert len(il) == 1
     assert np.all(il.ids() == ["a"])
+
+
+def test_from_df(rng, ml_ratings: pd.DataFrame):
+    ml_ratings = ml_ratings.rename(columns={"user": "user_id", "item": "item_id"})
+    ilc = ItemListCollection.from_df(ml_ratings, UserIDKey)
+    assert len(ilc) == ml_ratings["user_id"].nunique()
+    assert set(k.user_id for k in ilc.keys()) == set(ml_ratings["user_id"])
+
+    for uid in rng.choice(ml_ratings["user_id"].unique(), 25):
+        items = ilc.lookup(user_id=uid)
+        udf = ml_ratings[ml_ratings["user_id"] == uid]
+        assert len(items) == len(udf)
+        assert np.all(np.unique(items.ids()) == np.unique(udf["item_id"]))
+
+    tot = sum(len(il) for il in ilc.lists())
+    assert tot == len(ml_ratings)
+
+
+def test_to_df():
+    ilc = ItemListCollection.from_dict(
+        {72: ItemList(["a"], scores=[1]), 82: ItemList(["a", "b", "c"], scores=[3, 4, 10])},
+        key="user_id",
+    )
+    df = ilc.to_df()
+    print(df)
+    assert len(df) == 4
+    assert df["user_id"].tolist() == [72, 82, 82, 82]

--- a/lenskit/tests/data/test_collection.py
+++ b/lenskit/tests/data/test_collection.py
@@ -101,3 +101,13 @@ def test_collection_from_dict_singleton_field():
     assert k.user_id == 72  # type: ignore
     assert len(il) == 1
     assert np.all(il.ids() == ["a"])
+
+
+def test_lookup_projected():
+    ilc = ItemListCollection.from_dict({72: ItemList(["a"])}, key="user_id")
+
+    usk = _create_key(("user_id", "seq"), 72, 100)
+    il = ilc.lookup_projected(usk)
+    assert il is not None
+    assert len(il) == 1
+    assert np.all(il.ids() == ["a"])

--- a/lenskit/tests/eval/test_bulk_metrics.py
+++ b/lenskit/tests/eval/test_bulk_metrics.py
@@ -2,6 +2,8 @@ import pandas as pd  # noqa: 401
 
 from pytest import approx
 
+from lenskit.data import ItemListCollection
+from lenskit.data.schemas import ITEM_COMPAT_COLUMN, USER_COMPAT_COLUMN
 from lenskit.metrics.basic import ListLength
 from lenskit.metrics.bulk import RunAnalysis
 from lenskit.metrics.predict import RMSE
@@ -14,7 +16,12 @@ def test_bulk_measure_function(ml_ratings: pd.DataFrame):
     bms.add_metric(ListLength(), "length")
     bms.add_metric(RMSE)
 
-    metrics = bms.compute(ml_ratings.rename(columns={"rating": "score"}), ml_ratings)
+    data = ItemListCollection.from_df(
+        ml_ratings.rename(columns={"rating": "score"}), USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN
+    )
+    truth = ItemListCollection.from_df(ml_ratings, USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN)
+
+    metrics = bms.compute(data, truth)
     stats = metrics.summary()
     assert stats.loc["length", "mean"] == approx(ml_ratings["user"].value_counts().mean())
     assert stats.loc["RMSE", "mean"] == approx(0)
@@ -28,6 +35,8 @@ def test_recs(demo_recs):
     bms.add_metric(Precision())
     bms.add_metric(NDCG())
 
+    recs = ItemListCollection.from_df(recs, USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN)
+    test = ItemListCollection.from_df(test, USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN)
     metrics = bms.compute(recs, test)
     scores = metrics.list_scores()
     stats = metrics.summary()

--- a/lenskit/tests/models/test_knn_item_item.py
+++ b/lenskit/tests/models/test_knn_item_item.py
@@ -20,7 +20,7 @@ import lenskit.util.test as lktu
 from lenskit import batch
 from lenskit.basic import BiasScorer
 from lenskit.batch import BatchPipelineRunner
-from lenskit.data import ItemList, Vocabulary, from_interactions_df
+from lenskit.data import ItemList, ItemListCollection, UserIDKey, Vocabulary, from_interactions_df
 from lenskit.data.bulk import dict_to_df, iter_item_lists
 from lenskit.diagnostics import ConfigWarning, DataWarning
 from lenskit.knn.item import ItemItemScorer
@@ -403,9 +403,9 @@ def test_ii_batch_accuracy(ml_100k):
 
     pipe = builder.build()
 
-    preds = {}
-    recs = {}
-    test = {}
+    preds = ItemListCollection(UserIDKey)
+    recs = ItemListCollection(UserIDKey)
+    test = ItemListCollection(UserIDKey)
 
     for split in crossfold_users(ds, 5, SampleFrac(0.2)):
         _log.info("training on partition")
@@ -416,9 +416,9 @@ def test_ii_batch_accuracy(ml_100k):
         runner.recommend(n=10)
         runner.predict()
         result = runner.run(copy, split.test)
-        preds.update(result.output("predictions"))
-        recs.update(result.output("recommendations"))
-        test.update(split.test)
+        preds.add_from(result.output("predictions"))
+        recs.add_from(result.output("recommendations"))
+        test.add_from(split.test)
 
     preds = dict_to_df(preds)
     test = dict_to_df(test)

--- a/lenskit/tests/models/test_knn_item_item.py
+++ b/lenskit/tests/models/test_knn_item_item.py
@@ -420,10 +420,9 @@ def test_ii_batch_accuracy(ml_100k):
         recs.add_from(result.output("recommendations"))
         test.add_from(split.test)
 
-    preds = dict_to_df(preds)
-    test = dict_to_df(test)
+    pred_df = preds.to_df()
 
-    mae = call_metric(MAE, preds)
+    mae = call_metric(MAE, pred_df)
     assert mae == approx(0.70, abs=0.025)
 
     pra = RunAnalysis()

--- a/lenskit/tests/splitting/test_split_records.py
+++ b/lenskit/tests/splitting/test_split_records.py
@@ -26,7 +26,7 @@ def test_crossfold_records(ml_ds: Dataset):
         # do we have all the data?
         test_count = s.test_size
         assert test_count + s.train.interaction_count == ml_ds.count("pairs")
-        test_pairs = set((u, i) for (u, il) in s.test.items() for i in il.ids())
+        test_pairs = set((u, i) for (u, il) in s.test for i in il.ids())
         tdf = s.train.interaction_matrix("pandas", field="rating", original_ids=True)
         train_pairs = set(zip(tdf["user_id"], tdf["item_id"]))
 
@@ -40,20 +40,19 @@ def test_crossfold_records(ml_ds: Dataset):
         if s1 is s2:
             continue
 
-        p1 = set((u, i) for (u, il) in s1.test.items() for i in il.ids())
-        p2 = set((u, i) for (u, il) in s2.test.items() for i in il.ids())
+        p1 = set((u, i) for (u, il) in s1.test for i in il.ids())
+        p2 = set((u, i) for (u, il) in s2.test for i in il.ids())
         assert not (p1 & p2)
 
 
 def test_sample_records_once(ml_ds):
     split = sample_records(ml_ds, size=1000)
-    train, test = split
 
     test_count = split.test_size
     assert test_count == 1000
-    assert test_count + train.interaction_count == ml_ds.count("pairs")
-    test_pairs = set((u, i) for (u, il) in test.items() for i in il.ids())
-    tdf = train.interaction_matrix("pandas", field="rating", original_ids=True)
+    assert test_count + split.train.interaction_count == ml_ds.count("pairs")
+    test_pairs = set((u, i) for (u, il) in split.test for i in il.ids())
+    tdf = split.train.interaction_matrix("pandas", field="rating", original_ids=True)
     train_pairs = set(zip(tdf["user_id"], tdf["item_id"]))
 
     # no overlap
@@ -71,7 +70,7 @@ def test_sample_records(ml_ds):
         test_count = s.test_size
         assert test_count == 1000
         assert test_count + s.train.interaction_count == ml_ds.count("pairs")
-        test_pairs = set((u, i) for (u, il) in s.test.items() for i in il.ids())
+        test_pairs = set((u, i) for (u, il) in s.test for i in il.ids())
         tdf = s.train.interaction_matrix("pandas", field="rating", original_ids=True)
         train_pairs = set(zip(tdf["user_id"], tdf["item_id"]))
 
@@ -84,8 +83,8 @@ def test_sample_records(ml_ds):
         if s1 is s2:
             continue
 
-        p1 = set((u, i) for (u, il) in s1.test.items() for i in il.ids())
-        p2 = set((u, i) for (u, il) in s2.test.items() for i in il.ids())
+        p1 = set((u, i) for (u, il) in s1.test for i in il.ids())
+        p2 = set((u, i) for (u, il) in s2.test for i in il.ids())
         assert not (p1 & p2)
 
 
@@ -98,7 +97,7 @@ def test_sample_rows_more_smaller_parts(ml_ds: Dataset):
         test_count = s.test_size
         assert test_count == 500
         assert test_count + s.train.interaction_count == ml_ds.count("pairs")
-        test_pairs = set((u, i) for (u, il) in s.test.items() for i in il.ids())
+        test_pairs = set((u, i) for (u, il) in s.test for i in il.ids())
         tdf = s.train.interaction_matrix("pandas", field="rating", original_ids=True)
         train_pairs = set(zip(tdf["user_id"], tdf["item_id"]))
 
@@ -111,8 +110,8 @@ def test_sample_rows_more_smaller_parts(ml_ds: Dataset):
         if s1 is s2:
             continue
 
-        p1 = set((u, i) for (u, il) in s1.test.items() for i in il.ids())
-        p2 = set((u, i) for (u, il) in s2.test.items() for i in il.ids())
+        p1 = set((u, i) for (u, il) in s1.test for i in il.ids())
+        p2 = set((u, i) for (u, il) in s2.test for i in il.ids())
         assert not (p1 & p2)
 
 
@@ -125,7 +124,7 @@ def test_sample_non_disjoint(ml_ds: Dataset):
         test_count = s.test_size
         assert test_count == 1000
         assert test_count + s.train.interaction_count == ml_ds.count("pairs")
-        test_pairs = set((u, i) for (u, il) in s.test.items() for i in il.ids())
+        test_pairs = set((u, i) for (u, il) in s.test for i in il.ids())
         tdf = s.train.interaction_matrix("pandas", field="rating", original_ids=True)
         train_pairs = set(zip(tdf["user_id"], tdf["item_id"]))
 
@@ -137,8 +136,8 @@ def test_sample_non_disjoint(ml_ds: Dataset):
     # There are enough splits & items we should pick at least one duplicate
     ipairs = (
         (
-            set((u, i) for (u, il) in s1.test.items() for i in il.ids()),
-            set((u, i) for (u, il) in s2.test.items() for i in il.ids()),
+            set((u, i) for (u, il) in s1.test for i in il.ids()),
+            set((u, i) for (u, il) in s2.test for i in il.ids()),
         )
         for (s1, s2) in it.product(splits, splits)
     )
@@ -155,7 +154,7 @@ def test_sample_oversize(ml_ds: Dataset):
     for s in splits:
         test_count = s.test_size
         assert test_count + s.train.interaction_count == ml_ds.count("pairs")
-        test_pairs = set((u, i) for (u, il) in s.test.items() for i in il.ids())
+        test_pairs = set((u, i) for (u, il) in s.test for i in il.ids())
         tdf = s.train.interaction_matrix("pandas", field="rating", original_ids=True)
         train_pairs = set(zip(tdf["user_id"], tdf["item_id"]))
 


### PR DESCRIPTION
This adds a new `ItemListCollection` and uses it to represent test data and run results, allowing more flexibility and collections that aren't just for users. Closes #504. Closes #505.