### PR TITLE
Re-add return type variable for Component

### DIFF
--- a/docs/guide/examples/blendcomp.py
+++ b/docs/guide/examples/blendcomp.py
@@ -14,7 +14,7 @@ class LinearBlendConfig(BaseModel):
     """
 
 
-class LinearBlendScorer(Component):
+class LinearBlendScorer(Component[ItemList]):
     r"""
     Score items with a linear blend of two other scores.
 

--- a/lenskit-funksvd/lenskit/funksvd.py
+++ b/lenskit-funksvd/lenskit/funksvd.py
@@ -231,7 +231,7 @@ def _align_add_bias(bias, index, keys, series):
     return bias, series
 
 
-class FunkSVDScorer(Trainable, Component):
+class FunkSVDScorer(Trainable, Component[ItemList]):
     """
     FunkSVD explicit-feedback matrix factoriation.  FunkSVD is a regularized
     biased matrix factorization technique trained with featurewise stochastic

--- a/lenskit-hpf/lenskit/hpf.py
+++ b/lenskit-hpf/lenskit/hpf.py
@@ -16,7 +16,7 @@ from lenskit.pipeline import Component, Trainable
 _logger = logging.getLogger(__name__)
 
 
-class HPFScorer(Component, Trainable):
+class HPFScorer(Component[ItemList], Trainable):
     """
     Hierarchical Poisson factorization, provided by
     `hpfrec <https://hpfrec.readthedocs.io/en/latest/>`_.

--- a/lenskit-implicit/lenskit/implicit.py
+++ b/lenskit-implicit/lenskit/implicit.py
@@ -34,7 +34,7 @@ class ImplicitALSConfig(ImplicitConfig, extra="allow"):
     weight: float = 40.0
 
 
-class BaseRec(Component, Trainable):
+class BaseRec(Component[ItemList], Trainable):
     """
     Base class for Implicit-backed recommenders.
 

--- a/lenskit-sklearn/lenskit/sklearn/svd.py
+++ b/lenskit-sklearn/lenskit/sklearn/svd.py
@@ -38,7 +38,7 @@ class BiasedSVDConfig:
     n_iter: int = 5
 
 
-class BiasedSVDScorer(Component, Trainable):
+class BiasedSVDScorer(Component[ItemList], Trainable):
     """
     Biased matrix factorization for explicit feedback using SciKit-Learn's
     :class:`~sklearn.decomposition.TruncatedSVD`.  It operates by first

--- a/lenskit/lenskit/als/_common.py
+++ b/lenskit/lenskit/als/_common.py
@@ -130,7 +130,7 @@ class TrainingData(NamedTuple):
         return self._replace(ui_rates=self.ui_rates.to(device), iu_rates=self.iu_rates.to(device))
 
 
-class ALSBase(ABC, Component, Trainable):
+class ALSBase(ABC, Component[ItemList], Trainable):
     """
     Base class for ALS models.
 

--- a/lenskit/lenskit/basic/bias.py
+++ b/lenskit/lenskit/basic/bias.py
@@ -270,7 +270,7 @@ class BiasConfig(BaseModel, extra="forbid"):
         return entity_damping(self.damping, entity)
 
 
-class BiasScorer(Component):
+class BiasScorer(Component[ItemList]):
     """
     A user-item bias rating prediction model.  This component uses
     :class:`BiasModel` to predict ratings for users and items.

--- a/lenskit/lenskit/basic/candidates.py
+++ b/lenskit/lenskit/basic/candidates.py
@@ -11,7 +11,7 @@ from lenskit.pipeline import Component, Trainable
 _logger = logging.getLogger(__name__)
 
 
-class TrainingCandidateSelectorBase(Component, Trainable):
+class TrainingCandidateSelectorBase(Component[ItemList], Trainable):
     """
     Base class for candidate selectors using the training data.
 

--- a/lenskit/lenskit/basic/composite.py
+++ b/lenskit/lenskit/basic/composite.py
@@ -10,7 +10,7 @@ from lenskit.pipeline import Component
 _logger = logging.getLogger(__name__)
 
 
-class FallbackScorer(Component):
+class FallbackScorer(Component[ItemList]):
     """
     Scoring component that fills in missing scores using a fallback.
 

--- a/lenskit/lenskit/basic/history.py
+++ b/lenskit/lenskit/basic/history.py
@@ -20,7 +20,7 @@ from lenskit.pipeline import Component, Trainable
 _logger = logging.getLogger(__name__)
 
 
-class UserTrainingHistoryLookup(Component, Trainable):
+class UserTrainingHistoryLookup(Component[ItemList], Trainable):
     """
     Look up a user's history from the training data.
 
@@ -57,7 +57,7 @@ class UserTrainingHistoryLookup(Component, Trainable):
         return self.__class__.__name__
 
 
-class KnownRatingScorer(Component, Trainable):
+class KnownRatingScorer(Component[ItemList], Trainable):
     """
     Score items by returning their values from the training data.
 

--- a/lenskit/lenskit/basic/popularity.py
+++ b/lenskit/lenskit/basic/popularity.py
@@ -27,7 +27,7 @@ class PopConfig(BaseModel):
     """
 
 
-class PopScorer(Component, Trainable):
+class PopScorer(Component[ItemList], Trainable):
     """
     Score items by their popularity.  Use with :py:class:`TopN` to get a
     most-popular-items recommender.

--- a/lenskit/lenskit/basic/random.py
+++ b/lenskit/lenskit/basic/random.py
@@ -20,7 +20,7 @@ class RandomConfig(BaseModel, arbitrary_types_allowed=True):
     """
 
 
-class RandomSelector(Component):
+class RandomSelector(Component[ItemList]):
     """
     Randomly select items from a candidate list.
 
