### PR TITLE
Support trace-level logging and allow subclasses of Task

### DIFF
--- a/lenskit/lenskit/logging/__init__.py
+++ b/lenskit/lenskit/logging/__init__.py
@@ -11,7 +11,15 @@ from .progress import Progress, item_progress, set_progress_impl
 from .tasks import Task
 from .tracing import TracingLogger
 
-__all__ = ["LoggingConfig", "Progress", "item_progress", "set_progress_impl", "Task"]
+__all__ = [
+    "LoggingConfig",
+    "Progress",
+    "item_progress",
+    "set_progress_impl",
+    "Task",
+    "get_logger",
+    "TracingLogger",
+]
 
 
 def get_logger(name: str | None = None, **kw: Any) -> TracingLogger:

--- a/lenskit/lenskit/logging/__init__.py
+++ b/lenskit/lenskit/logging/__init__.py
@@ -9,7 +9,6 @@ import structlog
 from .config import LoggingConfig
 from .progress import Progress, item_progress, set_progress_impl
 from .tasks import Task
-from .tracing import TracingLogger
 
 __all__ = [
     "LoggingConfig",
@@ -18,13 +17,18 @@ __all__ = [
     "set_progress_impl",
     "Task",
     "get_logger",
-    "TracingLogger",
+    "trace",
 ]
 
+get_logger = structlog.stdlib.get_logger
 
-def get_logger(name: str | None = None, **kw: Any) -> TracingLogger:
+
+def trace(logger: structlog.stdlib.BoundLogger, *args: Any, **kwargs: Any):
     """
-    Get a logger.  This is a wrapper around :func:`structlog.get_logger` with
-    the LensKit tracing logger type annotation.
+    Emit a trace-level message, if LensKit tracing is enabled.  Trace-level
+    messages are more fine-grained than debug-level messages, and you usually
+    don't want them.
     """
-    return structlog.get_logger(name, **kw)
+    meth = getattr(logger, "trace", None)
+    if meth is not None:
+        meth(*args, **kwargs)

--- a/lenskit/lenskit/logging/__init__.py
+++ b/lenskit/lenskit/logging/__init__.py
@@ -2,8 +2,21 @@
 Logging, progress, and resource records.
 """
 
+from typing import Any
+
+import structlog
+
 from .config import LoggingConfig
 from .progress import Progress, item_progress, set_progress_impl
 from .tasks import Task
+from .tracing import TracingLogger
 
 __all__ = ["LoggingConfig", "Progress", "item_progress", "set_progress_impl", "Task"]
+
+
+def get_logger(name: str | None = None, **kw: Any) -> TracingLogger:
+    """
+    Get a logger.  This is a wrapper around :func:`structlog.get_logger` with
+    the LensKit tracing logger type annotation.
+    """
+    return structlog.get_logger(name, **kw)

--- a/lenskit/lenskit/logging/_console.py
+++ b/lenskit/lenskit/logging/_console.py
@@ -27,7 +27,8 @@ class ConsoleHandler(Handler):
     def emit(self, record: LogRecord) -> None:
         try:
             fmt = self.format(record)
-            console.print(*self._decoder.decode(fmt))
+            print(fmt)
+            # console.print(*self._decoder.decode(fmt))
         except Exception:
             self.handleError(record)
 

--- a/lenskit/lenskit/logging/config.py
+++ b/lenskit/lenskit/logging/config.py
@@ -21,6 +21,7 @@ LVL_TRACE = 5
 CORE_PROCESSORS = [
     structlog.processors.add_log_level,
     structlog.stdlib.add_logger_name,
+    structlog.stdlib.PositionalArgumentsFormatter(),
     structlog.processors.MaybeTimeStamper(),
 ]
 

--- a/lenskit/lenskit/logging/config.py
+++ b/lenskit/lenskit/logging/config.py
@@ -77,6 +77,11 @@ class LoggingConfig:  # pragma: nocover
             ``verbose`` option is provided, rather than passing your verbose
             option to it, to allow the ``LK_LOG_LEVEL`` environment variable to
             apply in the absence of a configuration option.
+
+        Args:
+            verbose:
+                The level of verbosity.  Values of ``True`` or ``1`` turn on
+                ``DEBUG``-level logs, and ``2`` or greater turns on tracing.
         """
         if isinstance(verbose, int) and verbose > 1:
             self.level = LVL_TRACE

--- a/lenskit/lenskit/logging/tasks.py
+++ b/lenskit/lenskit/logging/tasks.py
@@ -119,9 +119,9 @@ class Task(BaseModel, extra="allow"):
     Peak PyTorch GPU memory usage in bytes.
     """
 
-    subtasks: Annotated[
-        list[Task], Field(default_factory=list), BeforeValidator(_dict_extract_values)
-    ]
+    subtasks: Annotated[list[Task], BeforeValidator(_dict_extract_values)] = Field(
+        default_factory=list
+    )
     """
     This task's subtasks.
     """
@@ -266,6 +266,7 @@ class Task(BaseModel, extra="allow"):
         """
         Add or update a subtask.
         """
+        _log.debug("adding subtask", task=task.model_dump())
         with self._lock:
             if self._subtask_index is None:
                 self._subtask_index = {t.task_id: t for t in self.subtasks}

--- a/lenskit/lenskit/logging/tasks.py
+++ b/lenskit/lenskit/logging/tasks.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any
 from uuid import UUID, uuid4
 
 import structlog
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, BeforeValidator, Field, SerializeAsAny
 
 from .resource import ResourceMeasurement, reset_linux_hwm
 
@@ -74,7 +74,7 @@ class Task(BaseModel, extra="allow"):
     """
     The task ID.
     """
-    parent_id: UUID | None = Field(default=None, frozen=True)
+    parent_id: UUID | None = None
     """
     The parent task ID.
     """
@@ -119,7 +119,7 @@ class Task(BaseModel, extra="allow"):
     Peak PyTorch GPU memory usage in bytes.
     """
 
-    subtasks: Annotated[list[Task], BeforeValidator(_dict_extract_values)] = Field(
+    subtasks: Annotated[list[SerializeAsAny[Task]], BeforeValidator(_dict_extract_values)] = Field(
         default_factory=list
     )
     """

--- a/lenskit/lenskit/logging/tracing.py
+++ b/lenskit/lenskit/logging/tracing.py
@@ -2,6 +2,8 @@
 Extended logger providing TRACE support.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Any
 
@@ -13,8 +15,20 @@ class TracingLogger(structlog.stdlib.BoundLogger):
     Class for LensKit loggers with trace-level logging support.
     """
 
+    def bind(self, **new_values: Any) -> TracingLogger:
+        return super().bind(**new_values)  # type: ignore[return-value]
+
+    def new(self, **new_values: Any) -> TracingLogger:
+        return super().new(**new_values)  # type: ignore[return-value]
+
     def trace(self, event: str | None, *args: Any, **kw: Any):
-        self._proxy_to_logger("trace", event, *args, **kw)
+        if args:
+            kw["positional_args"] = args
+        try:
+            args, kwargs = self._process_event("trace", event, kw)
+        except structlog.DropEvent:
+            return None
+        self._logger.debug(*args, **kwargs)
 
 
 def lenskit_filtering_logger(level: int):

--- a/lenskit/lenskit/logging/tracing.py
+++ b/lenskit/lenskit/logging/tracing.py
@@ -1,0 +1,32 @@
+"""
+Extended logger providing TRACE support.
+"""
+
+import logging
+from typing import Any
+
+import structlog
+
+
+class TracingLogger(structlog.stdlib.BoundLogger):
+    """
+    Class for LensKit loggers with trace-level logging support.
+    """
+
+    def trace(self, event: str | None, *args: Any, **kw: Any):
+        self._proxy_to_logger("trace", event, *args, **kw)
+
+
+def lenskit_filtering_logger(level: int):
+    """
+    No-op filtering logger.
+    """
+
+    if level < logging.DEBUG:
+        return TracingLogger
+
+    def trace(self, event: str | None, *args: Any, **kw: Any):
+        pass
+
+    base = structlog.make_filtering_bound_logger(level)
+    return type(f"LensKitLoggerFilter{level}", (base,), {"trace": trace})

--- a/lenskit/lenskit/logging/worker.py
+++ b/lenskit/lenskit/logging/worker.py
@@ -25,6 +25,7 @@ from .config import CORE_PROCESSORS, active_logging_config, log_warning
 from .monitor import get_monitor
 from .processors import add_process_info
 from .tasks import Task
+from .tracing import lenskit_filtering_logger
 
 _active_context: WorkerContext | None = None
 _log = structlog.stdlib.get_logger(__name__)
@@ -90,7 +91,7 @@ class WorkerContext:
             [add_process_info]
             + CORE_PROCESSORS
             + [structlog.processors.ExceptionPrettyPrinter(), self._log_handler.send_structlog],
-            wrapper_class=structlog.make_filtering_bound_logger(self.config.level),
+            wrapper_class=lenskit_filtering_logger(self.config.level),
             logger_factory=structlog.stdlib.LoggerFactory(),
             cache_logger_on_first_use=False,
         )


### PR DESCRIPTION
The primary contribution of this PR is to add support for trace-level logging, with a custom logger subclass that supports tracing.

It also adds the annotation needed to allow subtasks to be subclasses of `Task`.