### PR TITLE
Rename scorers to consistently be called 'Scorer'

### DIFF
--- a/docs/guide/GettingStarted.ipynb
+++ b/docs/guide/GettingStarted.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lenskit.als import BiasedMF\n",
+    "from lenskit.als import BiasedMFScorer\n",
     "from lenskit.batch import recommend\n",
     "from lenskit.data import ItemListCollection, UserIDKey, load_movielens\n",
     "from lenskit.knn import ItemKNNScorer\n",
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "model_ii = ItemKNNScorer(20)\n",
-    "model_als = BiasedMF(50)"
+    "model_als = BiasedMFScorer(50)"
    ]
   },
   {
@@ -6145,7 +6145,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "dev-full",
    "language": "python",
    "name": "python3"
   },
@@ -6159,7 +6159,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/guide/pipeline.rst
+++ b/docs/guide/pipeline.rst
@@ -64,7 +64,7 @@ matrix factorization:
 
 .. code:: python
 
-    als = ImplicitMF(50)
+    als = ImplicitMFScorer(50)
     pipe = topn_pipeline(als)
 
 The :class:`RecPipelineBuilder` class provides a more flexible mechanism to
@@ -73,7 +73,7 @@ that class, do:
 
 .. code:: python
 
-    als = ImplicitMF(50)
+    als = ImplicitMFScorer(50)
     builder = RecPipelineBuilder()
     builder.scorer(als)
     pipe = builder.build('ALS')

--- a/docs/old/mf.rst
+++ b/docs/old/mf.rst
@@ -47,7 +47,7 @@ SciKit SVD
 This code implements a traditional SVD using scikit-learn.  It requires ``scikit-learn`` to
 be installed in order to function.
 
-.. autoclass:: BiasedSVD
+.. autoclass:: BiasedSVDScorer
     :show-inheritance:
     :members:
 

--- a/docs/old/mf.rst
+++ b/docs/old/mf.rst
@@ -31,11 +31,11 @@ LensKit provides alternating least squares implementations of matrix factorizati
 for explicit feedback data.  These implementations are parallelized with Numba, and perform
 best with the MKL from Conda.
 
-.. autoclass:: BiasedMF
+.. autoclass:: BiasedMFScorer
     :show-inheritance:
     :members:
 
-.. autoclass:: ImplicitMF
+.. autoclass:: ImplicitMFScorer
     :show-inheritance:
     :members:
 

--- a/docs/releases/2025.rst
+++ b/docs/releases/2025.rst
@@ -77,7 +77,7 @@ however, documented here.
   (:math:`1.75 \times 10^{-38}`).
 * The :mod:`implicit` bridge algorithms no longer look at rating values when
   they are present.
-* Bias is no longer optional for :class:`~lenksit.als.BiasedMF` and
+* Bias is no longer optional for :class:`~lenksit.als.BiasedMFScorer` and
   :class:`~lenskit.funksvd.FunkSVD`; both are inherently biased models, and
   FunkSVD is not commonly used.
 

--- a/lenskit-funksvd/lenskit/funksvd.py
+++ b/lenskit-funksvd/lenskit/funksvd.py
@@ -198,7 +198,7 @@ def _align_add_bias(bias, index, keys, series):
     return bias, series
 
 