@@ -74,7 +74,7 @@ class RandomSelector(Component):
             return items[np.zeros(0, dtype=np.int32)]
 
 
-class SoftmaxRanker(Component):
+class SoftmaxRanker(Component[ItemList]):
     """
     Stochastic top-N ranking with softmax sampling.
 

--- a/lenskit/lenskit/basic/topn.py
+++ b/lenskit/lenskit/basic/topn.py
@@ -24,7 +24,7 @@ class TopNConfig(BaseModel):
     """
 
 
-class TopNRanker(Component):
+class TopNRanker(Component[ItemList]):
     """
     Rank scored items by their score and take the top *N*.  The ranking length
     can be passed either at runtime or at component instantiation time, with the

--- a/lenskit/lenskit/knn/item.py
+++ b/lenskit/lenskit/knn/item.py
@@ -79,7 +79,7 @@ class ItemKNNConfig(BaseModel, extra="forbid"):
         return self.feedback == "explicit"
 
 
-class ItemKNNScorer(Component, Trainable):
+class ItemKNNScorer(Component[ItemList], Trainable):
     """
     Item-item nearest-neighbor collaborative filtering feedback. This item-item
     implementation is based on the description of item-based CF by

--- a/lenskit/lenskit/knn/user.py
+++ b/lenskit/lenskit/knn/user.py
@@ -69,7 +69,7 @@ class UserKNNConfig(BaseModel, extra="forbid"):
         return self.feedback == "explicit"
 
 
-class UserKNNScorer(Component, Trainable):
+class UserKNNScorer(Component[ItemList], Trainable):
     """
     User-user nearest-neighbor collaborative filtering with ratings. This
     user-user implementation is not terribly configurable; it hard-codes design

--- a/lenskit/lenskit/pipeline/_impl.py
+++ b/lenskit/lenskit/pipeline/_impl.py
@@ -65,7 +65,7 @@ class Pipeline:
     _nodes: dict[str, Node[Any]]
     _aliases: dict[str, Node[Any]]
     _defaults: dict[str, Node[Any]]
-    _components: dict[str, PipelineFunction[Any]]
+    _components: dict[str, PipelineFunction[Any] | Component[Any]]
     _hash: str | None = None
     _last: Node[Any] | None = None
     _anon_nodes: set[str]

--- a/lenskit/lenskit/pipeline/components.py
+++ b/lenskit/lenskit/pipeline/components.py
@@ -18,6 +18,7 @@ from types import FunctionType
 from typing import (
     Any,
     Callable,
+    Generic,
     Mapping,
     ParamSpec,
     Protocol,
@@ -35,7 +36,6 @@ from .types import Lazy
 
 P = ParamSpec("P")
 T = TypeVar("T")
-Cfg = TypeVar("Cfg")
 # COut is only return, so Component[U] can be assigned to Component[T] if U ≼ T.
 COut = TypeVar("COut", covariant=True)
 PipelineFunction: TypeAlias = Callable[..., COut]
@@ -130,7 +130,7 @@ class ParameterContainer(Protocol):  # pragma: nocover
         raise NotImplementedError()
 
 
-class Component:
+class Component(Generic[COut]):
     """
     Base class for pipeline component objects.  Any component that is not just a
     function should extend this class.
@@ -260,7 +260,7 @@ class Component:
 
 
 def instantiate_component(
-    comp: str | type | FunctionType, config: dict[str, Any] | None
+    comp: str | type | FunctionType, config: Mapping[str, Any] | None
 ) -> Callable[..., object]:
     """
     Utility function to instantiate a component given its class, function, or
@@ -281,7 +281,7 @@ def instantiate_component(
         return comp
     elif issubclass(comp, Component):
         cfg = comp.validate_config(config)
-        return comp(cfg)
+        return comp(cfg)  # type: ignore
     else:  # pragma: nocover
         return comp()  # type: ignore
 

--- a/lenskit/tests/pipeline/test_component_config.py
+++ b/lenskit/tests/pipeline/test_component_config.py
@@ -32,14 +32,14 @@ class PrefixConfigPYDC:
     prefix: str = "UNDEFINED"
 
 
-class PrefixerDC(Component):
+class PrefixerDC(Component[str]):
     config: PrefixConfigDC
 
     def __call__(self, msg: str) -> str:
         return self.config.prefix + msg
 
 
-class PrefixerM(Component):
+class PrefixerM(Component[str]):
     config: PrefixConfigM
 
     def __call__(self, msg: str) -> str:
@@ -51,7 +51,7 @@ class PrefixerM2(PrefixerM):
     config: PrefixConfigM
 
 
-class PrefixerPYDC(Component):
+class PrefixerPYDC(Component[str]):
     config: PrefixConfigPYDC
 
     def __call__(self, msg: str) -> str:

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -17,7 +17,7 @@ class PrefixConfig:
     prefix: str
 
 
-class Prefixer(Component):
+class Prefixer(Component[str]):
     config: PrefixConfig
 
     def __call__(self, msg: str) -> str:

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -28,7 +28,7 @@ class PrefixConfig:
     prefix: str
 
 
-class Prefixer(Component):
+class Prefixer(Component[str]):
     config: PrefixConfig
 
     def __call__(self, msg: str) -> str:


### PR DESCRIPTION
This brings back the return type generic variable for `Component`, which was removed in #596 but was important for the type-safety of the Pipeline interface. It also fills this variable in for our component implementations.