### PR TITLE
Add a multiprocess_executor to get a general MP executor with logging

### DIFF
--- a/lenskit/lenskit/parallel/__init__.py
+++ b/lenskit/lenskit/parallel/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from .config import ensure_parallel_init, get_parallel_config, initialize
 from .invoker import ModelOpInvoker, invoker
+from .pool import multiprocess_executor
 
 __all__ = [
     "initialize",
@@ -19,4 +20,5 @@ __all__ = [
     "ensure_parallel_init",
     "invoker",
     "ModelOpInvoker",
+    "multiprocess_executor",
 ]

--- a/lenskit/lenskit/parallel/config.py
+++ b/lenskit/lenskit/parallel/config.py
@@ -29,6 +29,7 @@ class ParallelConfig:
 
 
 def initialize(
+    config: ParallelConfig | None = None,
     *,
     processes: int | None = None,
     threads: int | None = None,
@@ -66,7 +67,10 @@ def initialize(
     # our parallel computation doesn't work with FD sharing
     torch.multiprocessing.set_sharing_strategy("file_system")
 
-    _config = _resolve_parallel_config(processes, threads, backend_threads, child_threads)
+    if config is None:
+        _config = _resolve_parallel_config(processes, threads, backend_threads, child_threads)
+    else:
+        _config = config
     _log.debug("configuring for parallelism: %s", _config)
 
     threadpool_limits(_config.backend_threads, "blas")

--- a/lenskit/lenskit/parallel/invoker.py
+++ b/lenskit/lenskit/parallel/invoker.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Generic, Iterable, Iterator, Optional, TypeAlias, TypeVar
 
-from .config import ensure_parallel_init, get_parallel_config
+from .config import ParallelConfig, ensure_parallel_init, get_parallel_config
 
 M = TypeVar("M")
 A = TypeVar("A")
@@ -22,24 +22,22 @@ def invoker(
     model: M,
     func: InvokeOp[M, A, R],
     n_jobs: Optional[int] = None,
+    *,
+    worker_parallel: ParallelConfig | None = None,
 ) -> ModelOpInvoker[A, R]:
     """
     Get an appropriate invoker for performing operations on ``model``.
 
     Args:
-        model: The model object on which to perform operations.
-        func: The function to call.  The function must be pickleable.
+        model:
+            The model object on which to perform operations.
+        func:
+            The function to call.  The function must be pickleable.
         n_jobs:
             The number of processes to use for parallel operations.  If ``None``, will
             call :func:`proc_count` with a maximum default process count of 4.
-        progress:
-            A progress bar to use to report status. It should have the following states:
-
-            * dispatched
-            * in-progress
-            * finished
-
-            One can be created with :func:`invoke_progress`
+        worker_parallel:
+            A parallel configuration for subprocess workers.
 
     Returns:
         ModelOpInvoker:
@@ -56,7 +54,7 @@ def invoker(
     else:
         from .pool import ProcessPoolOpInvoker
 
-        return ProcessPoolOpInvoker(model, func, n_jobs)
+        return ProcessPoolOpInvoker(model, func, n_jobs, worker_parallel=worker_parallel)
 
 
 class ModelOpInvoker(ABC, Generic[A, R]):

--- a/lenskit/lenskit/parallel/pool.py
+++ b/lenskit/lenskit/parallel/pool.py
@@ -46,11 +46,18 @@ class ProcessPoolOpInvoker(ModelOpInvoker[A, R], Generic[M, A, R]):
     manager: SharedMemoryManager
     pool: ProcessPoolExecutor
 
-    def __init__(self, model: M, func: InvokeOp[M, A, R], n_jobs: int):
+    def __init__(
+        self,
+        model: M,
+        func: InvokeOp[M, A, R],
+        n_jobs: int,
+        worker_parallel: ParallelConfig | None = None,
+    ):
         log = _log.bind(n_jobs=n_jobs)
         log.debug("persisting function")
-        kid_tc = ParallelConfig(1, 1, get_parallel_config().child_threads, 1)
-        ctx = LenskitMPContext(kid_tc)
+        if worker_parallel is None:
+            worker_parallel = ParallelConfig(1, 1, get_parallel_config().child_threads, 1)
+        ctx = LenskitMPContext(worker_parallel)
 
         log.debug("initializing shared memory")
         self.manager = SharedMemoryManager()

--- a/lenskit/lenskit/parallel/worker.py
+++ b/lenskit/lenskit/parallel/worker.py
@@ -15,19 +15,12 @@ from typing import Any
 import structlog
 from typing_extensions import Generic
 
-from .config import initialize as init_parallel
 from .invoker import A, InvokeOp, M, R
 from .serialize import ModelData, shm_deserialize
 
 _log = structlog.get_logger(__name__)
 
-
 __work_context: WorkerData
-
-
-@dataclass(frozen=True)
-class WorkerConfig:
-    threads: int
 
 
 @dataclass(frozen=True)
@@ -36,11 +29,10 @@ class WorkerData(Generic[M, A, R]):
     model: M
 
 
-def initalize(cfg: WorkerConfig, ctx: ModelData) -> None:
+def initalize(ctx: ModelData) -> None:
     global __work_context, __progress
     proc = mp.current_process()
     log = _log.bind(pid=proc.pid, pname=proc.name)
-    init_parallel(processes=1, threads=1, backend_threads=cfg.threads, child_threads=1)
 
     warnings.filterwarnings("ignore", "Sparse CSR tensor support is in beta state", UserWarning)
 


### PR DESCRIPTION
This adds a `multiprocess_executor` to set up a general-purpose process pool executor with LensKit's logging, parallel configuration, etc. set up.