-class FunkSVD(Component, Trainable):
+class FunkSVDScorer(Component, Trainable):
     """
     Algorithm class implementing FunkSVD matrix factorization.  FunkSVD is a regularized
     biased matrix factorization technique trained with featurewise stochastic gradient

--- a/lenskit-funksvd/tests/test_funksvd.py
+++ b/lenskit-funksvd/tests/test_funksvd.py
@@ -15,7 +15,7 @@ from pytest import approx, mark
 
 from lenskit.data import Dataset, ItemList, from_interactions_df
 from lenskit.data.bulk import dict_to_df, iter_item_lists
-from lenskit.funksvd import FunkSVD
+from lenskit.funksvd import FunkSVDScorer
 from lenskit.metrics import call_metric, quick_measure_model
 from lenskit.util.test import ml_100k, ml_ds, wantjit  # noqa: F401
 
@@ -28,7 +28,7 @@ simple_ds = from_interactions_df(simple_df)
 
 
 def test_fsvd_basic_build():
-    algo = FunkSVD(20, iterations=20)
+    algo = FunkSVDScorer(20, iterations=20)
     algo.train(simple_ds)
 
     assert algo.bias_ is not None
@@ -38,7 +38,7 @@ def test_fsvd_basic_build():
 
 
 def test_fsvd_clamp_build():
-    algo = FunkSVD(20, iterations=20, range=(1, 5))
+    algo = FunkSVDScorer(20, iterations=20, range=(1, 5))
     algo.train(simple_ds)
 
     assert algo.bias_ is not None
@@ -48,7 +48,7 @@ def test_fsvd_clamp_build():
 
 
 def test_fsvd_predict_basic():
-    algo = FunkSVD(20, iterations=20)
+    algo = FunkSVDScorer(20, iterations=20)
     algo.train(simple_ds)
 
     assert algo.bias_ is not None
@@ -66,7 +66,7 @@ def test_fsvd_predict_basic():
 
 
 def test_fsvd_predict_clamp():
-    algo = FunkSVD(20, iterations=20, range=(1, 5))
+    algo = FunkSVDScorer(20, iterations=20, range=(1, 5))
     algo.train(simple_ds)
 
     assert algo.bias_ is not None
@@ -84,7 +84,7 @@ def test_fsvd_predict_clamp():
 
 
 def test_fsvd_predict_bad_item():
-    algo = FunkSVD(20, iterations=20)
+    algo = FunkSVDScorer(20, iterations=20)
     algo.train(simple_ds)
 
     assert algo.bias_ is not None
@@ -101,7 +101,7 @@ def test_fsvd_predict_bad_item():
 
 
 def test_fsvd_predict_bad_item_clamp():
-    algo = FunkSVD(20, iterations=20, range=(1, 5))
+    algo = FunkSVDScorer(20, iterations=20, range=(1, 5))
     algo.train(simple_ds)
 
     assert algo.bias_ is not None
@@ -118,7 +118,7 @@ def test_fsvd_predict_bad_item_clamp():
 
 
 def test_fsvd_predict_bad_user():
-    algo = FunkSVD(20, iterations=20)
+    algo = FunkSVDScorer(20, iterations=20)
     algo.train(simple_ds)
 
     assert algo.bias_ is not None
@@ -137,7 +137,7 @@ def test_fsvd_predict_bad_user():
 @wantjit
 @mark.slow
 def test_fsvd_save_load(ml_ds: Dataset):
-    original = FunkSVD(20, iterations=20)
+    original = FunkSVDScorer(20, iterations=20)
     original.train(ml_ds)
 
     assert original.bias_ is not None
@@ -163,7 +163,7 @@ def test_fsvd_save_load(ml_ds: Dataset):
 @wantjit
 @mark.slow
 def test_fsvd_known_preds(ml_ds: Dataset):
-    algo = FunkSVD(15, iterations=125, lrate=0.001)
+    algo = FunkSVDScorer(15, iterations=125, lrate=0.001)
     _log.info("training %s on ml data", algo)
     algo.train(ml_ds)
 
@@ -195,7 +195,7 @@ def test_fsvd_known_preds(ml_ds: Dataset):
 @mark.eval
 def test_fsvd_batch_accuracy(ml_100k: pd.DataFrame):
     ds = from_interactions_df(ml_100k)
-    results = quick_measure_model(FunkSVD(25, 125, damping=10), ds, predicts_ratings=True)
+    results = quick_measure_model(FunkSVDScorer(25, 125, damping=10), ds, predicts_ratings=True)
 
     assert results.global_metrics().loc["MAE"] == approx(0.74, abs=0.025)
     assert results.list_summary().loc["RMSE", "mean"] == approx(0.92, abs=0.05)

--- a/lenskit-hpf/lenskit/hpf.py
+++ b/lenskit-hpf/lenskit/hpf.py
@@ -16,7 +16,7 @@ from lenskit.pipeline import Component, Trainable
 _logger = logging.getLogger(__name__)
 
 
-class HPF(Component, Trainable):
+class HPFScorer(Component, Trainable):
     """
     Hierarchical Poisson factorization, provided by
     `hpfrec <https://hpfrec.readthedocs.io/en/latest/>`_.

