### PR TITLE
Accelerate item-item k-NN algorithms

### DIFF
--- a/lenskit/lenskit/knn/item.py
+++ b/lenskit/lenskit/knn/item.py
@@ -16,8 +16,8 @@ import warnings
 
 import numpy as np
 import torch
-from scipy.sparse import coo_array, csr_array
-from typing_extensions import Callable, Optional, TypeAlias, override
+from scipy.sparse import csr_array
+from typing_extensions import Optional, override
 
 from lenskit import util
 from lenskit.data import Dataset, FeedbackType, ItemList, QueryInput, RecQuery, Vocabulary
@@ -26,6 +26,7 @@ from lenskit.logging.progress import item_progress_handle, pbh_update
 from lenskit.math.sparse import normalize_sparse_rows, safe_spmv
 from lenskit.parallel import ensure_parallel_init
 from lenskit.pipeline import Component, Trainable
+from lenskit.util.torch import inference_mode
 
 _log = logging.getLogger(__name__)
 MAX_BLOCKS = 1024
@@ -39,6 +40,12 @@ class ItemKNNScorer(Component, Trainable):
     work well in the previous Java-based LensKit code :cite:p:`lenskit-java`. In
     explicit-feedback mode, its output is equivalent to that of the Java
     version.
+
+    .. note::
+
+        This component must be used with queries containing the user's history,
+        either directly in the input or by wiring its query input to the output of a
+        user history component (e.g., :class:`~lenskit.basic.UserTrainingHistoryLookup`).
 
     Args:
         nnbrs:
@@ -67,16 +74,14 @@ class ItemKNNScorer(Component, Trainable):
 
     items_: Vocabulary
     "Vocabulary of item IDs."
-    item_means_: torch.Tensor | None
+    item_means_: np.ndarray[int, np.dtype[np.float32]] | None
     "Mean rating for each known item."
-    item_counts_: torch.Tensor
+    item_counts_: np.ndarray[int, np.dtype[np.int32]]
     "Number of saved neighbors for each item."
-    sim_matrix_: torch.Tensor
+    sim_matrix_: csr_array
     "Similarity matrix (sparse CSR tensor)."
     users_: Vocabulary
     "Vocabulary of user IDs."
