### PR TITLE
Add map-reduce support for global metrics

### DIFF
--- a/docs/guide/evaluation/predictions.rst
+++ b/docs/guide/evaluation/predictions.rst
@@ -25,19 +25,22 @@ The following computes RMSE over a small subset of the ``ml-small`` ratings::
     from lenskit.datasets import MovieLens
     from lenskit.algorithms.bias import Bias
     from lenskit.batch import predict
-    from lenskit.metrics.predict import user_metric, RMSE
+    from lenskit.metrics import RunAnalysis
+    from lenskit.metrics.predict import RMSE
     ratings = MovieLens('ml-small').ratings.sample(frac=0.1)
     test = ratings.iloc[:1000]
     train = ratings.iloc[1000:]
     algo = Bias()
     algo.fit(train)
     preds = predict(algo, test)
-    measure_user_predictions(preds, RMSE)
+    pra = RunAnalysis()
+    pra.add_metric(RMSE())
+    results = pra.compute(preds, test)
 
 Calling Metrics
 ---------------
 
-There are three ways to call a prediction accuracy metric:
+There are two ways to directly call a prediction accuracy metric:
 
 * Pass two item lists, the first containing predicted ratings (as the list's
   :py:meth:`~lenskit.data.ItemLists.scores`) and the second containing
@@ -45,18 +48,8 @@ There are three ways to call a prediction accuracy metric:
 
 * Pass a single item list with scores and a ``rating`` field.
 
-* Pass a single data frame with both ``score`` and ``rating`` columns
-  (``prediction`` is accepted as an alias for ``score``).
-
-When computing globally-averaged prediction accuracy, it's best to use the data
-frame option.
-
-If you want per-user metrics, the :py:func:`measure_user_predictions` function
-helps automate this computation.  It takes a data frame (with a ``user_id`` or
-``user`` column, along with the ``score`` and ``rating`` columns) and a metric
-and returns a series of per-user scores, indexed by user ID::
-
-    measure_user_predictions(preds, RMSE)
+For evaluation, you will usually want to use :class:`~lenskit.metrics.RunAnalysis`,
+which takes care of calling the prediction metric for you.
 
 Missing Data
 ------------
@@ -89,6 +82,3 @@ The corresponding ``missing_truth="ignore"`` will cause the metric to ignore
 predictions with no corresponding rating (this case is unlikely to produce
 unhelpful eval results, but may indicate a misconfiguration in how you determine
 the items to score).
-
-:py:func:`measure_user_predictions` also accepts these options, and passes
-them through to the underlying metric.

--- a/lenskit/lenskit/metrics/_base.py
+++ b/lenskit/lenskit/metrics/_base.py
@@ -76,3 +76,37 @@ class GlobalMetric(Metric):
         Individual metric classes need to implement this method.
         """
         raise NotImplementedError()
+
+
+class DecomposedMetric(Metric):
+    """
+    Base class for metrics that measure entire runs through flexible
+    aggregations of per-list intermediate measurements.  They can optionally
+    extract individual-list metrics from the per-list measurements.
+    """
+
+    @abstractmethod
+    def compute_list_data(self, output: ItemList, test: ItemList, /) -> object:
+        """
+        Compute measurements for a single list.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def extract_list_metric(self, metric: object, /) -> float | None:
+        """
+        Extract a single-list metric from the per-list measurement result (if
+        applicable).
+
+        Returns:
+            The per-list metric, or ``None`` if this metric does not compute
+            per-list metrics.
+        """
+        return None
+
+    @abstractmethod
+    def global_aggregate(self, values: list[object], /) -> float:
+        """
+        Aggregate list metrics to compute a global value.
+        """
+        raise NotImplementedError()

--- a/lenskit/lenskit/metrics/predict.py
+++ b/lenskit/lenskit/metrics/predict.py
@@ -19,7 +19,6 @@ from numpy.typing import NDArray
 from typing_extensions import Callable, Literal, TypeAlias, override
 
 from lenskit.data import ItemList, ItemListCollection
-from lenskit.data.bulk import group_df
 from lenskit.data.schemas import ITEM_COMPAT_COLUMN, normalize_columns
 from lenskit.data.types import AliasedColumn
 
@@ -202,23 +201,3 @@ class MAE(PredictMetric, ListMetric, GlobalMetric):
             return np.nan
         else:
             return sae / n
-
-
-def measure_user_predictions(
-    predictions: pd.DataFrame, metric: PredictMetric | type[PredictMetric]
-) -> pd.Series:
-    """
-    Compute per-user metrics for a set of predictions.
-
-    Args:
-        predictions:
-            A data frame of predictions.  Must have `user_id`, `item_id`,
-            `score`, and `rating` columns.
-        metric:
-            The metric to compute.  :fun:`rmse` and :fun:`mae` both implement
-            this interface.
-    """
-    if isinstance(metric, type):
-        metric = metric()
-
-    return group_df(predictions).apply(lambda df: metric.measure_list(df))

--- a/lenskit/tests/eval/test_predict_metrics.py
+++ b/lenskit/tests/eval/test_predict_metrics.py
@@ -13,7 +13,7 @@ from pytest import approx, mark, raises
 
 from lenskit.data import ItemList, from_interactions_df
 from lenskit.metrics import RunAnalysis, call_metric
-from lenskit.metrics.predict import MAE, RMSE, measure_user_predictions
+from lenskit.metrics.predict import MAE, RMSE
 
 _log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This adds the concept of “decomposed” metrics that compute listwise data and then aggregate it for a global metric computation.