--- a/lenskit-hpf/tests/test_hpf.py
+++ b/lenskit-hpf/tests/test_hpf.py
@@ -27,7 +27,7 @@ simple_df = pd.DataFrame(
 
 @mark.slow
 def test_hpf_train_large(tmp_path, ml_ratings):
-    algo = hpf.HPF(20)
+    algo = hpf.HPFScorer(20)
     ratings = ml_ratings.assign(rating=ml_ratings.rating + 0.5)
     ds = from_interactions_df(ratings)
     algo.train(ds)
@@ -56,7 +56,7 @@ def test_hpf_train_large(tmp_path, ml_ratings):
 
 @mark.slow
 def test_hpf_train_binary(tmp_path, ml_ratings):
-    algo = hpf.HPF(20)
+    algo = hpf.HPFScorer(20)
     ratings = ml_ratings.drop(columns=["timestamp", "rating"])
     ds = from_interactions_df(ratings)
     algo.train(ds)

--- a/lenskit-sklearn/lenskit/sklearn/svd.py
+++ b/lenskit-sklearn/lenskit/sklearn/svd.py
@@ -29,7 +29,7 @@ except ImportError:
 _log = logging.getLogger(__name__)
 
 
-class BiasedSVD(Component, Trainable):
+class BiasedSVDScorer(Component, Trainable):
     """
     Biased matrix factorization for implicit feedback using SciKit-Learn's SVD
     solver (:class:`sklearn.decomposition.TruncatedSVD`).  It operates by first

--- a/lenskit-sklearn/lenskit/sklearn/svd.py
+++ b/lenskit-sklearn/lenskit/sklearn/svd.py
@@ -36,7 +36,7 @@ class BiasedSVD(Component, Trainable):
     computing the bias, then computing the SVD of the bias residuals.
 
     You'll generally want one of the iterative SVD implementations such as
-    :class:`lennskit.algorithms.als.BiasedMF`; this is here primarily as an
+    :class:`lennskit.algorithms.als.BiasedMFScorer`; this is here primarily as an
     example and for cases where you want to evaluate a pure SVD implementation.
     """
 

--- a/lenskit-sklearn/tests/test_svd.py
+++ b/lenskit-sklearn/tests/test_svd.py
@@ -28,7 +28,7 @@ need_skl = mark.skipif(not svd.SKL_AVAILABLE, reason="scikit-learn not installed
 
 @need_skl
 def test_svd_basic_build():
-    algo = svd.BiasedSVD(2)
+    algo = svd.BiasedSVDScorer(2)
     algo.train(simple_ds)
 
     assert algo.user_components_.shape == (3, 2)
@@ -37,7 +37,7 @@ def test_svd_basic_build():
 @need_skl
 def test_svd_predict_basic():
     _log.info("SVD input data:\n%s", simple_df)
-    algo = svd.BiasedSVD(2, damping=0)
+    algo = svd.BiasedSVDScorer(2, damping=0)
     algo.train(simple_ds)
     _log.info("user means:\n%s", str(algo.bias_.user_biases))
     _log.info("item means:\n%s", str(algo.bias_.item_biases))
@@ -54,7 +54,7 @@ def test_svd_predict_basic():
 
 @need_skl
 def test_svd_predict_bad_item():
-    algo = svd.BiasedSVD(2)
+    algo = svd.BiasedSVDScorer(2)
     algo.train(simple_ds)
 
     preds = algo(10, ItemList([4]))
@@ -67,7 +67,7 @@ def test_svd_predict_bad_item():
 
 @need_skl
 def test_svd_predict_bad_user():
-    algo = svd.BiasedSVD(2)
+    algo = svd.BiasedSVDScorer(2)
     algo.train(simple_ds)
 
     preds = algo(50, ItemList([3]))
@@ -81,7 +81,7 @@ def test_svd_predict_bad_user():
 @need_skl
 @mark.slow
 def test_svd_save_load(ml_ds: Dataset):
-    original = svd.BiasedSVD(20)
+    original = svd.BiasedSVDScorer(20)
     original.train(ml_ds)
 
     mod = pickle.dumps(original)
@@ -99,7 +99,7 @@ def test_svd_save_load(ml_ds: Dataset):
 @mark.eval
 def test_svd_batch_accuracy(rng, ml_100k: pd.DataFrame):
     data = from_interactions_df(ml_100k)
-    svd_algo = svd.BiasedSVD(25, damping=10)
+    svd_algo = svd.BiasedSVDScorer(25, damping=10)
     results = quick_measure_model(svd_algo, data, predicts_ratings=True, rng=rng)
 
     assert results.global_metrics()["MAE"] == approx(0.71, abs=0.025)

--- a/lenskit/lenskit/als/__init__.py
+++ b/lenskit/lenskit/als/__init__.py
@@ -9,7 +9,7 @@ LensKit ALS implementations.
 """
 
 from ._common import ALSBase
-from ._explicit import BiasedMF
-from ._implicit import ImplicitMF
+from ._explicit import BiasedMFScorer
+from ._implicit import ImplicitMFScorer
 
-__all__ = ["ALSBase", "BiasedMF", "ImplicitMF"]
+__all__ = ["ALSBase", "BiasedMFScorer", "ImplicitMFScorer"]

--- a/lenskit/lenskit/als/_explicit.py
+++ b/lenskit/lenskit/als/_explicit.py
@@ -25,7 +25,7 @@ from ._common import ALSBase, TrainContext, TrainingData
 _log = logging.getLogger(__name__)
 
 
-class BiasedMF(ALSBase):
+class BiasedMFScorer(ALSBase):
     """
     Biased matrix factorization trained with alternating least squares
     :cite:p:`zhouLargeScaleParallelCollaborative2008`.  This is a
@@ -143,7 +143,7 @@ class BiasedMF(ALSBase):
         return ItemList(items, scores=scores)
 
     def __str__(self):
-        return "als.BiasedMF(features={}, regularization={})".format(self.features, self.reg)
+        return "als.BiasedMFScorer(features={}, regularization={})".format(self.features, self.reg)
 
 
 @torch.jit.script

--- a/lenskit/lenskit/als/_implicit.py
+++ b/lenskit/lenskit/als/_implicit.py
@@ -24,13 +24,13 @@ from ._common import ALSBase, TrainContext, TrainingData
 _log = logging.getLogger(__name__)
 
 
-class ImplicitMF(ALSBase):
+class ImplicitMFScorer(ALSBase):
     """
     Implicit matrix factorization trained with alternating least squares
-    :cite:p:`hu:implicit-mf`.  This algorithm outputs
-    'predictions', but they are not on a meaningful scale.  If its input data
-    contains ``rating`` values, these will be used as the 'confidence' values;
-    otherwise, confidence will be 1 for every rated item.
+    :cite:p:`hu:implicit-mf`.  This algorithm outputs 'predictions', but they
+    are not on a meaningful scale.  If its input data contains ``rating``
+    values, these will be used as the 'confidence' values; otherwise, confidence
+    will be 1 for every rated item.
 
     See the base class :class:`.MFPredictor` for documentation on the estimated
     parameters you can extract from a trained model.
@@ -40,7 +40,7 @@ class ImplicitMF(ALSBase):
     \\times n` matrix of all 1s.
 
     .. versionchanged:: 2025.1
-        ``ImplicitMF`` no longer supports multiple training methods. It always uses
+        ``ImplicitMFScorer`` no longer supports multiple training methods. It always uses
         Cholesky decomposition now.
 
     .. versionchanged:: 0.14
@@ -68,8 +68,8 @@ class ImplicitMF(ALSBase):
             used, and multipled by ``weight``; if ``False``, ImplicitMF treats
             every rated user-item pair as having a rating of 1.\
         save_user_feature:
-            Whether to save the user feature vector in the model, or recompute it at
-            scoring time.
+            Whether to save the user feature vector in the model, or recompute
+            it at scoring time.
         rng:
             Random number seed or generator.
     """
@@ -160,7 +160,7 @@ class ImplicitMF(ALSBase):
         return u_feat, None
 
     def __str__(self):
-        return "als.ImplicitMF(features={}, reg={}, w={})".format(
+        return "als.ImplicitMFScorer(features={}, reg={}, w={})".format(
             self.features, self.reg, self.weight
         )
 

--- a/lenskit/tests/models/test_als_implicit.py
+++ b/lenskit/tests/models/test_als_implicit.py
@@ -14,7 +14,7 @@ import torch
 from pytest import approx, mark
 
 import lenskit.util.test as lktu
-from lenskit.als import BiasedMFScorer
+from lenskit.als import ImplicitMFScorer
 from lenskit.data import Dataset, ItemList, RecQuery, from_interactions_df, load_movielens_df
 from lenskit.metrics import quick_measure_model
 from lenskit.pipeline import topn_pipeline
@@ -29,7 +29,7 @@ simple_dsr = from_interactions_df(simple_dfr)
 
 
 def test_als_basic_build():
-    algo = BiasedMFScorer(20, epochs=10)
+    algo = ImplicitMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     assert algo.users_ is not None
@@ -42,7 +42,7 @@ def test_als_basic_build():
 
 
 def test_als_predict_basic():
-    algo = BiasedMFScorer(20, epochs=10)
+    algo = ImplicitMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     preds = algo(query=10, items=ItemList([3]))
@@ -57,7 +57,7 @@ def test_als_predict_basic():
 
 def test_als_predict_basic_for_new_ratings():
     """Test ImplicitMF ability to support new ratings"""
-    algo = BiasedMFScorer(20, epochs=10)
+    algo = ImplicitMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     query = RecQuery(15, ItemList([1, 2]))
@@ -79,7 +79,7 @@ def test_als_predict_basic_for_new_user_with_new_ratings():
     u = 10
     i = 3
 
-    algo = BiasedMFScorer(20, epochs=10, use_ratings=True)
+    algo = ImplicitMFScorer(20, epochs=10, use_ratings=True)
     algo.train(simple_dsr)
 
     preds = algo(u, ItemList([i]))
@@ -107,7 +107,7 @@ def test_als_predict_for_new_users_with_new_ratings(rng: np.random.Generator, ml
     users = rng.choice(ml_ds.users.ids(), n_users)
     items = ItemList(rng.choice(ml_ds.items.ids(), n_items))
 
-    algo = BiasedMFScorer(20, epochs=10, use_ratings=False)
+    algo = ImplicitMFScorer(20, epochs=10, use_ratings=False)
     algo.train(ml_ds)
     assert algo.users_ is not None
     assert algo.user_features_ is not None
@@ -167,7 +167,7 @@ def test_als_recs_topn_for_new_users_with_new_ratings(
 
     users = rng.choice(ml_ds.users.ids(), n_users).tolist()
 
-    algo = BiasedMFScorer(20, epochs=10, use_ratings=True)
+    algo = ImplicitMFScorer(20, epochs=10, use_ratings=True)
     pipe = topn_pipeline(algo, n=10)
     pipe.train(ml_ds)
     assert algo.users_ is not None
@@ -210,7 +210,7 @@ def test_als_recs_topn_for_new_users_with_new_ratings(
 
 
 def test_als_predict_bad_item():
-    algo = BiasedMFScorer(20, epochs=10)
+    algo = ImplicitMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     preds = algo(10, ItemList([4]))
@@ -222,7 +222,7 @@ def test_als_predict_bad_item():
 
 
 def test_als_predict_bad_user():
-    algo = BiasedMFScorer(20, epochs=10)
+    algo = ImplicitMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     preds = algo(50, ItemList([3]))
@@ -238,7 +238,7 @@ def test_als_predict_no_user_features_basic(ml_ratings: pd.DataFrame, ml_ds: Dat
     u = np.random.choice(ml_ds.users.ids(), 1)[0]
     items = np.random.choice(ml_ds.items.ids(), 2)
 
-    algo = BiasedMFScorer(5, epochs=10)
+    algo = ImplicitMFScorer(5, epochs=10)
     algo.train(ml_ds)
     preds = algo(u, ItemList(items))
     preds = preds.scores("pandas", index="ids")
@@ -246,7 +246,7 @@ def test_als_predict_no_user_features_basic(ml_ratings: pd.DataFrame, ml_ds: Dat
 
     user_data = ml_ds.user_row(u)
 
-    algo_no_user_features = BiasedMFScorer(5, epochs=10, save_user_features=False)
+    algo_no_user_features = ImplicitMFScorer(5, epochs=10, save_user_features=False)
     algo_no_user_features.train(ml_ds)
     query = RecQuery(u, user_data)
     preds_no_user_features = algo_no_user_features(query, ItemList(items))
@@ -261,7 +261,7 @@ def test_als_predict_no_user_features_basic(ml_ratings: pd.DataFrame, ml_ds: Dat
 
 @lktu.wantjit
 def test_als_train_large(ml_ds: Dataset):
-    algo = BiasedMFScorer(20, epochs=20, use_ratings=False)
+    algo = ImplicitMFScorer(20, epochs=20, use_ratings=False)
     algo.train(ml_ds)
 
     assert algo.users_ is not None
@@ -274,7 +274,7 @@ def test_als_train_large(ml_ds: Dataset):
 
 def test_als_save_load(tmp_path, ml_ds: Dataset):
     "Test saving and loading ALS models, and regularized training."
-    algo = BiasedMFScorer(5, epochs=5, reg=(2, 1), use_ratings=False)
+    algo = ImplicitMFScorer(5, epochs=5, reg=(2, 1), use_ratings=False)
     algo.train(ml_ds)
     assert algo.users_ is not None
 
@@ -293,7 +293,7 @@ def test_als_save_load(tmp_path, ml_ds: Dataset):
 
 @lktu.wantjit
 def test_als_train_large_noratings(ml_ds: Dataset):
-    algo = BiasedMFScorer(20, epochs=20)
+    algo = ImplicitMFScorer(20, epochs=20)
     algo.train(ml_ds)
 
     assert algo.users_ is not None
@@ -306,7 +306,7 @@ def test_als_train_large_noratings(ml_ds: Dataset):
 
 @lktu.wantjit
 def test_als_train_large_ratings(ml_ds):
-    algo = BiasedMFScorer(20, epochs=20, use_ratings=True)
+    algo = ImplicitMFScorer(20, epochs=20, use_ratings=True)
     algo.train(ml_ds)
 
     assert algo.users_ is not None
@@ -321,7 +321,7 @@ def test_als_train_large_ratings(ml_ds):
 @mark.eval
 def test_als_implicit_batch_accuracy(ml_100k):
     ds = from_interactions_df(ml_100k)
-    results = quick_measure_model(BiasedMFScorer(25, epochs=20), ds)
+    results = quick_measure_model(ImplicitMFScorer(25, epochs=20), ds)
 
     ndcg = results.list_summary().loc["NDCG", "mean"]
     _log.info("nDCG for users is %.4f", ndcg)

--- a/lenskit/tests/models/test_als_implicit.py
+++ b/lenskit/tests/models/test_als_implicit.py
@@ -14,7 +14,7 @@ import torch
 from pytest import approx, mark
 
 import lenskit.util.test as lktu
-from lenskit.als import ImplicitMF
+from lenskit.als import BiasedMFScorer
 from lenskit.data import Dataset, ItemList, RecQuery, from_interactions_df, load_movielens_df
 from lenskit.metrics import quick_measure_model
 from lenskit.pipeline import topn_pipeline
@@ -29,7 +29,7 @@ simple_dsr = from_interactions_df(simple_dfr)
 
 
 def test_als_basic_build():
-    algo = ImplicitMF(20, epochs=10)
+    algo = BiasedMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     assert algo.users_ is not None
@@ -42,7 +42,7 @@ def test_als_basic_build():
 
 
 def test_als_predict_basic():
-    algo = ImplicitMF(20, epochs=10)
+    algo = BiasedMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     preds = algo(query=10, items=ItemList([3]))
@@ -57,7 +57,7 @@ def test_als_predict_basic():
 
 def test_als_predict_basic_for_new_ratings():
     """Test ImplicitMF ability to support new ratings"""
-    algo = ImplicitMF(20, epochs=10)
+    algo = BiasedMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     query = RecQuery(15, ItemList([1, 2]))
@@ -79,7 +79,7 @@ def test_als_predict_basic_for_new_user_with_new_ratings():
     u = 10
     i = 3
 
-    algo = ImplicitMF(20, epochs=10, use_ratings=True)
+    algo = BiasedMFScorer(20, epochs=10, use_ratings=True)
     algo.train(simple_dsr)
 
     preds = algo(u, ItemList([i]))
@@ -107,7 +107,7 @@ def test_als_predict_for_new_users_with_new_ratings(rng: np.random.Generator, ml
     users = rng.choice(ml_ds.users.ids(), n_users)
     items = ItemList(rng.choice(ml_ds.items.ids(), n_items))
 
-    algo = ImplicitMF(20, epochs=10, use_ratings=False)
+    algo = BiasedMFScorer(20, epochs=10, use_ratings=False)
     algo.train(ml_ds)
     assert algo.users_ is not None
     assert algo.user_features_ is not None
@@ -167,7 +167,7 @@ def test_als_recs_topn_for_new_users_with_new_ratings(
 
     users = rng.choice(ml_ds.users.ids(), n_users).tolist()
 
-    algo = ImplicitMF(20, epochs=10, use_ratings=True)
+    algo = BiasedMFScorer(20, epochs=10, use_ratings=True)
     pipe = topn_pipeline(algo, n=10)
     pipe.train(ml_ds)
     assert algo.users_ is not None
@@ -210,7 +210,7 @@ def test_als_recs_topn_for_new_users_with_new_ratings(
 
 
 def test_als_predict_bad_item():
-    algo = ImplicitMF(20, epochs=10)
+    algo = BiasedMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     preds = algo(10, ItemList([4]))
@@ -222,7 +222,7 @@ def test_als_predict_bad_item():
 
 
 def test_als_predict_bad_user():
-    algo = ImplicitMF(20, epochs=10)
+    algo = BiasedMFScorer(20, epochs=10)
     algo.train(simple_ds)
 
     preds = algo(50, ItemList([3]))
@@ -238,7 +238,7 @@ def test_als_predict_no_user_features_basic(ml_ratings: pd.DataFrame, ml_ds: Dat
     u = np.random.choice(ml_ds.users.ids(), 1)[0]
     items = np.random.choice(ml_ds.items.ids(), 2)
 
-    algo = ImplicitMF(5, epochs=10)
+    algo = BiasedMFScorer(5, epochs=10)
     algo.train(ml_ds)
     preds = algo(u, ItemList(items))
     preds = preds.scores("pandas", index="ids")
@@ -246,7 +246,7 @@ def test_als_predict_no_user_features_basic(ml_ratings: pd.DataFrame, ml_ds: Dat
 
     user_data = ml_ds.user_row(u)
 
-    algo_no_user_features = ImplicitMF(5, epochs=10, save_user_features=False)
+    algo_no_user_features = BiasedMFScorer(5, epochs=10, save_user_features=False)
     algo_no_user_features.train(ml_ds)
     query = RecQuery(u, user_data)
     preds_no_user_features = algo_no_user_features(query, ItemList(items))
@@ -261,7 +261,7 @@ def test_als_predict_no_user_features_basic(ml_ratings: pd.DataFrame, ml_ds: Dat
 
 @lktu.wantjit
 def test_als_train_large(ml_ds: Dataset):
-    algo = ImplicitMF(20, epochs=20, use_ratings=False)
+    algo = BiasedMFScorer(20, epochs=20, use_ratings=False)
     algo.train(ml_ds)
 
     assert algo.users_ is not None
@@ -274,7 +274,7 @@ def test_als_train_large(ml_ds: Dataset):
 
 def test_als_save_load(tmp_path, ml_ds: Dataset):
     "Test saving and loading ALS models, and regularized training."
-    algo = ImplicitMF(5, epochs=5, reg=(2, 1), use_ratings=False)
+    algo = BiasedMFScorer(5, epochs=5, reg=(2, 1), use_ratings=False)
     algo.train(ml_ds)
     assert algo.users_ is not None
 
@@ -293,7 +293,7 @@ def test_als_save_load(tmp_path, ml_ds: Dataset):
 
 @lktu.wantjit
 def test_als_train_large_noratings(ml_ds: Dataset):
-    algo = ImplicitMF(20, epochs=20)
+    algo = BiasedMFScorer(20, epochs=20)
     algo.train(ml_ds)
 
     assert algo.users_ is not None
@@ -306,7 +306,7 @@ def test_als_train_large_noratings(ml_ds: Dataset):
 
 @lktu.wantjit
 def test_als_train_large_ratings(ml_ds):
-    algo = ImplicitMF(20, epochs=20, use_ratings=True)
+    algo = BiasedMFScorer(20, epochs=20, use_ratings=True)
     algo.train(ml_ds)
 
     assert algo.users_ is not None
@@ -321,7 +321,7 @@ def test_als_train_large_ratings(ml_ds):
 @mark.eval
 def test_als_implicit_batch_accuracy(ml_100k):
     ds = from_interactions_df(ml_100k)
-    results = quick_measure_model(ImplicitMF(25, epochs=20), ds)
+    results = quick_measure_model(BiasedMFScorer(25, epochs=20), ds)
 
     ndcg = results.list_summary().loc["NDCG", "mean"]
     _log.info("nDCG for users is %.4f", ndcg)

--- a/lenskit/tests/utils/test_task_logging.py
+++ b/lenskit/tests/utils/test_task_logging.py
@@ -1,12 +1,12 @@
 from lenskit import batch
-from lenskit.als import ImplicitMF
+from lenskit.als import BiasedMFScorer
 from lenskit.data import Dataset
 from lenskit.logging.tasks import Task, TaskStatus
 from lenskit.pipeline import topn_pipeline
 
 
 def test_train_task(ml_ds: Dataset):
-    info = ImplicitMF(50, epochs=5)
+    info = BiasedMFScorer(50, epochs=5)
     pipe = topn_pipeline(info)
 
     with Task("train ImplicitMF", reset_hwm=True) as task:


### PR DESCRIPTION
This renames the ALS, SKLearn, and FunkSVD scoring models to be named `FooScorer`.