### PR TITLE
Speed up popularity scoring and top-N ranking

### DIFF
--- a/lenskit/lenskit/basic/popularity.py
+++ b/lenskit/lenskit/basic/popularity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 
@@ -5,7 +7,7 @@ import numpy as np
 import pandas as pd
 from typing_extensions import override
 
-from lenskit.data import Dataset, ItemList
+from lenskit.data import Dataset, ItemList, Vocabulary
 from lenskit.pipeline import Component, Trainable
 
 _log = logging.getLogger(__name__)
@@ -34,7 +36,8 @@ class PopScorer(Component, Trainable):
 
     score_method: str
 
-    item_scores_: pd.Series
+    items_: Vocabulary
+    item_scores_: np.ndarray[int, np.dtype[np.float32]]
 
     def __init__(self, score_method: str = "quantile"):
         self.score_method = score_method
@@ -46,9 +49,12 @@ class PopScorer(Component, Trainable):
     @override
     def train(self, data: Dataset):
         _log.info("counting item popularity")
+        self.items_ = data.items.copy()
         stats = data.item_stats()
-        scores = stats["count"]
-        self.item_scores_ = self._train_internal(scores)
+        scores = stats["count"].reindex(self.items_.ids())
+        self.item_scores_ = np.require(
+            self._train_internal(scores).reindex(self.items_.ids()).values, np.float32
+        )
 
         return self
 
@@ -71,7 +77,10 @@ class PopScorer(Component, Trainable):
         return scores
 
     def __call__(self, items: ItemList) -> ItemList:
-        scores = self.item_scores_.reindex(items.ids())
+        inums = items.numbers(vocabulary=self.items_, missing="negative")
+        mask = inums >= 0
+        scores = np.full(len(items), np.nan, np.float32)
+        scores[mask] = self.item_scores_[inums[mask]]
         return ItemList(items, scores=scores)
 
     def __str__(self):

--- a/lenskit/lenskit/basic/random.py
+++ b/lenskit/lenskit/basic/random.py
@@ -119,7 +119,7 @@ class SoftmaxRanker(Component):
         if n < 0 or n > N:
             n = N
 
-        keys = -np.log(rng.uniform(0, 1, N))
+        keys = np.log(rng.uniform(0, 1, N))
         keys /= np.maximum(scores[valid_mask], 1.0e-10)
 
         picked = argtopn(keys, n)

--- a/lenskit/lenskit/basic/random.py
+++ b/lenskit/lenskit/basic/random.py
@@ -3,6 +3,7 @@ import numpy as np
 from lenskit.data import ItemList
 from lenskit.data.query import QueryInput, RecQuery
 from lenskit.pipeline import Component
+from lenskit.stats import argtopk
 from lenskit.util.random import DerivableSeed, RNGFactory, derivable_rng
 
 
@@ -121,5 +122,5 @@ class SoftmaxRanker(Component):
         keys = -np.log(rng.uniform(0, 1, N))
         keys /= np.maximum(scores[valid_mask], 1.0e-10)
 
-        picked = np.argsort(keys)[:n]
+        picked = argtopk(keys, n)
         return ItemList(valid_items[picked], ordered=True)

--- a/lenskit/lenskit/basic/random.py
+++ b/lenskit/lenskit/basic/random.py
@@ -3,7 +3,7 @@ import numpy as np
 from lenskit.data import ItemList
 from lenskit.data.query import QueryInput, RecQuery
 from lenskit.pipeline import Component
-from lenskit.stats import argtopk
+from lenskit.stats import argtopn
 from lenskit.util.random import DerivableSeed, RNGFactory, derivable_rng
 
 
@@ -122,5 +122,5 @@ class SoftmaxRanker(Component):
         keys = -np.log(rng.uniform(0, 1, N))
         keys /= np.maximum(scores[valid_mask], 1.0e-10)
 
-        picked = argtopk(keys, n)
+        picked = argtopn(keys, n)
         return ItemList(valid_items[picked], ordered=True)

--- a/lenskit/lenskit/basic/topn.py
+++ b/lenskit/lenskit/basic/topn.py
@@ -6,7 +6,7 @@ import logging
 
 from lenskit.data import ItemList
 from lenskit.pipeline.components import Component
-from lenskit.stats import argtopk
+from lenskit.stats import argtopn
 
 _log = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class TopNRanker(Component):
         if scores is None:
             raise RuntimeError("input item list has no scores")
 
