### PR TITLE
Implement global metrics and global/local metric interface

### DIFF
--- a/docs/api/metrics.rst
+++ b/docs/api/metrics.rst
@@ -12,6 +12,8 @@ Base Interfaces
     :caption: Basic Interfaces
 
     ~lenskit.metrics.Metric
+    ~lenskit.metrics.ListMetric
+    ~lenskit.metrics.GlobalMetric
     ~lenskit.metrics.MetricFunction
     ~lenskit.metrics.RankingMetricBase
 

--- a/docs/guide/batch.rst
+++ b/docs/guide/batch.rst
@@ -61,7 +61,7 @@ And measure their results:
     >>> measure = RunAnalysis()
     >>> measure.add_metric(RBP())
     >>> scores = measure.compute(recs, split.test)
-    >>> scores.summary()    # doctest: +ELLIPSIS
+    >>> scores.list_summary()    # doctest: +ELLIPSIS
             mean    median     std
     RBP  0.07...    0.0...  0.1...
 

--- a/docs/guide/evaluation/rankings.rst
+++ b/docs/guide/evaluation/rankings.rst
@@ -9,10 +9,11 @@ The :py:mod:`lenskit.metrics.ranking` module contains the core top-*N* ranking
 accuracy metrics (including rank-oblivious list metrics like precision, recall,
 and hit rate).
 
