### PR TITLE
Fix subprocess logging

### DIFF
--- a/lenskit/lenskit/logging/monitor.py
+++ b/lenskit/lenskit/logging/monitor.py
@@ -210,6 +210,6 @@ class MonitorThread(threading.Thread):
             logger = structlog.get_logger(name)
             data = json.loads(data)
             method = getattr(logger, data["method"])
-            method(data["event"])
+            method(**data["event"])
         else:
             _log.error("invalid log backend")

--- a/lenskit/lenskit/logging/processors.py
+++ b/lenskit/lenskit/logging/processors.py
@@ -2,6 +2,7 @@
 LensKit logging processors.
 """
 
+import multiprocessing as mp
 from datetime import datetime
 from typing import Any
 
@@ -32,3 +33,17 @@ def format_timestamp(logger: Any, method: str, event_dict: EventDict) -> EventDi
         return event_dict
     else:
         return event_dict
+
+
+def add_process_info(logger: Any, method: str, event_dict: EventDict) -> EventDict:
+    """
+    Add process info if it does not exist.
+    """
+
+    proc = mp.current_process()
+    if "pid" not in event_dict:
+        event_dict["pid"] = proc.pid
+    if "pname" not in event_dict:
+        event_dict["pname"] = proc.name
+
+    return event_dict

--- a/lenskit/lenskit/parallel/pool.py
+++ b/lenskit/lenskit/parallel/pool.py
@@ -71,8 +71,8 @@ class LenskitProcess(SpawnProcess):
 
     @override
     def run(self):
-        log = _log.bind(pid=self.pid, pname=self.name)
         with WorkerContext(self._log_config):
+            log = _log.bind(pid=self.pid, pname=self.name)
             log.info("multiprocessing worker started")
             super().run()
 

--- a/lenskit/lenskit/parallel/worker.py
+++ b/lenskit/lenskit/parallel/worker.py
@@ -50,7 +50,7 @@ def initalize(cfg: WorkerConfig, ctx: ModelData) -> None:
         log.error("deserialization failed: %s", e)
         raise e
 
-    log.debug("worker %d ready (process %s)", os.getpid(), mp.current_process())
+    log.debug("worker %d ready (process %s)", os.getpid(), mp.current_process().name)
 
 
 def worker(arg: Any) -> Any:


### PR DESCRIPTION
This fixes the order of setup for subprocess logging to stop clobbering progress bars and correctly route messages.