-        order = argtopk(scores, n)
+        order = argtopn(scores, n)
 
         # now we need to return in expected order
         result = items[order]

--- a/lenskit/lenskit/basic/topn.py
+++ b/lenskit/lenskit/basic/topn.py
@@ -64,12 +64,14 @@ class TopNRanker(Component):
         v_mask = ~np.isnan(scores)
         items = items[v_mask]
 
-        # order remaining scores
-        order = np.argsort(scores[v_mask])
-        if n >= 0 and n < len(order):
-            order = order[: -(n + 1) : -1]
+        vscores = -scores[v_mask]
+        if n >= 0 and n < len(vscores):
+            parts = np.argpartition(vscores, n)
+            top_scores = vscores[parts[:n]]
+            top_sort = np.argsort(top_scores)
+            order = parts[top_sort]
         else:
-            order = order[::-1]
+            order = np.argsort(vscores)
 
         # now we need to return in expected order
         result = items[order]

--- a/lenskit/lenskit/basic/topn.py
+++ b/lenskit/lenskit/basic/topn.py
@@ -4,10 +4,9 @@ Basic Top-*N* ranking.
 
 import logging
 
-import numpy as np
-
 from lenskit.data import ItemList
 from lenskit.pipeline.components import Component
+from lenskit.stats import argtopk
 
 _log = logging.getLogger(__name__)
 
@@ -60,18 +59,7 @@ class TopNRanker(Component):
         if scores is None:
             raise RuntimeError("input item list has no scores")
 
-        # find and filter out invalid scores
-        v_mask = ~np.isnan(scores)
-        items = items[v_mask]
-
-        vscores = -scores[v_mask]
-        if n >= 0 and n < len(vscores):
-            parts = np.argpartition(vscores, n)
-            top_scores = vscores[parts[:n]]
-            top_sort = np.argsort(top_scores)
-            order = parts[top_sort]
-        else:
-            order = np.argsort(vscores)
+        order = argtopk(scores, n)
 
         # now we need to return in expected order
         result = items[order]

--- a/lenskit/lenskit/parallel/__init__.py
+++ b/lenskit/lenskit/parallel/__init__.py
@@ -10,13 +10,14 @@ LensKit parallel computation support.
 
 from __future__ import annotations
 
-from .config import ensure_parallel_init, get_parallel_config, initialize
+from .config import effective_cpu_count, ensure_parallel_init, get_parallel_config, initialize
 from .invoker import ModelOpInvoker, invoker
 from .pool import multiprocess_executor
 
 __all__ = [
     "initialize",
     "get_parallel_config",
+    "effective_cpu_count",
     "ensure_parallel_init",
     "invoker",
     "ModelOpInvoker",

--- a/lenskit/lenskit/stats.py
+++ b/lenskit/lenskit/stats.py
@@ -55,13 +55,13 @@ def gini(xs: ArrayLike) -> float:
     return max(num / denom, 0)
 
 
-def argtopk(xs: ArrayLike, k: int) -> np.ndarray[int, np.dtype[np.int64]]:
+def argtopn(xs: ArrayLike, n: int) -> np.ndarray[int, np.dtype[np.int64]]:
     """
-    Compute the ordered positions of the top *k* elements.  Similar to
+    Compute the ordered positions of the top *n* elements.  Similar to
     :func:`torch.topk`, but works with NumPy arrays and only returns the
     indices.
     """
-    if k == 0:
+    if n == 0:
         return np.empty(0, np.int64)
 
     xs = np.asarray(xs)
@@ -72,12 +72,12 @@ def argtopk(xs: ArrayLike, k: int) -> np.ndarray[int, np.dtype[np.int64]]:
         mask = ~invalid
         vxs = xs[mask]
         remap = np.arange(N)[mask]
-        res = argtopk(vxs, k)
+        res = argtopn(vxs, n)
         return remap[res]
 
-    if k >= 0 and k < N:
-        parts = np.argpartition(-xs, k)
-        top_scores = xs[parts[:k]]
+    if n >= 0 and n < N:
+        parts = np.argpartition(-xs, n)
+        top_scores = xs[parts[:n]]
         top_sort = np.argsort(-top_scores)
         order = parts[top_sort]
     else:

--- a/lenskit/lenskit/stats.py
+++ b/lenskit/lenskit/stats.py
@@ -54,3 +54,33 @@ def gini(xs: ArrayLike) -> float:
             "Gini coefficient is not defined for non-positive totals", DataWarning, stacklevel=2
         )
     return num / denom