-Ranking metrics extend the :py:class:`RankingMetric` base class, and are
-callable objects that take the recommendation list and the test ratings, both as
-:py:class:`~lenskit.data.ItemList`, and return the score; most metrics require
-the recommendation item list to be :py:attr:`~lenskit.data.ItemList.ordered`.
+Ranking metrics extend the :py:class:`RankingMetricBase` base class in addition
+to :py:class:`ListMetric` and/or :py:class:`GlobalMetric`, return a score given
+a recommendation list and a test rating list, both as :py:class:`item lists
+<lenskit.data.ItemList>`; most metrics require the recommendation item list to
+be :py:attr:`~lenskit.data.ItemList.ordered`.
 
 All LensKit ranking metrics take `k` as a constructor argument to control the
 list of the length that is considered; this allows multiple measurements (e.g.

--- a/lenskit/lenskit/batch/_predict.py
+++ b/lenskit/lenskit/batch/_predict.py
@@ -65,27 +65,6 @@ def legacy_predict(algo, pairs, *, n_jobs=None, **kwargs):
     a list of item IDs. It should return a dictionary or a :py:class:`pandas.Series`
     mapping item IDs to predictions.
 
-    To use this function, provide a pre-fit algorithm:
-
-        >>> from lenskit.algorithms.bias import Bias
-        >>> from lenskit.metrics import call_metric, RMSE
-        >>> from lenskit.data import from_interactions_df
-        >>> from lenskit.data.movielens import load_movielens_df
-        >>> ratings = load_movielens_df('data/ml-latest-small')
-        >>> bias = Bias()
-        >>> bias.fit(from_interactions_df(ratings[:-1000]))
-        <lenskit.algorithms.bias.Bias object at ...>
-        >>> preds = predict(bias, ratings[-1000:])
-        >>> preds.head()
-               user  item  rating   timestamp  prediction
-        99004   664  8361     3.0  1393891425    3.288286
-        99005   664  8528     3.5  1393891047    3.559119
-        99006   664  8529     4.0  1393891173    3.573008
-        99007   664  8636     4.0  1393891175    3.846268
-        99008   664  8641     4.5  1393890852    3.710635
-        >>> call_metric(RMSE, preds)
-        0.832699...
-
     Args:
         algo(lenskit.algorithms.Predictor):
             A rating predictor function or algorithm.

--- a/lenskit/lenskit/metrics/_base.py
+++ b/lenskit/lenskit/metrics/_base.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
 from typing import ClassVar, Protocol
 
-from lenskit.data import ItemList
+from lenskit.data import ItemList, ItemListCollection
 
 
 class MetricFunction(Protocol):
-    "Interface for metrics implemented as simple functions."
+    "Interface for per-list metrics implemented as simple functions."
 
     @abstractmethod
     def __call__(self, output: ItemList, test: ItemList, /) -> float: ...
@@ -13,19 +13,13 @@ class MetricFunction(Protocol):
 
 class Metric(ABC):
     """
-    Base class for LensKit metrics.
+    Base class for LensKit metrics.  Individual metrics need to implement a
+    sub-interface, such as :class:`ListMetric` and/or :class:`GlobalMetric`.
 
     For simplicity in the analysis code, you cannot simply implement the
     properties of this class on an arbitrary class in order to implement a
     metric with all available behavior such as labeling and defaults; you must
     actually extend this class.  This requirement may be relaxed in the future.
-    """
-
-    default: ClassVar[float | None] = 0.0
-    """
-    The default value to infer when computing statistics over missing values.
-    If ``None``, no inference is done (necessary for metrics like RMSE, where
-    the missing value is theoretically infinite).
     """
 
     @property
@@ -37,21 +31,48 @@ class Metric(ABC):
         """
         return self.__class__.__name__
 
-    @property
-    def mean_label(self) -> str:
-        """
-        The label to use when aggregating the metric by taking the mean.
-
-        The base implementation delegates to :attr:`label`.
-        """
-        return self.label
-
-    @abstractmethod
-    def __call__(self, output: ItemList, test: ItemList, /) -> float:
-        """
-        Metrics should be callable to compute their values.
-        """
-        ...
-
     def __str__(self):
         return f"Metric {self.label}"
+
+
+class ListMetric(Metric):
+    """
+    Base class for metrics that measure individual recommendation (or
+    prediction) lists, and whose results may be aggregated to compute overall
+    metrics.
+
+    For prediction metrics, this is *macro-averaging*.
+    """
+
+    default: ClassVar[float | None] = 0.0
+    """
+    The default value to infer when computing statistics over missing values.
+    If ``None``, no inference is done (necessary for metrics like RMSE, where
+    the missing value is theoretically infinite).
+    """
+
+    @abstractmethod
+    def measure_list(self, output: ItemList, test: ItemList, /) -> float:
+        """
+        Compute the metric value for a single result list.
+
+        Individual metric classes need to implement this method.
+        """
+        raise NotImplementedError()
+
+
+class GlobalMetric(Metric):
+    """
+    Base class for metrics that measure entire runs at a time.
+
+    For prediction metrics, this is *micro-averaging*.
+    """
+
+    @abstractmethod
+    def measure_run(self, output: ItemListCollection, test: ItemListCollection, /) -> float:
+        """
+        Compute a metric value for an entire run.
+
+        Individual metric classes need to implement this method.
+        """
+        raise NotImplementedError()

--- a/lenskit/lenskit/metrics/bulk.py
+++ b/lenskit/lenskit/metrics/bulk.py
@@ -56,7 +56,7 @@ class RunAnalysisResult:
         """
         return self._list_scores.fillna(self._defaults)
 
-    def summary(self) -> pd.DataFrame:
+    def list_summary(self) -> pd.DataFrame:
         """
         Sumamry statistics for the per-list metrics.  Each metric is on its own
         row, with columns reporting the following:

--- a/lenskit/lenskit/metrics/predict.py
+++ b/lenskit/lenskit/metrics/predict.py
@@ -12,11 +12,11 @@ and instructions on using these metrics.
 from __future__ import annotations
 
 import logging
-from typing import Callable, Literal, TypeAlias, override
 
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
+from typing_extensions import Callable, Literal, TypeAlias, override
 
 from lenskit.data import ItemList, ItemListCollection
 from lenskit.data.bulk import group_df

--- a/lenskit/lenskit/metrics/predict.py
+++ b/lenskit/lenskit/metrics/predict.py
@@ -72,15 +72,19 @@ class PredictMetric(Metric):
         truth, that are aligned and checked for missing data in accordance with
         the configured options.
         """
-        if isinstance(predictions, ItemList):
-            pred_s = predictions.scores("pandas", index="ids")
-            assert pred_s is not None, "item list does not have scores"
-            if truth is not None:
-                rate_s = truth.field("rating", "pandas", index="ids")
-            else:
-                rate_s = predictions.field("rating", "pandas", index="ids")
-            assert rate_s is not None, "no ratings provided"
-            pred_s, rate_s = pred_s.align(rate_s, join="outer")
+        if not isinstance(predictions, ItemList):  # pragma: nocover
+            raise TypeError(f"predictions must be ItemList, not {type(predictions)}")
+        if truth is not None and not isinstance(truth, ItemList):  # pragma: nocover
+            raise TypeError(f"truth must be ItemList, not {type(truth)}")
+
+        pred_s = predictions.scores("pandas", index="ids")
+        assert pred_s is not None, "item list does not have scores"
+        if truth is not None:
+            rate_s = truth.field("rating", "pandas", index="ids")
+        else:
+            rate_s = predictions.field("rating", "pandas", index="ids")
+        assert rate_s is not None, "no ratings provided"
+        pred_s, rate_s = pred_s.align(rate_s, join="outer")
 
         pred_m = pred_s.isna()
         rate_m = rate_s.isna()

--- a/lenskit/lenskit/metrics/ranking/_base.py
+++ b/lenskit/lenskit/metrics/ranking/_base.py
@@ -1,6 +1,8 @@
 from lenskit.data import ItemList
 
-from .._base import Metric
+from .._base import GlobalMetric, ListMetric, Metric
+
+__all__ = ["Metric", "ListMetric", "GlobalMetric", "RankingMetricBase"]
 
 
 class RankingMetricBase(Metric):

--- a/lenskit/lenskit/metrics/ranking/_dcg.py
+++ b/lenskit/lenskit/metrics/ranking/_dcg.py
@@ -1,7 +1,6 @@
-from typing import Callable, TypeAlias, override
-
 import numpy as np
 from numpy.typing import NDArray
+from typing_extensions import Callable, TypeAlias, override
 
 from lenskit.data import ItemList
 

--- a/lenskit/lenskit/metrics/ranking/_dcg.py
+++ b/lenskit/lenskit/metrics/ranking/_dcg.py
@@ -1,16 +1,16 @@
-from typing import Callable, TypeAlias
+from typing import Callable, TypeAlias, override
 
 import numpy as np
 from numpy.typing import NDArray
 
 from lenskit.data import ItemList
 
-from ._base import RankingMetricBase
+from ._base import ListMetric, RankingMetricBase
 
 Discount: TypeAlias = Callable[[NDArray[np.number]], NDArray[np.float64]]
 
 
-class NDCG(RankingMetricBase):
+class NDCG(ListMetric, RankingMetricBase):
     """
     Compute the normalized discounted cumulative gain :cite:p:`ndcg`.
 
@@ -62,7 +62,8 @@ class NDCG(RankingMetricBase):
         else:
             return "NDCG"
 
-    def __call__(self, recs: ItemList, test: ItemList) -> float:
+    @override
+    def measure_list(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)
         items = recs.ids()
 

--- a/lenskit/lenskit/metrics/ranking/_hit.py
+++ b/lenskit/lenskit/metrics/ranking/_hit.py
@@ -1,11 +1,13 @@
+from typing import override
+
 import numpy as np
 
 from lenskit.data import ItemList
 
-from ._base import RankingMetricBase
+from ._base import ListMetric, RankingMetricBase
 
 
-class Hit(RankingMetricBase):
+class Hit(ListMetric, RankingMetricBase):
     """
     Compute whether or not a list is a hit; any list with at least one
     relevant item in the first :math:`k` positions (:math:`L_{\\le k} \\cap
@@ -21,14 +23,8 @@ class Hit(RankingMetricBase):
         else:
             return "Hit"
 
-    @property
-    def mean_label(self):
-        if self.k is not None:
-            return f"HitRate@{self.k}"
-        else:
-            return "HitRate"
-
-    def __call__(self, recs: ItemList, test: ItemList) -> float:
+    @override
+    def measure_list(self, recs: ItemList, test: ItemList) -> float:
         if len(test) == 0:
             return np.nan
 

--- a/lenskit/lenskit/metrics/ranking/_hit.py
+++ b/lenskit/lenskit/metrics/ranking/_hit.py
@@ -1,6 +1,5 @@
-from typing import override
-
 import numpy as np
+from typing_extensions import override
 
 from lenskit.data import ItemList
 

--- a/lenskit/lenskit/metrics/ranking/_pr.py
+++ b/lenskit/lenskit/metrics/ranking/_pr.py
@@ -1,6 +1,5 @@
-from typing import override
-
 import numpy as np
+from typing_extensions import override
 
 from lenskit.data.items import ItemList
 

--- a/lenskit/lenskit/metrics/ranking/_pr.py
+++ b/lenskit/lenskit/metrics/ranking/_pr.py
@@ -1,11 +1,13 @@
+from typing import override
+
 import numpy as np
 
 from lenskit.data.items import ItemList
 
-from ._base import RankingMetricBase
+from ._base import ListMetric, RankingMetricBase
 
 
-class Precision(RankingMetricBase):
+class Precision(ListMetric, RankingMetricBase):
     """
     Compute recommendation precision.  This is computed as:
 
@@ -23,7 +25,8 @@ class Precision(RankingMetricBase):
         else:
             return "Precision"
 
-    def __call__(self, recs: ItemList, test: ItemList) -> float:
+    @override
+    def measure_list(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)
         nrecs = len(recs)
         if nrecs == 0:
@@ -34,7 +37,7 @@ class Precision(RankingMetricBase):
         return ngood / nrecs
 
 
-class Recall(RankingMetricBase):
+class Recall(ListMetric, RankingMetricBase):
     """
     Compute recommendation recall.  This is computed as:
 
@@ -49,7 +52,8 @@ class Recall(RankingMetricBase):
         else:
             return "Recall"
 
-    def __call__(self, recs: ItemList, test: ItemList) -> float:
+    @override
+    def measure_list(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)
 
         items = recs.ids()

--- a/lenskit/lenskit/metrics/ranking/_rbp.py
+++ b/lenskit/lenskit/metrics/ranking/_rbp.py
@@ -1,6 +1,5 @@
-from typing import override
-
 import numpy as np
+from typing_extensions import override
 
 from lenskit.data.items import ItemList
 

--- a/lenskit/lenskit/metrics/ranking/_rbp.py
+++ b/lenskit/lenskit/metrics/ranking/_rbp.py
@@ -1,11 +1,13 @@
+from typing import override
+
 import numpy as np
 
 from lenskit.data.items import ItemList
 
-from ._base import RankingMetricBase
+from ._base import ListMetric, RankingMetricBase
 
 
-class RBP(RankingMetricBase):
+class RBP(ListMetric, RankingMetricBase):
     """
     Evaluate recommendations with rank-biased precision :cite:p:`rbp` with a
     patience parameter :math:`\\gamma`.
@@ -52,7 +54,8 @@ class RBP(RankingMetricBase):
         else:
             return "RBP"
 
-    def __call__(self, recs: ItemList, test: ItemList) -> float:
+    @override
+    def measure_list(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)
         k = len(recs)
 

--- a/lenskit/lenskit/metrics/ranking/_recip.py
+++ b/lenskit/lenskit/metrics/ranking/_recip.py
@@ -1,11 +1,13 @@
+from typing import override
+
 import numpy as np
 
 from lenskit.data import ItemList
 
-from ._base import RankingMetricBase
+from ._base import ListMetric, RankingMetricBase
 
 
-class RecipRank(RankingMetricBase):
+class RecipRank(ListMetric, RankingMetricBase):
     """
     Compute the reciprocal rank :cite:p:`trec5-confusion` of the first relevant
     item in a list of recommendations.  Taking the mean of this metric over the
@@ -25,14 +27,8 @@ class RecipRank(RankingMetricBase):
         else:
             return "RecipRank"
 
-    @property
-    def mean_label(self):
-        if self.k is not None:
-            return f"MRR@{self.k}"
-        else:
-            return "MRR"
-
-    def __call__(self, recs: ItemList, test: ItemList) -> float:
+    @override
+    def measure_list(self, recs: ItemList, test: ItemList) -> float:
         if len(test) == 0:
             return np.nan
 

--- a/lenskit/lenskit/metrics/ranking/_recip.py
+++ b/lenskit/lenskit/metrics/ranking/_recip.py
@@ -1,6 +1,5 @@
-from typing import override
-
 import numpy as np
+from typing_extensions import override
 
 from lenskit.data import ItemList
 

--- a/lenskit/tests/batch/test_batch_pipeline.py
+++ b/lenskit/tests/batch/test_batch_pipeline.py
@@ -102,7 +102,7 @@ def test_bias_batch(ml_split: TTSplit, ncpus: int | None):
     pa = RunAnalysis()
     pa.add_metric(RMSE())
     pred_acc = pa.compute(preds, ml_split.test)
-    pas = pred_acc.summary()
+    pas = pred_acc.list_summary()
     print(pas)
     assert pas.loc["RMSE", "mean"] == approx(0.949, rel=0.1)
 
@@ -111,7 +111,7 @@ def test_bias_batch(ml_split: TTSplit, ncpus: int | None):
     ra.add_metric(NDCG())
     ra.add_metric(RBP())
     rec_acc = ra.compute(recs, ml_split.test)
-    ras = rec_acc.summary()
+    ras = rec_acc.list_summary()
     print(ras)
 
     assert ras.loc["RBP", "mean"] > 0
@@ -135,7 +135,7 @@ def test_pop_batch_recommend(ml_split: TTSplit, ncpus: int | None):
     ra.add_metric(NDCG())
     ra.add_metric(RBP())
     rec_acc = ra.compute(recs, ml_split.test)
-    ras = rec_acc.summary()
+    ras = rec_acc.list_summary()
     print(ras)
 
     assert ras.loc["RBP", "mean"] > 0

--- a/lenskit/tests/eval/test_bulk_metrics.py
+++ b/lenskit/tests/eval/test_bulk_metrics.py
@@ -22,7 +22,7 @@ def test_bulk_measure_function(ml_ratings: pd.DataFrame):
     truth = ItemListCollection.from_df(ml_ratings, USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN)
 
     metrics = bms.compute(data, truth)
-    stats = metrics.summary()
+    stats = metrics.list_summary()
     assert stats.loc["length", "mean"] == approx(ml_ratings["user"].value_counts().mean())
     assert stats.loc["RMSE", "mean"] == approx(0)
 
@@ -39,7 +39,7 @@ def test_recs(demo_recs):
     test = ItemListCollection.from_df(test, USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN)
     metrics = bms.compute(recs, test)
     scores = metrics.list_scores()
-    stats = metrics.summary()
+    stats = metrics.list_summary()
     print(stats)
     for m in bms.metrics:
         assert stats.loc[m.label, "mean"] == approx(scores[m.label].mean())

--- a/lenskit/tests/eval/test_bulk_metrics.py
+++ b/lenskit/tests/eval/test_bulk_metrics.py
@@ -7,7 +7,7 @@ from lenskit.data.schemas import ITEM_COMPAT_COLUMN, USER_COMPAT_COLUMN
 from lenskit.metrics.basic import ListLength
 from lenskit.metrics.bulk import RunAnalysis
 from lenskit.metrics.predict import RMSE
-from lenskit.metrics.ranking import NDCG, Precision
+from lenskit.metrics.ranking import NDCG, RBP, Precision, RecipRank
 from lenskit.util.test import demo_recs, ml_ratings
 
 
@@ -34,11 +34,13 @@ def test_recs(demo_recs):
     bms.add_metric(ListLength())
     bms.add_metric(Precision())
     bms.add_metric(NDCG())
+    bms.add_metric(RBP)
+    bms.add_metric(RecipRank)
 
     recs = ItemListCollection.from_df(recs, USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN)
     test = ItemListCollection.from_df(test, USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN)
     metrics = bms.compute(recs, test)
-    scores = metrics.list_scores()
+    scores = metrics.list_metrics()
     stats = metrics.list_summary()
     print(stats)
     for m in bms.metrics:

--- a/lenskit/tests/eval/test_predict_metrics.py
+++ b/lenskit/tests/eval/test_predict_metrics.py
@@ -114,7 +114,7 @@ def test_batch_rmse(ml_100k):
     metrics = pa.compute(preds, split.test)
 
     umdf = metrics.list_scores(fill_missing=False)
-    mdf = metrics.summary()
+    mdf = metrics.list_summary()
 
     # we should have all users
     assert len(umdf) == len(split.test)

--- a/lenskit/tests/eval/test_predict_metrics.py
+++ b/lenskit/tests/eval/test_predict_metrics.py
@@ -131,3 +131,9 @@ def test_batch_rmse(ml_100k):
 
     assert umdf["MAE"].mean() == approx(0.76, abs=0.05)
     assert mdf.loc["MAE", "mean"] == approx(0.76, abs=0.05)
+
+    # we should have global metrics
+    gs = metrics.global_metrics()
+    print("global metrics:", gs)
+    assert gs["RMSE"] == approx(0.93, abs=0.05)
+    assert gs["MAE"] == approx(0.76, abs=0.05)

--- a/lenskit/tests/eval/test_predict_metrics.py
+++ b/lenskit/tests/eval/test_predict_metrics.py
@@ -113,7 +113,7 @@ def test_batch_rmse(ml_100k):
 
     metrics = pa.compute(preds, split.test)
 
-    umdf = metrics.list_scores(fill_missing=False)
+    umdf = metrics.list_metrics(fill_missing=False)
     mdf = metrics.list_summary()
 
     # we should have all users

--- a/lenskit/tests/eval/test_rank_hit.py
+++ b/lenskit/tests/eval/test_rank_hit.py
@@ -22,7 +22,7 @@ def _test_hit(items, rel, **kwargs) -> float:
     recs = ItemList(items, ordered=True)
     truth = ItemList(rel)
     metric = Hit(**kwargs)
-    return metric(recs, truth)
+    return metric.measure_list(recs, truth)
 
 
 def test_hit_empty_zero():

--- a/lenskit/tests/eval/test_rank_mrr.py
+++ b/lenskit/tests/eval/test_rank_mrr.py
@@ -17,7 +17,7 @@ from lenskit.util.test import demo_recs  # noqa: F401
 def _test_rr(items, rel, **kw):
     recs = ItemList(items, ordered=True)
     truth = ItemList(rel)
-    return RecipRank(**kw)(recs, truth)
+    return RecipRank(**kw).measure_list(recs, truth)
 
 
 def test_mrr_empty_zero():

--- a/lenskit/tests/eval/test_rank_ndcg.py
+++ b/lenskit/tests/eval/test_rank_ndcg.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pytest import approx, mark
 
 from lenskit.data import ItemList
+from lenskit.metrics import call_metric
 from lenskit.metrics.ranking import NDCG
 from lenskit.metrics.ranking._dcg import array_dcg, fixed_dcg
 
@@ -68,26 +69,26 @@ def test_dcg_mult2():
 def test_ndcg_empty():
     recs = ItemList(ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
-    assert NDCG()(recs, truth) == approx(0.0)
+    assert call_metric(NDCG, recs, truth) == approx(0.0)
 
 
 def test_ndcg_no_match():
     recs = ItemList([4], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
-    assert NDCG()(recs, truth) == approx(0.0)
+    assert call_metric(NDCG, recs, truth) == approx(0.0)
 
 
 def test_ndcg_perfect():
     recs = ItemList([2, 3, 1], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
-    assert NDCG()(recs, truth) == approx(1.0)
+    assert call_metric(NDCG, recs, truth) == approx(1.0)
 
 
 def test_ndcg_perfect_k_short():
     recs = ItemList([2, 3, 1], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
-    assert NDCG(k=2)(recs, truth) == approx(1.0)
-    assert NDCG(k=2)(recs[:2], truth) == approx(1.0)
+    assert call_metric(NDCG, recs, truth, k=2) == approx(1.0)
+    assert call_metric(NDCG, recs[:2], truth, k=2) == approx(1.0)
 
 
 def test_ndcg_shorter_not_best():
@@ -95,26 +96,28 @@ def test_ndcg_shorter_not_best():
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     b_ideal = fixed_dcg(3)
     r_ideal = array_dcg(np.array([5.0, 4.0, 3.0]))
-    assert NDCG()(recs, truth) == approx(fixed_dcg(2) / b_ideal)
-    assert NDCG(k=2)(recs, truth) == approx(1.0)
-    assert NDCG(gain="rating")(recs, truth) == approx(array_dcg(np.array([3.0, 5.0])) / r_ideal)
+    assert call_metric(NDCG, recs, truth) == approx(fixed_dcg(2) / b_ideal)
+    assert call_metric(NDCG, recs, truth, k=2) == approx(1.0)
+    assert call_metric(NDCG, recs, truth, gain="rating") == approx(
+        array_dcg(np.array([3.0, 5.0])) / r_ideal
+    )
 
 
 def test_ndcg_perfect_k():
     recs = ItemList([2, 3], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
-    assert NDCG(k=2)(recs, truth) == approx(1.0)
+    assert call_metric(NDCG, recs, truth, k=2) == approx(1.0)
 
 
 def test_ndcg_perfect_k_norate():
     recs = ItemList([1, 3], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
-    assert NDCG(k=2)(recs, truth) == approx(1.0)
+    assert call_metric(NDCG, recs, truth, k=2) == approx(1.0)
 
 
 def test_ndcg_almost_perfect_k_gain():
     recs = ItemList([1, 3], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
-    assert NDCG(k=2, gain="rating")(recs, truth) == approx(
+    assert call_metric(NDCG, recs, truth, k=2, gain="rating") == approx(
         array_dcg(np.array([3.0, 4.0])) / array_dcg(np.array([5.0, 4.0]))
     )

--- a/lenskit/tests/eval/test_rank_precision.py
+++ b/lenskit/tests/eval/test_rank_precision.py
@@ -17,7 +17,7 @@ from lenskit.util.test import demo_recs  # noqa: F401
 def _test_prec(items, rel, **k):
     recs = ItemList(items, ordered=True)
     truth = ItemList(rel)
-    return Precision(**k)(recs, truth)
+    return Precision(**k).measure_list(recs, truth)
 
 
 def test_precision_empty_none():

--- a/lenskit/tests/eval/test_rank_rbp.py
+++ b/lenskit/tests/eval/test_rank_rbp.py
@@ -14,6 +14,7 @@ from hypothesis import given
 from pytest import approx, mark
 
 from lenskit.data import ItemList
+from lenskit.metrics import call_metric
 from lenskit.metrics.ranking import RBP
 from lenskit.util.test import demo_recs  # noqa: F401
 
@@ -23,19 +24,19 @@ _log = logging.getLogger(__name__)
 def test_rbp_empty():
     recs = ItemList([], ordered=True)
     truth = ItemList([1, 2, 3])
-    assert RBP()(recs, truth) == approx(0.0)
+    assert call_metric(RBP, recs, truth) == approx(0.0)
 
 
 def test_rbp_no_match():
     recs = ItemList([4], ordered=True)
     truth = ItemList([1, 2, 3])
-    assert RBP()(recs, truth) == approx(0.0)
+    assert call_metric(RBP, recs, truth) == approx(0.0)
 
 
 def test_rbp_one_match():
     recs = ItemList([1], ordered=True)
     truth = ItemList([1, 2, 3])
-    assert RBP()(recs, truth) == approx(0.5)
+    assert call_metric(RBP, recs, truth) == approx(0.5)
 
 
 @given(st.lists(st.integers(1), min_size=1, max_size=100, unique=True), st.floats(0.05, 0.95))
@@ -43,14 +44,14 @@ def test_rbp_perfect(items, p):
     n = len(items)
     recs = ItemList(items, ordered=True)
     truth = ItemList(items)
-    assert RBP(patience=p)(recs, truth) == approx(np.sum(p ** np.arange(n)) * (1 - p))
+    assert call_metric(RBP, recs, truth, patience=p) == approx(np.sum(p ** np.arange(n)) * (1 - p))
 
 
 @given(st.lists(st.integers(1), min_size=1, max_size=100, unique=True), st.floats(0.05, 0.95))
 def test_rbp_perfect_norm(items, p):
     recs = ItemList(items, ordered=True)
     truth = ItemList(items)
-    assert RBP(patience=p, normalize=True)(recs, truth) == approx(1.0)
+    assert call_metric(RBP, recs, truth, patience=p, normalize=True) == approx(1.0)
 
 
 @given(
@@ -63,7 +64,9 @@ def test_rbp_perfect_k(items, k, p):
     eff_n = min(n, k)
     recs = ItemList(items, ordered=True)
     truth = ItemList(items)
-    assert RBP(k, patience=p)(recs, truth) == approx(np.sum(p ** np.arange(eff_n)) * (1 - p))
+    assert call_metric(RBP, recs, truth, k, patience=p) == approx(
+        np.sum(p ** np.arange(eff_n)) * (1 - p)
+    )
 
 
 @given(
@@ -74,11 +77,11 @@ def test_rbp_perfect_k(items, k, p):
 def test_rbp_perfect_k_norm(items, k, p):
     recs = ItemList(items, ordered=True)
     truth = ItemList(items)
-    assert RBP(k, patience=p, normalize=True)(recs, truth) == approx(1.0)
+    assert call_metric(RBP, recs, truth, k, patience=p, normalize=True) == approx(1.0)
 
 
 def test_rbp_missing():
     recs = ItemList([1, 2], ordered=True)
     truth = ItemList([1, 2, 3])
     # (1 + 0.5) * 0.5
-    assert RBP()(recs, truth) == approx(0.75)
+    assert call_metric(RBP, recs, truth) == approx(0.75)

--- a/lenskit/tests/eval/test_rank_recall.py
+++ b/lenskit/tests/eval/test_rank_recall.py
@@ -21,7 +21,7 @@ _log = logging.getLogger(__name__)
 def _test_recall(items, rel, **kwargs):
     recs = ItemList(items, ordered=True)
     truth = ItemList(rel)
-    return Recall(**kwargs)(recs, truth)
+    return Recall(**kwargs).measure_list(recs, truth)
 
 
 def test_recall_empty_zero():

--- a/lenskit/tests/models/test_knn_item_item.py
+++ b/lenskit/tests/models/test_knn_item_item.py
@@ -420,18 +420,15 @@ def test_ii_batch_accuracy(ml_100k):
         recs.add_from(result.output("recommendations"))
         test.add_from(split.test)
 
-    pred_df = preds.to_df()
-
-    mae = call_metric(MAE, pred_df)
-    assert mae == approx(0.70, abs=0.025)
-
     pra = RunAnalysis()
     pra.add_metric(RMSE())
+    pra.add_metric(MAE())
 
     evres = pra.compute(preds, test)
     metrics = evres.list_metrics(fill_missing=False)
     assert not np.any(np.isnan(metrics["RMSE"]))
     assert metrics["RMSE"].mean() == approx(0.90, abs=0.05)
+    assert evres.global_metrics()["MAE"] == approx(0.70, abs=0.025)
 
     rra = RunAnalysis()
     rra.add_metric(RecipRank())

--- a/lenskit/tests/models/test_knn_item_item.py
+++ b/lenskit/tests/models/test_knn_item_item.py
@@ -429,7 +429,7 @@ def test_ii_batch_accuracy(ml_100k):
     pra.add_metric(RMSE())
 
     evres = pra.compute(preds, test)
-    metrics = evres.list_scores(fill_missing=False)
+    metrics = evres.list_metrics(fill_missing=False)
     assert not np.any(np.isnan(metrics["RMSE"]))
     assert metrics["RMSE"].mean() == approx(0.90, abs=0.05)
 

--- a/lenskit/tests/models/test_knn_item_item.py
+++ b/lenskit/tests/models/test_knn_item_item.py
@@ -438,7 +438,7 @@ def test_ii_batch_accuracy(ml_100k):
     rra.add_metric(RBP())
 
     evres = rra.compute(preds, test)
-    summary = evres.summary()
+    summary = evres.list_summary()
     assert summary.loc["RecipRank", "mean"] > 0
     assert summary.loc["RBP", "mean"] > 0
 


### PR DESCRIPTION
This changes metrics from callables to classes that implement `ListMetric` and/or `GlobalMetric` (although simple list metrics can be specified as functions), and implements global RMSE & MAE.

These are slower than the old bulk operations, but clearer to write. We may look at re-optimizing later.