### PR TITLE
Add __init__.py

### DIFF
--- a/lenskit/lenskit/__init__.py
+++ b/lenskit/lenskit/__init__.py
@@ -1,0 +1,3 @@
+"""
+Recommender toolkit.
+"""

--- a/lenskit/lenskit/__init__.py
+++ b/lenskit/lenskit/__init__.py
@@ -1,5 +1,10 @@
 """
-Recommender toolkit.
+Recommender systems toolkit.
 """
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "UNSPECIFIED"

--- a/lenskit/lenskit/__init__.py
+++ b/lenskit/lenskit/__init__.py
@@ -1,3 +1,5 @@
 """
 Recommender toolkit.
 """
+
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
This re-adds an `__init__.py` to `lenskit` (but *not* the other packages), using `pkgutil`.  This _seems_ to work, and will allow top-level exports again.