+
+
+def argtopk(xs: ArrayLike, k: int) -> np.ndarray[int, np.dtype[np.int64]]:
+    """
+    Compute the ordered positions of the top *k* elements.  Similar to
+    :func:`torch.topk`, but works with NumPy arrays and only returns the
+    indices.
+    """
+    xs = np.asarray(xs)
+
+    n = len(xs)
+    invalid = np.isnan(xs)
+    if np.any(invalid):
+        mask = ~invalid
+        vxs = xs[mask]
+        remap = np.arange(n)[mask]
+        res = argtopk(vxs, k)
+        return remap[res]
+
+    if k >= 0 and k < n:
+        parts = np.argpartition(xs, k)
+        assert not np.any(np.isnan(xs[parts]))
+        top_scores = xs[parts[:k]]
+        top_sort = np.argsort(top_scores)
+        order = parts[top_sort]
+        assert not np.any(np.isnan(xs[order]))
+    else:
+        order = np.argsort(xs)
+
+    return order[::-1]

--- a/lenskit/lenskit/stats.py
+++ b/lenskit/lenskit/stats.py
@@ -42,7 +42,6 @@ def gini(xs: ArrayLike) -> float:
         )
 
     n = len(xs)
-    # we don't actually need to sort — argsort will assign ranks to values
     xs = np.sort(xs)
     ranks = np.arange(1, n + 1, dtype=np.float64)
     ranks *= 2
@@ -53,7 +52,7 @@ def gini(xs: ArrayLike) -> float:
         warnings.warn(
             "Gini coefficient is not defined for non-positive totals", DataWarning, stacklevel=2
         )
-    return num / denom
+    return max(num / denom, 0)
 
 
 def argtopk(xs: ArrayLike, k: int) -> np.ndarray[int, np.dtype[np.int64]]:

--- a/lenskit/lenskit/stats.py
+++ b/lenskit/lenskit/stats.py
@@ -61,25 +61,26 @@ def argtopk(xs: ArrayLike, k: int) -> np.ndarray[int, np.dtype[np.int64]]:
     :func:`torch.topk`, but works with NumPy arrays and only returns the
     indices.
     """
+    if k == 0:
+        return np.empty(0, np.int64)
+
     xs = np.asarray(xs)
 
-    n = len(xs)
+    N = len(xs)
     invalid = np.isnan(xs)
     if np.any(invalid):
         mask = ~invalid
         vxs = xs[mask]
-        remap = np.arange(n)[mask]
+        remap = np.arange(N)[mask]
         res = argtopk(vxs, k)
         return remap[res]
 
-    if k >= 0 and k < n:
-        parts = np.argpartition(xs, k)
-        assert not np.any(np.isnan(xs[parts]))
+    if k >= 0 and k < N:
+        parts = np.argpartition(-xs, k)
         top_scores = xs[parts[:k]]
-        top_sort = np.argsort(top_scores)
+        top_sort = np.argsort(-top_scores)
         order = parts[top_sort]
-        assert not np.any(np.isnan(xs[order]))
     else:
-        order = np.argsort(xs)
+        order = np.argsort(-xs)
 
-    return order[::-1]
+    return order

--- a/lenskit/tests/basic/test_popular.py
+++ b/lenskit/tests/basic/test_popular.py
@@ -32,7 +32,7 @@ def test_popscore_quantile(rng, ml_ds):
     counts = counts.sort_values()
 
     winner = counts.index[-1]
-    assert pop.item_scores_.loc[winner] == 1.0
+    assert pop.item_scores_[ml_ds.items.number(winner)] == 1.0
 
 
 def test_popscore_rank(rng, ml_ds):
@@ -45,7 +45,7 @@ def test_popscore_rank(rng, ml_ds):
     assert pop.item_scores_.max() == len(counts)
 
     winner = counts.index[-1]
-    assert pop.item_scores_.loc[winner] == len(counts)
+    assert pop.item_scores_[ml_ds.items.number(winner)] == len(counts)
 
 
 def test_popscore_counts(rng, ml_ds):
@@ -54,7 +54,7 @@ def test_popscore_counts(rng, ml_ds):
 
     counts = ml_ds.item_stats()["count"]
 
-    scores, counts = pop.item_scores_.align(counts)
+    scores, counts = pd.Series(pop.item_scores_, index=pop.items_.ids()).align(counts)
     assert all(scores == counts)
 
     items = rng.choice(counts.index, 100)

--- a/lenskit/tests/basic/test_time_bounded_popular.py
+++ b/lenskit/tests/basic/test_time_bounded_popular.py
@@ -31,7 +31,7 @@ simple_ds = from_interactions_df(simple_df)
 def test_time_bounded_pop_score_quantile_one_day_window():
     algo = popularity.TimeBoundedPopScore(one_day_ago)
     algo.train(simple_ds)
-    assert algo.item_scores_.equals(pd.Series([1.0, 0.0, 0.0], index=[1, 2, 3]))
+    assert np.all(algo.item_scores_ == [1.0, 0.0, 0.0])
 
 
 def test_time_bounded_pop_score_quantile_one_day_window_call_interface():
@@ -46,7 +46,7 @@ def test_time_bounded_pop_score_quantile_one_day_window_call_interface():
 def test_time_bounded_pop_score_quantile_two_day_window():
     algo = popularity.TimeBoundedPopScore(two_days_ago)
     algo.train(simple_ds)
-    assert algo.item_scores_.equals(pd.Series([0.25, 1.0, 0.5], index=[1, 2, 3]))
+    assert np.all(algo.item_scores_ == pd.Series([0.25, 1.0, 0.5], index=[1, 2, 3]))
 
 
 def test_time_bounded_pop_score_fallbacks_to_pop_score_for_dataset_without_timestamps():
@@ -54,19 +54,19 @@ def test_time_bounded_pop_score_fallbacks_to_pop_score_for_dataset_without_times
 
     algo = popularity.TimeBoundedPopScore(one_day_ago)
     algo.train(ds)
-    assert algo.item_scores_.equals(pd.Series([0.25, 1.0, 0.5], index=[1, 2, 3]))
+    assert np.all(algo.item_scores_ == pd.Series([0.25, 1.0, 0.5], index=[1, 2, 3]))
 
 
 def test_time_bounded_pop_score_rank():
     algo = popularity.TimeBoundedPopScore(two_days_ago, "rank")
     algo.train(simple_ds)
-    assert algo.item_scores_.equals(pd.Series([1.5, 3.0, 1.5], index=[1, 2, 3]))
+    assert np.all(algo.item_scores_ == pd.Series([1.5, 3.0, 1.5], index=[1, 2, 3]))
 
 
 def test_time_bounded_pop_score_counts():
     algo = popularity.TimeBoundedPopScore(two_days_ago, "count")
     algo.train(simple_ds)
-    assert algo.item_scores_.equals(pd.Series([1, 2, 1], index=[1, 2, 3], dtype=np.int32))
+    assert np.all(algo.item_scores_ == pd.Series([1, 2, 1], index=[1, 2, 3], dtype=np.int32))
 
 
 def test_time_bounded_pop_score_save_load():

--- a/lenskit/tests/basic/test_topn.py
+++ b/lenskit/tests/basic/test_topn.py
@@ -89,8 +89,6 @@ def test_configured_truncation(n, items: ItemList):
     assert src_s is not None
     src_s = src_s[src_s.notna()]
 
-    rem_s = src_s[src_s.index.difference(rank_s.index)]
-
     # make sure the scores were preserved properly
     rank_s, src_s = rank_s.align(src_s, "left")
     assert not np.any(np.isnan(src_s))
@@ -100,8 +98,9 @@ def test_configured_truncation(n, items: ItemList):
     assert np.all(rank_s.diff()) >= 0
 
     # make sure it's the largest
-    if len(rem_s) > 0:
-        assert np.all(rank_s >= np.max(rem_s))
+    omitted = ~np.isin(items.ids(), ranked.ids())
+    if np.any(omitted) and np.any(~np.isnan(scores[omitted])):
+        assert np.all(rank_s >= np.nanmax(scores[omitted]))
 
 
 @given(st.integers(min_value=1, max_value=100), scored_lists())
@@ -128,8 +127,6 @@ def test_runtime_truncation(n, items: ItemList):
     assert src_s is not None
     src_s = src_s[src_s.notna()]
 
-    rem_s = src_s[src_s.index.difference(rank_s.index)]
-
     # make sure the scores were preserved properly
     rank_s, src_s = rank_s.align(src_s, "left")
     assert not np.any(np.isnan(src_s))
@@ -139,5 +136,6 @@ def test_runtime_truncation(n, items: ItemList):
     assert np.all(rank_s.diff()) >= 0
 
     # make sure it's the largest
-    if len(rem_s) > 0:
-        assert np.all(rank_s >= np.max(rem_s))
+    omitted = ~np.isin(items.ids(), ranked.ids())
+    if np.any(omitted) and np.any(~np.isnan(scores[omitted])):
+        assert np.all(rank_s >= np.nanmax(scores[omitted]))

--- a/lenskit/tests/math/test_argtopk.py
+++ b/lenskit/tests/math/test_argtopk.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+import hypothesis.extra.numpy as nph
+import hypothesis.strategies as st
+from hypothesis import given
+
+from lenskit.stats import argtopk
+
+
+@given(
+    nph.arrays(nph.floating_dtypes(endianness="="), st.integers(0, 5000)), st.integers(min_value=-1)
+)
+def test_arg_topk(xs, k):
+    positions = argtopk(xs, k)
+    if k >= 0:
+        assert len(positions) <= k
+    assert positions.dtype == np.int64
+    if k == 0 or np.all(np.isnan(xs)):
+        assert len(positions) == 0
+        return
+
+    top_xs = xs[positions]
+
+    # we have the correct number of positions
+    if k >= 0:
+        assert len(positions) == min(k, np.sum(~np.isnan(xs)))
+    else:
+        assert len(positions) == np.sum(~np.isnan(xs))
+    # all rank positions are valid
+    assert np.all(positions >= 0)
+    assert np.all(positions < len(xs))
+    # all rank positions are unique
+    assert len(np.unique(positions)) == len(positions)
+    # all ranked items are numbers
+    assert not np.any(np.isnan(top_xs))
+
+    # we have the largest values
+    if len(positions) < k:
+        omitted = np.ones(len(xs), dtype=np.bool)
+        omitted[positions] = False
+        if not np.all(np.isnan(xs[omitted])):
+            assert np.min(top_xs) >= np.nanmax(xs[omitted])
+
+    # the values are sorted
+    if len(top_xs) > 1:
+        assert np.all(top_xs[:-1] >= top_xs[1:])

--- a/lenskit/tests/math/test_argtopk.py
+++ b/lenskit/tests/math/test_argtopk.py
@@ -33,6 +33,8 @@ def test_arg_topk(xs, k):
 
     top_xs = xs[positions]
 
+    sort_xs = np.sort(-xs[~np.isnan(xs)])
+
     # we have the correct number of positions
     if k >= 0:
         assert len(positions) == min(k, np.sum(~np.isnan(xs)))
@@ -56,3 +58,9 @@ def test_arg_topk(xs, k):
     # the values are sorted
     if len(top_xs) > 1:
         assert np.all(top_xs[:-1] >= top_xs[1:])
+
+    # the min matches the underlying sort
+    if k > 1:
+        assert top_xs[-1] == -sort_xs[min(k - 1, len(sort_xs) - 1)]
+    elif np.all(np.isfinite(sort_xs)):
+        assert np.all(top_xs == -sort_xs)

--- a/lenskit/tests/math/test_argtopk.py
+++ b/lenskit/tests/math/test_argtopk.py
@@ -2,9 +2,21 @@ import numpy as np
 
 import hypothesis.extra.numpy as nph
 import hypothesis.strategies as st
-from hypothesis import given
+from hypothesis import given, settings
 
 from lenskit.stats import argtopk
+
+
+def test_simple_topk():
+    positions = argtopk([1.0, 0.0], 1)
+    assert len(positions) == 1
+    assert positions[0] == 0
+
+
+def test_simple_topk_rev():
+    positions = argtopk([0.0, 1.0], 1)
+    assert len(positions) == 1
+    assert positions[0] == 1
 
 
 @given(
@@ -39,7 +51,7 @@ def test_arg_topk(xs, k):
         omitted = np.ones(len(xs), dtype=np.bool)
         omitted[positions] = False
         if not np.all(np.isnan(xs[omitted])):
-            assert np.min(top_xs) >= np.nanmax(xs[omitted])
+            assert np.all(top_xs >= np.nanmax(xs[omitted]))
 
     # the values are sorted
     if len(top_xs) > 1:

--- a/lenskit/tests/math/test_argtopn.py
+++ b/lenskit/tests/math/test_argtopn.py
@@ -50,7 +50,7 @@ def test_arg_topn(xs, k):
 
     # we have the largest values
     if len(positions) < k:
-        omitted = np.ones(len(xs), dtype=np.bool)
+        omitted = np.ones(len(xs), dtype="bool")
         omitted[positions] = False
         if not np.all(np.isnan(xs[omitted])):
             assert np.all(top_xs >= np.nanmax(xs[omitted]))

--- a/lenskit/tests/math/test_argtopn.py
+++ b/lenskit/tests/math/test_argtopn.py
@@ -4,17 +4,17 @@ import hypothesis.extra.numpy as nph
 import hypothesis.strategies as st
 from hypothesis import given, settings
 
-from lenskit.stats import argtopk
+from lenskit.stats import argtopn
 
 
-def test_simple_topk():
-    positions = argtopk([1.0, 0.0], 1)
+def test_simple_topn():
+    positions = argtopn([1.0, 0.0], 1)
     assert len(positions) == 1
     assert positions[0] == 0
 
 
-def test_simple_topk_rev():
-    positions = argtopk([0.0, 1.0], 1)
+def test_simple_topn_rev():
+    positions = argtopn([0.0, 1.0], 1)
     assert len(positions) == 1
     assert positions[0] == 1
 
@@ -22,8 +22,8 @@ def test_simple_topk_rev():
 @given(
     nph.arrays(nph.floating_dtypes(endianness="="), st.integers(0, 5000)), st.integers(min_value=-1)
 )
-def test_arg_topk(xs, k):
-    positions = argtopk(xs, k)
+def test_arg_topn(xs, k):
+    positions = argtopn(xs, k)
     if k >= 0:
         assert len(positions) <= k
     assert positions.dtype == np.int64

--- a/lenskit/tests/math/test_gini.py
+++ b/lenskit/tests/math/test_gini.py
@@ -5,7 +5,10 @@ from hypothesis import strategies as st
 from hypothesis.extra import numpy as nph
 from pytest import approx, mark
 
+from lenskit.logging import get_logger
 from lenskit.stats import gini
+
+_log = get_logger(__name__)
 
 
 def test_gini_uniform():
@@ -24,7 +27,12 @@ def test_completely_unequal():
     nph.arrays(
         st.one_of(nph.floating_dtypes(sizes=[32, 64]), nph.integer_dtypes()),
         nph.array_shapes(max_dims=1, min_side=2),
-        elements={"allow_nan": False, "allow_infinity": False, "min_value": 0},
+        elements={
+            "allow_nan": False,
+            "allow_infinity": False,
+            "min_value": 0,
+            "allow_subnormal": False,
+        },
     )
 )
 def test_random_values(xs):
@@ -44,6 +52,6 @@ def test_random_values(xs):
     xss[1:] = np.cumsum(np.sort(xs))
     actual = np.trapezoid(xss)
 
-    print(g, actual, ideal)
+    _log.debug("computed gini", n=len(xs), gini=g, actual=actual, ideal=ideal)
     # we use max just to deal with extremely small values
     assert g == approx(max((ideal - actual) / ideal, 0), abs=0.001)

--- a/lenskit/tests/math/test_gini.py
+++ b/lenskit/tests/math/test_gini.py
@@ -22,7 +22,7 @@ def test_completely_unequal():
 @mark.skipif(np.version.version < "2.0", reason="NumPy too old")
 @given(
     nph.arrays(
-        st.one_of(nph.floating_dtypes(), nph.integer_dtypes()),
+        st.one_of(nph.floating_dtypes(sizes=[32, 64]), nph.integer_dtypes()),
         nph.array_shapes(max_dims=1, min_side=2),
         elements={"allow_nan": False, "allow_infinity": False, "min_value": 0},
     )
@@ -45,4 +45,5 @@ def test_random_values(xs):
     actual = np.trapezoid(xss)
 
     print(g, actual, ideal)
-    assert g == approx((ideal - actual) / ideal, abs=0.001)
+    # we use max just to deal with extremely small values
+    assert g == approx(max((ideal - actual) / ideal, 0), abs=0.001)


### PR DESCRIPTION
The primary change here is to speed up popularity scoring (by not using Pandas), and top-N ranking (by using `np.argpartition` to identify the top-K, and then `argsort` on a much smaller set for the final ordering).

It also fixes some boundary condition test failures in Gini coefficient, and improves logging in the pipeline batch runner.