### PR TITLE
Add test-only splitting

### DIFF
--- a/lenskit/lenskit/splitting/__init__.py
+++ b/lenskit/lenskit/splitting/__init__.py
@@ -12,10 +12,24 @@ import numpy as np
 
 from lenskit.data import Dataset
 
-from .holdout import LastFrac, LastN, SampleFrac, SampleN  # noqa: F401
-from .records import crossfold_records, sample_records  # noqa: F401
-from .split import TTSplit  # noqa: F401
-from .users import crossfold_users, sample_users  # noqa: F401
+from .holdout import HoldoutMethod, LastFrac, LastN, SampleFrac, SampleN
+from .records import crossfold_records, sample_records
+from .split import TTSplit
+from .users import crossfold_users, sample_users
+
+__all__ = [
+    "TTSplit",
+    "HoldoutMethod",
+    "LastFrac",
+    "LastN",
+    "SampleFrac",
+    "SampleN",
+    "crossfold_records",
+    "sample_records",
+    "crossfold_users",
+    "sample_users",
+    "simple_test_pair",
+]
 
 
 def simple_test_pair(

--- a/lenskit/lenskit/splitting/records.py
+++ b/lenskit/lenskit/splitting/records.py
@@ -183,7 +183,7 @@ def _make_pair(
 
     test = ItemListCollection.from_df(df[mask], UserIDKey)
     if test_only:
-        train = MatrixDataset(data.users, data.items, df.loc[:0])
+        train = MatrixDataset(data.users, data.items, df.iloc[:0])
     else:
         train = MatrixDataset(data.users, data.items, df[~mask])
 

--- a/lenskit/tests/splitting/test_split_records.py
+++ b/lenskit/tests/splitting/test_split_records.py
@@ -88,6 +88,17 @@ def test_sample_records(ml_ds):
         assert not (p1 & p2)
 
 
+def test_sample_records_test_only(ml_ds):
+    splits = sample_records(ml_ds, size=1000, repeats=1, test_only=True)
+    splits = list(splits)
+    assert len(splits) == 1
+
+    for s in splits:
+        test_count = s.test_size
+        assert test_count == 1000
+        assert s.train.interaction_count == 0
+
+
 def test_sample_rows_more_smaller_parts(ml_ds: Dataset):
     splits = sample_records(ml_ds, 500, repeats=10)
     splits = list(splits)

--- a/lenskit/tests/splitting/test_split_users.py
+++ b/lenskit/tests/splitting/test_split_users.py
@@ -110,6 +110,17 @@ def test_sample_users(ml_ds: Dataset):
         assert s.test_size + s.train.count("pairs") == ml_ds.count("pairs")
 
 
+def test_sample_test_only(ml_ds: Dataset):
+    splits = sample_users(ml_ds, 100, SampleN(5), repeats=1, test_only=True)
+    splits = list(splits)
+    assert len(splits) == 1
+
+    for s in splits:
+        assert len(s.test) == 100
+        assert s.test_size == 500
+        assert s.train.interaction_count == 0
+
+
 def test_sample_users_non_disjoint(ml_ds: Dataset):
     splits = sample_users(ml_ds, 100, SampleN(5), repeats=5, disjoint=False)
     splits = list(splits)


### PR DESCRIPTION
This adds a `test_only` option to the data splitting functions to return splits with empty training sets, saving time when we are just saving the test data for later use.