-    rating_matrix_: torch.Tensor
-    "Normalized rating matrix to look up user ratings at prediction time."
 
     def __init__(
         self,
@@ -112,6 +117,7 @@ class ItemKNNScorer(Component, Trainable):
         return hasattr(self, "items_")
 
     @override
+    @inference_mode
     def train(self, data: Dataset):
         """
         Train a model.
@@ -132,57 +138,56 @@ class ItemKNNScorer(Component, Trainable):
 
         _log.debug("[%s] beginning fit, memory use %s", self._timer, util.max_memory())
 
-        with torch.inference_mode():
-            field = "rating" if self.feedback == "explicit" else None
-            init_rmat = data.interaction_matrix("torch", field=field)
-            n_items = data.item_count
-            _log.info(
-                "[%s] made sparse matrix for %d items (%d ratings from %d users)",
-                self._timer,
-                n_items,
-                len(init_rmat.values()),
-                data.user_count,
-            )
-            _log.debug("[%s] made matrix, memory use %s", self._timer, util.max_memory())
+        field = "rating" if self.feedback == "explicit" else None
+        init_rmat = data.interaction_matrix("torch", field=field)
+        n_items = data.item_count
+        _log.info(
+            "[%s] made sparse matrix for %d items (%d ratings from %d users)",
+            self._timer,
+            n_items,
+            len(init_rmat.values()),
+            data.user_count,
+        )
+        _log.debug("[%s] made matrix, memory use %s", self._timer, util.max_memory())
 
-            # we operate on *transposed* rating matrix: items on the rows
-            rmat = init_rmat.transpose(0, 1).to_sparse_csr().to(torch.float64)
+        # we operate on *transposed* rating matrix: items on the rows
+        rmat = init_rmat.transpose(0, 1).to_sparse_csr().to(torch.float64)
 
-            if self.feedback == "explicit":
-                rmat, means = normalize_sparse_rows(rmat, "center")
-                if np.allclose(rmat.values(), 0.0):
-                    _log.warning("normalized ratings are zero, centering is not recommended")
-                    warnings.warn(
-                        "Ratings seem to have the same value, centering is not recommended.",
-                        DataWarning,
-                    )
-            else:
-                means = None
-            _log.debug("[%s] centered, memory use %s", self._timer, util.max_memory())
+        if self.feedback == "explicit":
+            rmat, means = normalize_sparse_rows(rmat, "center")
+            if np.allclose(rmat.values(), 0.0):
+                _log.warning("normalized ratings are zero, centering is not recommended")
+                warnings.warn(
+                    "Ratings seem to have the same value, centering is not recommended.",
+                    DataWarning,
+                )
+        else:
+            means = None
+        _log.debug("[%s] centered, memory use %s", self._timer, util.max_memory())
 
-            rmat, _norms = normalize_sparse_rows(rmat, "unit")
-            _log.debug("[%s] normalized, memory use %s", self._timer, util.max_memory())
+        rmat, _norms = normalize_sparse_rows(rmat, "unit")
+        _log.debug("[%s] normalized, memory use %s", self._timer, util.max_memory())
 
-            _log.info("[%s] computing similarity matrix", self._timer)
-            smat = self._compute_similarities(rmat)
-            _log.debug("[%s] computed, memory use %s", self._timer, util.max_memory())
+        _log.info("[%s] computing similarity matrix", self._timer)
+        smat = self._compute_similarities(rmat)
+        _log.debug("[%s] computed, memory use %s", self._timer, util.max_memory())
 
-            _log.info(
-                "[%s] got neighborhoods for %d of %d items",
-                self._timer,
-                np.sum(np.diff(smat.crow_indices()) > 0),
-                n_items,
-            )
+        _log.info(
+            "[%s] got neighborhoods for %d of %d items",
+            self._timer,
+            np.sum(np.diff(smat.crow_indices()) > 0),
+            n_items,
+        )
 
-            _log.info("[%s] computed %d neighbor pairs", self._timer, len(smat.col_indices()))
+        _log.info("[%s] computed %d neighbor pairs", self._timer, len(smat.col_indices()))
 
-            self.items_ = data.items
-            self.item_means_ = means
-            self.item_counts_ = torch.diff(smat.crow_indices())
-            self.sim_matrix_ = smat
-            self.users_ = data.users
-            self.rating_matrix_ = init_rmat
-            _log.debug("[%s] done, memory use %s", self._timer, util.max_memory())
+        self.items_ = data.items
+        self.item_means_ = means
+        self.item_counts_ = torch.diff(smat.crow_indices())
+        self.sim_matrix_ = smat
+        self.users_ = data.users
+        self.rating_matrix_ = init_rmat
+        _log.debug("[%s] done, memory use %s", self._timer, util.max_memory())
 
     def _compute_similarities(self, rmat: torch.Tensor):
         nitems, nusers = rmat.shape
@@ -195,26 +200,17 @@ class ItemKNNScorer(Component, Trainable):
         return smat.to(torch.float32)
 
     @override
+    @inference_mode
     def __call__(self, query: QueryInput, items: ItemList) -> ItemList:
         query = RecQuery.create(query)
         _log.debug("predicting %d items for user %s", len(items), query.user_id)
 
         ratings = query.user_items
-        if ratings is None:
-            if query.user_id is None:
-                warnings.warn(
-                    "cannot recommend without without either user ID or items", DataWarning
-                )
-                return ItemList(items, scores=np.nan)
-
-            upos = self.users_.number(query.user_id, missing=None)
-            if upos is None:
-                _log.debug("user %s missing, returning empty predictions", query.user_id)
-                return ItemList(items, scores=np.nan)
-            row = self.rating_matrix_[upos]  # type: ignore
-            ratings = ItemList(
-                item_nums=row.indices()[0], rating=row.values(), vocabulary=self.items_
-            )
+        if ratings is None or len(ratings) == 0:
+            if ratings is None:
+                warnings.warn("no user history, did you omit a history component?", DataWarning)
+            _log.debug("user has no history, returning")
+            return ItemList(items, scores=np.nan)
 
         # set up rating array
         # get rated item positions & limit to in-model items
@@ -225,17 +221,17 @@ class ItemKNNScorer(Component, Trainable):
         _log.debug("user %s: %d of %d rated items in model", query.user_id, n_valid, len(ratings))
 
         if self.feedback == "explicit":
-            ri_vals = ratings.field("rating", "torch")
+            ri_vals = ratings.field("rating", "numpy")
             if ri_vals is None:
                 raise RuntimeError("explicit-feedback scorer must have ratings")
-            ri_vals = ri_vals[ri_mask].to(torch.float64)
+            ri_vals = np.require(ri_vals[ri_mask], np.float32)
         else:
-            ri_vals = torch.full((n_valid,), 1.0, dtype=torch.float64)
+            ri_vals = np.full(n_valid, 1.0, dtype=np.float32)
 
         # mean-center the rating array
         if self.feedback == "explicit":
             assert self.item_means_ is not None
-            ri_vals -= self.item_means_[ri_vpos]
+            ri_vals -= self.item_means_[ri_vpos].numpy()
 
         model = csr_array(
             (
@@ -265,34 +261,36 @@ class ItemKNNScorer(Component, Trainable):
         tgt_slow = tgt_mask.copy()
         tgt_slow[tgt_mask] = ~fast
 
-        # ri_map = np.full(model.shape[1], -1, dtype=np.int32)
-        # ri_map[ri_vpos] = np.arange(ri_n, dtype=np.int32)
-        # ti_map = np.full(model.shape[1], -1, dtype=np.int32)
-        # ti_map[tgt_inums[tgt_mask]] = np.arange(tgt_n, dtype=np.int32)
-
-        # mask = ri_map[model.row] >= 0
-        # mask &= ti_map[model.col] >= 0
-        # model = csr_array(
-        #     (model.data[mask], (ti_map[model.col[mask]], ri_map[model.row[mask]])),
-        #     shape=(tgt_n, ri_n),
-        # )
-
-        scores = np.full(np.sum(tgt_mask).item(), np.nan, dtype=np.float32)
-        scores[tgt_fast] = model.T[scorable & fast, :] @ ri_vals
+        scores = np.full(len(items), np.nan, dtype=np.float32)
+        fast_mod = model[:, scorable & fast]
+        if self.feedback == "explicit":
+            scores[tgt_fast] = ri_vals @ fast_mod
+            scores[tgt_fast] /= fast_mod.sum(axis=0)
+        else:
+            scores[tgt_fast] = fast_mod.sum(axis=0)
 
         slow_mat = model.T[~fast, :]
         assert isinstance(slow_mat, csr_array)
-        rows = np.repeat(np.arange(slow_mat.shape[0], dtype=np.int32), np.diff(slow_mat.indptr))
-        order = np.lexsort([-slow_mat.data, rows])
-        ranks = np.arange(len(order), dtype=np.int32)
-        # compute per-row ranks
-        ranks = ranks[order] - rows
+        n_slow, _ = slow_mat.shape
+        if n_slow:
+            slow_mat = torch.sparse_csr_tensor(
+                crow_indices=slow_mat.indptr,
+                col_indices=slow_mat.indices,
+                values=slow_mat.data,
+                size=slow_mat.shape,
+            ).to_dense()
+            slow_trimmed, slow_inds = torch.topk(slow_mat, self.nnbrs)
+            assert slow_trimmed.shape == (n_slow, self.nnbrs)
+            if self.feedback == "explicit":
+                scores[tgt_slow] = torch.sum(
+                    slow_trimmed * torch.from_numpy(ri_vals)[slow_inds], axis=1
+                ).numpy()
+                scores[tgt_slow] /= torch.sum(slow_trimmed, axis=1).numpy()
+            else:
+                scores[tgt_slow] = torch.sum(slow_trimmed, axis=1).numpy()
 
-        s_mask = ranks < self.nnbrs
-        slow_trimmed = coo_array(
-            (slow_mat.data[s_mask], (rows[s_mask], slow_mat.indices[s_mask])), shape=slow_mat.shape
-        )
-        scores[tgt_slow] = slow_trimmed @ ri_vals
+        if self.feedback == "explicit":
+            scores[tgt_mask] += self.item_means_[ti_mask].numpy()
 
         _log.debug(
             "user %s: predicted for %d of %d items",
@@ -302,31 +300,6 @@ class ItemKNNScorer(Component, Trainable):
         )
 
         return ItemList(items, scores=scores)
-
-        # now compute the predictions
-        if self.feedback == "explicit":
-            sims = _predict_weighted_average(
-                self.sim_matrix_, (self.min_nbrs, self.nnbrs), ri_vals, ri_vpos
-            )
-            sims += self.item_means_
-        else:
-            sims = _predict_sum(self.sim_matrix_, (self.min_nbrs, self.nnbrs), ri_vals, ri_vpos)
-
-        # and prepare the output
-        scores = torch.full((len(items),), np.nan, dtype=sims.dtype)
-        out_nums = items.numbers("torch", vocabulary=self.items_, missing="negative")
-        out_good = out_nums >= 0
-        scores[out_good] = sims[out_nums[out_nums >= 0]]
-        results = ItemList(items, scores=scores)
-
-        _log.debug(
-            "user %s: predicted for %d of %d items",
-            query.user_id,
-            int(torch.isfinite(scores).sum()),
-            len(items),
-        )
-
-        return results
 
     def __str__(self):
         return "ItemItem(nnbrs={}, msize={})".format(self.nnbrs, self.save_nbrs)
@@ -427,172 +400,3 @@ def _sim_blocks(
         values=c_values,
         size=(nitems, nitems),
     )
-
-
-def _predict_weighted_average(
-    model: torch.Tensor,
-    nrange: tuple[int, int],
-    rate_v: torch.Tensor,
-    rated: torch.Tensor,
-) -> torch.Tensor:
-    "Weighted average prediction function"
-    nitems, _ni = model.shape
-    assert nitems == _ni
-    min_nbrs, max_nbrs = nrange
-
-    # we proceed rating-by-rating, and accumulate results
-    scores = torch.zeros(nitems)
-    t_sims = torch.zeros(nitems)
-    counts = torch.zeros(nitems, dtype=torch.int32)
-    # these store the similarities and values for neighbors, so we can un-count
-    nbr_sims = torch.empty((nitems, max_nbrs))
-    nbr_vals = torch.empty((nitems, max_nbrs))
-    # and this stores the smallest similarity so far for each item
-    nbr_min = torch.full((nitems,), torch.finfo().max)
-
-    for i, iidx in enumerate(rated):
-        row = model[int(iidx)]
-        row_is = row.indices()[0]
-        row_vs = row.values()
-        assert row_is.shape == row_vs.shape
-
-        row_avs = torch.abs(row_vs)
-        fast = counts[row_is] < max_nbrs
-
-        # save the fast-path items
-        if torch.any(fast):
-            ris_fast = row_is[fast]
-            vs_fast = row_vs[fast]
-            avs_fast = row_avs[fast]
-            vals_fast = vs_fast * rate_v[i]
-            nbr_sims[ris_fast, counts[ris_fast]] = vs_fast
-            nbr_vals[ris_fast, counts[ris_fast]] = vals_fast
-            counts[ris_fast] += 1
-            t_sims[ris_fast] += avs_fast
-            scores[ris_fast] += vals_fast
-            nbr_min[ris_fast] = torch.minimum(nbr_min[ris_fast], vs_fast)
-
-        # skip early if we're done
-        if torch.all(fast):
-            continue
-
-        # now we have the slow-path items
-        slow = torch.logical_not(fast)
-        ris_slow = row_is[slow]
-        rvs_slow = row_vs[slow]
-        # which slow items might actually need an update?
-        exc = rvs_slow > nbr_min[ris_slow]
-        if not torch.any(exc):
-            continue
-
-        ris_slow = ris_slow[exc]
-        rvs_slow = rvs_slow[exc]
-
-        # this is brute-force linear search for simplicity right now
-        # for each, find the neighbor that's the smallest:
-        min_sims, mins = torch.min(nbr_sims[ris_slow], dim=1)
-        assert torch.all(min_sims < rvs_slow)
-
-        # now we need to update values: add in new and remove old
-        min_vals = nbr_vals[ris_slow, mins]
-        ravs_slow = row_avs[slow][exc]
-        slow_vals = rvs_slow * rate_v[i]
-        t_sims[ris_slow] += ravs_slow - min_sims.abs()
-        scores[ris_slow] += slow_vals - min_vals
-        # and save
-        nbr_sims[ris_slow, mins] = ravs_slow
-        nbr_vals[ris_slow, mins] = slow_vals
-        # and now we need to update the saved minimums
-        nm_sims, _nm_is = torch.min(nbr_sims[ris_slow], dim=1)
-        nbr_min[ris_slow] = nm_sims
-
-    # compute averages for items that pass match the threshold
-    mask = counts >= min_nbrs
-    scores[mask] /= t_sims[mask]
-    scores[torch.logical_not(mask)] = torch.nan
-
-    return scores
-
-
-def _predict_sum(
-    model: torch.Tensor,
-    nrange: tuple[int, int],
-    rate_v: torch.Tensor,
-    rated: torch.Tensor,
-) -> torch.Tensor:
-    "Sum-of-similarities prediction function"
-    nitems, _ni = model.shape
-    assert nitems == _ni
-    min_nbrs, max_nbrs = nrange
-    _msg(logging.DEBUG, f"sum-scoring with {len(rated)} items")
-
-    # we proceed rating-by-rating, and accumulate results
-    t_sims = torch.zeros(nitems)
-    counts = torch.zeros(nitems, dtype=torch.int32)
-    nbr_sims = torch.zeros((nitems, max_nbrs))
-    # and this stores the smallest similarity so far for each item
-    nbr_min = torch.full((nitems,), torch.finfo().max)
-
-    for i, iidx in enumerate(rated):
-        iidx = int(iidx)
-        row = model[iidx]
-        row_is = row.indices()[0]
-        row_vs = row.values()
-        assert row_is.shape == row_vs.shape
-
-        fast = counts[row_is] < max_nbrs
-
-        # save the fast-path items
-        if torch.any(fast):
-            ris_fast = row_is[fast]
-            vs_fast = row_vs[fast]
-            nbr_sims[ris_fast, counts[ris_fast]] = vs_fast
-            counts[ris_fast] += 1
-            t_sims[ris_fast] += vs_fast
-            nbr_min[ris_fast] = torch.minimum(nbr_min[ris_fast], vs_fast)
-
-        # skip early if we're done
-        if torch.all(fast):
-            continue
-
-        # now we have the slow-path items
-        slow = torch.logical_not(fast)
-        ris_slow = row_is[slow]
-        rvs_slow = row_vs[slow]
-        # which slow items might actually need an update?
-        exc = rvs_slow > nbr_min[ris_slow]
-        if not torch.any(exc):
-            continue
-
-        ris_slow = ris_slow[exc]
-        rvs_slow = rvs_slow[exc]
-
-        # this is brute-force linear search for simplicity right now
-        # for each, find the neighbor that's the smallest:
-        min_sims, mins = torch.min(nbr_sims[ris_slow], dim=1)
-
-        # now we need to update values: add in new and remove old
-        # anywhere our new neighbor is grater than smallest, replace smallest
-        t_sims[ris_slow] -= min_sims
-        t_sims[ris_slow] += rvs_slow
-        # and save
-        nbr_sims[ris_slow, mins] = rvs_slow
-        # save the minimums
-        nm_sims, _nm_is = torch.min(nbr_sims[ris_slow], dim=1)
-        nbr_min[ris_slow] = nm_sims
-
-    # compute averages for items that pass match the threshold
-    t_sims[counts < min_nbrs] = torch.nan
-
-    return t_sims
-
-
-AggFun: TypeAlias = Callable[
-    [
-        torch.Tensor,
-        tuple[int, int],
-        torch.Tensor,
-        torch.Tensor,
-    ],
-    torch.Tensor,
-]

--- a/lenskit/lenskit/util/torch.py
+++ b/lenskit/lenskit/util/torch.py
@@ -1,0 +1,20 @@
+"""
+PyTorch utility functions.
+"""
+
+import functools
+
+import torch
+
+
+def inference_mode(func):
+    """
+    Function decorator that puts PyTorch in inference mode.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with torch.inference_mode():
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/lenskit/tests/models/test_knn_item_item.py
+++ b/lenskit/tests/models/test_knn_item_item.py
@@ -25,6 +25,7 @@ from lenskit.data.bulk import dict_to_df, iter_item_lists
 from lenskit.diagnostics import ConfigWarning, DataWarning
 from lenskit.knn.item import ItemKNNScorer
 from lenskit.metrics import MAE, RBP, RMSE, RecipRank, RunAnalysis, call_metric, quick_measure_model
+from lenskit.operations import score
 from lenskit.pipeline import RecPipelineBuilder, topn_pipeline
 from lenskit.splitting import SampleFrac, crossfold_users
 from lenskit.testing import BasicComponentTests, ScorerTests, wantjit
@@ -456,8 +457,9 @@ def test_ii_known_preds(ml_ds):
     from lenskit import batch
 
     iknn = ItemKNNScorer(20, min_sim=1.0e-6)
+    pipe = topn_pipeline(iknn)
     _log.info("training %s on ml data", iknn)
-    iknn.train(ml_ds)
+    pipe.train(ml_ds)
     _log.info("model means: %s", iknn.item_means_)
 
     dir = Path(__file__).parent
@@ -466,7 +468,7 @@ def test_ii_known_preds(ml_ds):
     known_preds = pd.read_csv(str(pred_file))
 
     preds = {
-        user: iknn(user, ItemList(kps, prediction=False))
+        user: score(pipe, query=user, items=ItemList(kps, prediction=False))
         for (user, kps) in iter_item_lists(known_preds)
     }
     preds = dict_to_df(preds)


### PR DESCRIPTION
This significantly speeds up the item-item k-NN algorithm's scoring performance (by up to an order of magnitude).

It also removes the history lookup logic, so the k-NN scorer needs to be used with a history lookup component.