### PR TITLE
Move Trainable interface and add TrainingOptions

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -12,6 +12,7 @@ Core Abstractions
     lenskit.pipeline
     lenskit.diagnostics
     lenskit.operations
+    lenskit.training
 
 .. toctree::
     :caption: Core
@@ -21,6 +22,7 @@ Core Abstractions
     pipeline
     operations
     diagnostics
+    training
 
 Components and Models
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/api/training.rst
+++ b/docs/api/training.rst
@@ -1,0 +1,4 @@
+Model Training
+==============
+
+.. automodule:: lenskit.training

--- a/docs/guide/conventions.rst
+++ b/docs/guide/conventions.rst
@@ -24,19 +24,29 @@ Random Seeds
 
 .. _SPEC 7: https://scientific-python.org/specs/spec-0007/
 
-LensKit components follow `SPEC 7`_ for specifying random number seeds.
-Components that use randomization (either at runtime, or to set initial
-conditions for training) have a constructor parameter `rng` that takes either a
-:class:`~numpy.random.Generator` or seed material.  If you want reproducible
-stochastic pipelines, configure the random seeds for your components.
+LensKit components follow `SPEC 7`_ for specifying random number seeds.  If you
+want reproducible stochastic pipelines, configure the random seeds for your
+components and/or training process.
 
-This convention is also followed for other LensKit code, such as the `data
-splitting support <./splitting>`_.
+Components that use randomization at **inference time** take either seed
+material or a :class:`~numpy.random.Generator` as an ``rng`` constructor
+parameter; if seed material is supplied, that seed should be considered part of
+the configuration (see the source code in :mod:`lenskit.basic.random` for
+examples).
+
+Components that use randomization at **training time** should obtain their
+generator or seed from the :attr:`~lenskit.training.TrainingOptions`.  This
+makes it easy to configure a seed for the training process without needing
+to configure each component.
+
+Other LensKit code, such as the `data splitting support <./splitting>`_, follow
+SPEC 7 directly by accepting an ``rng`` keyword parameter.
 
 .. important::
 
-    If you specify random seeds, we strongly recommend specifying seeds instead of
-    generators, so that the seed can be included in serialized configurations.
+    If you specify random seeds for component configurations, we strongly
+    recommend specifying seeds instead of generators, so that the seed can be
+    included in serialized configurations.
 
 .. versionchanged:: 2025.1
 
@@ -46,19 +56,10 @@ splitting support <./splitting>`_.
 
 LensKit extends SPEC 7 with a global RNG that components can use as a fallback,
 to make it easier to configure system-wide generation for things like tests.
-This is configured with :func:`~lenskit.random.set_global_rng`.
-
-When implementing a component that uses randomness in its training, we recommend
-deferring conversion of the provided RNG into an actual generator until
-model-training time, so that serializing an untrained pipeline or its
-configuration includes the original seed instead of the resulting generator.
-When using the RNG to create initial state for e.g. training a model with
-PyTorch, it can be useful to create that state in NumPy and then convert to a
-tensor, so that components are consistent in their random number generation
-behavior instead of having variation between NumPy and other backends.
-Components can use the :func:`~lenskit.random_generator` function to
-convert seed material or a generator into a NumPy generator, falling back to the
-global RNG if one is specified.
+This is configured with :func:`~lenskit.random.set_global_rng`. Components can
+use the :func:`~lenskit.random_generator` function to convert seed material or a
+generator into a NumPy generator, falling back to the global RNG if one is
+specified.
 
 Derived Seeds
 -------------

--- a/docs/guide/conventions.rst
+++ b/docs/guide/conventions.rst
@@ -34,10 +34,13 @@ parameter; if seed material is supplied, that seed should be considered part of
 the configuration (see the source code in :mod:`lenskit.basic.random` for
 examples).
 
-Components that use randomization at **training time** should obtain their
-generator or seed from the :attr:`~lenskit.training.TrainingOptions`.  This
-makes it easy to configure a seed for the training process without needing
-to configure each component.
+Components that use randomization at **training time** (e.g. to shuffle data or
+to initialize parameter values) should obtain their generator or seed from the
+:attr:`~lenskit.training.TrainingOptions`.  This makes it easy to configure a
+seed for the training process without needing to configure each component.  For
+consistent configurability, it's best for components using other frameworks such
+as PyTorch to use NumPy to initialize the parameter values and then convert the
+initial values to the appropriate compute backend.
 
 Other LensKit code, such as the `data splitting support <./splitting>`_, follow
 SPEC 7 directly by accepting an ``rng`` keyword parameter.

--- a/docs/guide/pipeline.rst
+++ b/docs/guide/pipeline.rst
@@ -342,8 +342,9 @@ a component that requires no training or configuration can simply be a Python
 function.
 
 Most components will extend the :class:`Component` base class to expose
-configuration capabilities, and implement the :class:`Trainable` protocol if
-they contain a model that needs to be trained.
+configuration capabilities, and implement the
+:class:`lenskit.training.Trainable` protocol if they contain a model that needs
+to be trained.
 
 Components also must be pickleable, as LensKit uses pickling for shared memory
 parallelism in its batch-inference code.

--- a/lenskit-funksvd/lenskit/funksvd.py
+++ b/lenskit-funksvd/lenskit/funksvd.py
@@ -21,7 +21,6 @@ from lenskit import util
 from lenskit.basic import BiasModel, Damping
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
 from lenskit.pipeline import Component
-from lenskit.random import ConfiguredSeed, random_generator
 from lenskit.training import Trainable, TrainingOptions
 
 _logger = logging.getLogger(__name__)
@@ -53,10 +52,6 @@ class FunkSVDConfig(BaseModel):
     range: tuple[float, float] | None = None
     """
     Min/max range of ratings to clamp output.
-    """
-    rng: ConfiguredSeed = None
-    """
-    RNG seed.
     """
 
 
@@ -278,7 +273,7 @@ class FunkSVDScorer(Trainable, Component[ItemList]):
         _logger.info("[%s] preparing rating data for %d samples", timer, len(rate_df))
         _logger.debug("shuffling rating data")
         shuf = np.arange(len(rate_df), dtype=np.int_)
-        rng = random_generator(self.config.rng)
+        rng = options.random_generator()
         rng.shuffle(shuf)
         rate_df = rate_df.iloc[shuf, :]
 

--- a/lenskit-funksvd/lenskit/funksvd.py
+++ b/lenskit-funksvd/lenskit/funksvd.py
@@ -20,8 +20,9 @@ from typing_extensions import override
 from lenskit import util
 from lenskit.basic import BiasModel, Damping
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
-from lenskit.pipeline import Component, Trainable
+from lenskit.pipeline import Component
 from lenskit.random import ConfiguredSeed, random_generator
+from lenskit.training import Trainable, TrainingOptions
 
 _logger = logging.getLogger(__name__)
 
@@ -257,18 +258,17 @@ class FunkSVDScorer(Trainable, Component[ItemList]):
     items_: Vocabulary
     item_features_: np.ndarray[tuple[int, int], np.dtype[np.float64]]
 
-    @property
-    def is_trained(self) -> bool:
-        return hasattr(self, "item_features_")
-
     @override
-    def train(self, data: Dataset):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         """
         Train a FunkSVD model.
 
         Args:
             ratings: the ratings data frame.
         """
+        if hasattr(self, "item_features_") and not options.retrain:
+            return
+
         timer = util.Stopwatch()
         rate_df = data.interaction_matrix(format="pandas", layout="coo", field="rating")
 

--- a/lenskit-hpf/lenskit/hpf.py
+++ b/lenskit-hpf/lenskit/hpf.py
@@ -8,7 +8,7 @@ import logging
 
 import hpfrec
 import numpy as np
-from pydantic import BaseModel
+from pydantic import BaseModel, JsonValue
 from typing_extensions import override
 
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
@@ -18,6 +18,7 @@ _logger = logging.getLogger(__name__)
 
 
 class HPFConfig(BaseModel, extra="allow"):
+    __pydantic_extra__: dict[str, JsonValue]
     features: int = 50
 
 
@@ -61,9 +62,9 @@ class HPFScorer(Component[ItemList], Trainable):
             }
         )
 
-        hpf = hpfrec.HPF(self.config.features, reindex=False, **self.config.__pydantic_extra__)
+        hpf = hpfrec.HPF(self.config.features, reindex=False, **self.config.__pydantic_extra__)  # type: ignore
 
-        _logger.info("fitting HPF model with %d features", self.features)
+        _logger.info("fitting HPF model with %d features", self.config.features)
         hpf.fit(log)
 
         self.users_ = data.users

--- a/lenskit-hpf/lenskit/hpf.py
+++ b/lenskit-hpf/lenskit/hpf.py
@@ -12,7 +12,8 @@ from pydantic import BaseModel, JsonValue
 from typing_extensions import override
 
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
-from lenskit.pipeline import Component, Trainable
+from lenskit.pipeline import Component
+from lenskit.training import Trainable, TrainingOptions
 
 _logger = logging.getLogger(__name__)
 
@@ -47,12 +48,11 @@ class HPFScorer(Component[ItemList], Trainable):
     items_: Vocabulary
     item_features_: np.ndarray[tuple[int, int], np.dtype[np.float64]]
 
-    @property
-    def is_trained(self) -> bool:
-        return hasattr(self, "item_features_")
-
     @override
-    def train(self, data: Dataset):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
+        if hasattr(self, "item_features_") and not options.retrain:
+            return
+
         log = data.interaction_matrix("pandas", field="rating")
         log = log.rename(
             columns={

--- a/lenskit-hpf/tests/test_hpf.py
+++ b/lenskit-hpf/tests/test_hpf.py
@@ -28,7 +28,7 @@ class TestHPF(BasicComponentTests, ScorerTests):
 
 @mark.slow
 def test_hpf_train_large(tmp_path, ml_ratings):
-    algo = hpf.HPFScorer(20)
+    algo = hpf.HPFScorer(features=20)
     ratings = ml_ratings.assign(rating=ml_ratings.rating + 0.5)
     ds = from_interactions_df(ratings)
     algo.train(ds)
@@ -57,7 +57,7 @@ def test_hpf_train_large(tmp_path, ml_ratings):
 
 @mark.slow
 def test_hpf_train_binary(tmp_path, ml_ratings):
-    algo = hpf.HPFScorer(20)
+    algo = hpf.HPFScorer(features=20)
     ratings = ml_ratings.drop(columns=["timestamp", "rating"])
     ds = from_interactions_df(ratings)
     algo.train(ds)

--- a/lenskit-hpf/tests/test_hpf.py
+++ b/lenskit-hpf/tests/test_hpf.py
@@ -16,6 +16,7 @@ from lenskit.data import ItemList, from_interactions_df
 from lenskit.metrics import quick_measure_model
 from lenskit.pipeline import topn_pipeline
 from lenskit.testing import BasicComponentTests, ScorerTests
+from lenskit.training import TrainingOptions
 
 hpf = importorskip("lenskit.hpf")
 
@@ -47,7 +48,7 @@ def test_hpf_train_large(tmp_path, ml_ratings):
     assert np.all(a2.item_features_ == algo.item_features_)
 
     pipe = topn_pipeline(algo)
-    pipe.train(ds, retrain=False)
+    pipe.train(ds, TrainingOptions(retrain=False))
 
     for u in np.random.choice(ratings.user_id.unique(), size=50, replace=False):
         recs = pipe.run("recommender", query=u, n=50)
@@ -76,7 +77,7 @@ def test_hpf_train_binary(tmp_path, ml_ratings):
     assert np.all(a2.item_features_ == algo.item_features_)
 
     pipe = topn_pipeline(algo)
-    pipe.train(ds, retrain=False)
+    pipe.train(ds, TrainingOptions(retrain=False))
 
     for u in np.random.choice(ratings.user_id.unique(), size=50, replace=False):
         recs = pipe.run("recommender", query=u, n=50)

--- a/lenskit-implicit/lenskit/implicit.py
+++ b/lenskit-implicit/lenskit/implicit.py
@@ -64,7 +64,7 @@ class BaseRec(Component[ItemList], Trainable):
     """
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         if hasattr(self, "delegate") and not options.retrain:
             return
 

--- a/lenskit-sklearn/lenskit/sklearn/svd.py
+++ b/lenskit-sklearn/lenskit/sklearn/svd.py
@@ -90,7 +90,7 @@ class BiasedSVDScorer(Component[ItemList], Trainable):
             self.config.features, algorithm=self.config.algorithm, n_iter=self.config.n_iter
         )
         _log.info("[%s] training SVD (k=%d)", timer, self.factorization_.n_components)  # type: ignore
-        Xt = self.factorization_.fit_transform(r_mat)
+        Xt = self.factorization_.fit_transform(r_mat)  # type: ignore
         self.user_components_ = Xt
         self.users_ = data.users.copy()
         self.items_ = data.items.copy()

--- a/lenskit-sklearn/lenskit/sklearn/svd.py
+++ b/lenskit-sklearn/lenskit/sklearn/svd.py
@@ -16,7 +16,8 @@ from typing_extensions import Literal, override
 from lenskit.basic import BiasModel, Damping
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery
 from lenskit.data.vocab import Vocabulary
-from lenskit.pipeline import Component, Trainable
+from lenskit.pipeline import Component
+from lenskit.training import Trainable, TrainingOptions
 from lenskit.util import Stopwatch
 
 try:
@@ -61,12 +62,11 @@ class BiasedSVDScorer(Component[ItemList], Trainable):
     items_: Vocabulary
     user_components_: NDArray[np.float64]
 
-    @property
-    def is_trained(self):
-        return hasattr(self, "factorization_")
-
     @override
-    def train(self, data: Dataset):
+    def train(self, data: Dataset, options: TrainingOptions):
+        if hasattr(self, "factorization_") and not options.retrain:
+            return
+
         timer = Stopwatch()
         _log.info("[%s] computing bias", timer)
         self.bias_ = BiasModel.learn(data, self.config.damping)

--- a/lenskit-sklearn/lenskit/sklearn/svd.py
+++ b/lenskit-sklearn/lenskit/sklearn/svd.py
@@ -63,7 +63,7 @@ class BiasedSVDScorer(Component[ItemList], Trainable):
     user_components_: NDArray[np.float64]
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         if hasattr(self, "factorization_") and not options.retrain:
             return
 

--- a/lenskit/lenskit/als/_common.py
+++ b/lenskit/lenskit/als/_common.py
@@ -20,8 +20,9 @@ from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
 from lenskit.data.types import UIPair
 from lenskit.logging import item_progress
 from lenskit.parallel.config import ensure_parallel_init
-from lenskit.pipeline import Component, Trainable
+from lenskit.pipeline import Component
 from lenskit.random import ConfiguredSeed, RNGInput, RNGLike, random_generator
+from lenskit.training import Trainable, TrainingOptions
 
 EntityClass: TypeAlias = Literal["user", "item"]
 
@@ -156,18 +157,17 @@ class ALSBase(ABC, Component[ItemList], Trainable):
             kwargs = kwargs | {"rng": rng}
         super().__init__(config, **kwargs)
 
-    @property
-    def is_trained(self) -> bool:
-        return hasattr(self, "item_features_")
-
     @override
-    def train(self, data: Dataset):
+    def train(self, data: Dataset, options: TrainingOptions):
         """
         Run ALS to train a model.
 
         Args:
             ratings: the ratings data frame.
         """
+        if hasattr(self, "item_features_") and not options.retrain:
+            return
+
         ensure_parallel_init()
         timer = util.Stopwatch()
 

--- a/lenskit/lenskit/als/_common.py
+++ b/lenskit/lenskit/als/_common.py
@@ -158,7 +158,7 @@ class ALSBase(ABC, Component[ItemList], Trainable):
         super().__init__(config, **kwargs)
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         """
         Run ALS to train a model.
 

--- a/lenskit/lenskit/als/_common.py
+++ b/lenskit/lenskit/als/_common.py
@@ -144,15 +144,18 @@ class ALSBase(ABC, Component[ItemList], Trainable):
     logger: structlog.stdlib.BoundLogger
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()) -> bool:
         """
         Run ALS to train a model.
 
         Args:
             ratings: the ratings data frame.
+
+        Returns:
+            ``True`` if the model was trained.
         """
         if hasattr(self, "item_features_") and not options.retrain:
-            return
+            return False
 
         ensure_parallel_init()
         timer = util.Stopwatch()
@@ -175,6 +178,8 @@ class ALSBase(ABC, Component[ItemList], Trainable):
                 torch.norm(self.item_features_, "fro"),
                 features=self.config.features,
             )
+
+        return True
 
     def fit_iters(self, data: Dataset, options: TrainingOptions) -> Iterator[Self]:
         """

--- a/lenskit/lenskit/als/_common.py
+++ b/lenskit/lenskit/als/_common.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 import numpy as np
 import structlog
@@ -21,7 +21,6 @@ from lenskit.data.types import UIPair
 from lenskit.logging import item_progress
 from lenskit.parallel.config import ensure_parallel_init
 from lenskit.pipeline import Component
-from lenskit.random import ConfiguredSeed, RNGInput, RNGLike, random_generator
 from lenskit.training import Trainable, TrainingOptions
 
 EntityClass: TypeAlias = Literal["user", "item"]
@@ -43,10 +42,6 @@ class ALSConfig(BaseModel):
     regularization: float | UIPair[float] = 0.1
     """
     L2 regularization strength.
-    """
-    rng: ConfiguredSeed = None
-    """
-    Random number seed.
     """
     save_user_features: bool = True
     """
@@ -140,7 +135,6 @@ class ALSBase(ABC, Component[ItemList], Trainable):
     """
 
     config: ALSConfig
-    rng: RNGLike | None = None
 
     users_: Vocabulary | None
     items_: Vocabulary
@@ -148,14 +142,6 @@ class ALSBase(ABC, Component[ItemList], Trainable):
     item_features_: torch.Tensor
 
     logger: structlog.stdlib.BoundLogger
-
-    def __init__(self, config: ALSConfig | None = None, *, rng: RNGInput = None, **kwargs: Any):
-        # hadle non-configurable RNG
-        if isinstance(rng, (np.random.Generator, np.random.BitGenerator)):
-            self.rng = rng
-        elif rng is not None:
-            kwargs = kwargs | {"rng": rng}
-        super().__init__(config, **kwargs)
 
     @override
     def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
@@ -171,7 +157,7 @@ class ALSBase(ABC, Component[ItemList], Trainable):
         ensure_parallel_init()
         timer = util.Stopwatch()
 
-        for algo in self.fit_iters(data):
+        for algo in self.fit_iters(data, options):
             pass  # we just need to do the iterations
 
         if self.user_features_ is not None:
@@ -190,7 +176,7 @@ class ALSBase(ABC, Component[ItemList], Trainable):
                 features=self.config.features,
             )
 
-    def fit_iters(self, data: Dataset) -> Iterator[Self]:
+    def fit_iters(self, data: Dataset, options: TrainingOptions) -> Iterator[Self]:
         """
         Run ALS to train a model, yielding after each iteration.
 
@@ -199,12 +185,13 @@ class ALSBase(ABC, Component[ItemList], Trainable):
         """
 
         log = self.logger = self.logger.bind(features=self.config.features)
+        rng = options.random_generator()
 
         train = self.prepare_data(data)
         self.users_ = train.users
         self.items_ = train.items
 
-        self.initialize_params(train)
+        self.initialize_params(train, rng)
 
         assert self.user_features_ is not None
         assert self.item_features_ is not None
@@ -250,11 +237,10 @@ class ALSBase(ABC, Component[ItemList], Trainable):
         """
         ...
 
-    def initialize_params(self, data: TrainingData):
+    def initialize_params(self, data: TrainingData, rng: np.random.Generator):
         """
         Initialize the model parameters at the beginning of training.
         """
-        rng = random_generator(self.rng or self.config.rng)
         self.logger.debug("initializing item matrix")
         self.item_features_ = self.initial_params(data.n_items, self.config.features, rng)
         self.logger.debug("|Q|: %f", torch.norm(self.item_features_, "fro"))

--- a/lenskit/lenskit/als/_implicit.py
+++ b/lenskit/lenskit/als/_implicit.py
@@ -17,6 +17,7 @@ from lenskit.logging import get_logger
 from lenskit.logging.progress import item_progress_handle, pbh_update
 from lenskit.math.solve import solve_cholesky
 from lenskit.parallel.chunking import WorkChunks
+from lenskit.training import TrainingOptions
 
 from ._common import ALSBase, ALSConfig, TrainContext, TrainingData
 
@@ -71,8 +72,8 @@ class ImplicitMFScorer(ALSBase):
     OtOr_: torch.Tensor
 
     @override
-    def train(self, data: Dataset):
-        super().train(data)
+    def train(self, data: Dataset, options: TrainingOptions):
+        super().train(data, options)
 
         # compute OtOr and save it on the model
         reg = self.config.user_reg

--- a/lenskit/lenskit/als/_implicit.py
+++ b/lenskit/lenskit/als/_implicit.py
@@ -73,11 +73,11 @@ class ImplicitMFScorer(ALSBase):
 
     @override
     def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
-        super().train(data, options)
-
-        # compute OtOr and save it on the model
-        reg = self.config.user_reg
-        self.OtOr_ = _implicit_otor(self.item_features_, reg)
+        if super().train(data, options):
+            # compute OtOr and save it on the model
+            reg = self.config.user_reg
+            self.OtOr_ = _implicit_otor(self.item_features_, reg)
+            return True
 
     @override
     def prepare_data(self, data: Dataset) -> TrainingData:

--- a/lenskit/lenskit/als/_implicit.py
+++ b/lenskit/lenskit/als/_implicit.py
@@ -72,7 +72,7 @@ class ImplicitMFScorer(ALSBase):
     OtOr_: torch.Tensor
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         super().train(data, options)
 
         # compute OtOr and save it on the model

--- a/lenskit/lenskit/basic/bias.py
+++ b/lenskit/lenskit/basic/bias.py
@@ -289,7 +289,7 @@ class BiasScorer(Component[ItemList], Trainable):
     config: BiasConfig
     model_: BiasModel
 
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         """
         Train the bias model on some rating data.
 

--- a/lenskit/lenskit/basic/bias.py
+++ b/lenskit/lenskit/basic/bias.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 import logging
 from collections.abc import Container
 from dataclasses import dataclass
-from typing import Literal
+from typing import Annotated, Literal
 
 import numpy as np
 import torch
-from pydantic import BaseModel, NonNegativeFloat
+from pydantic import BaseModel, NonNegativeFloat, PlainSerializer
 from typing_extensions import Self, TypeAlias, overload
 
 from lenskit.data import ID, Dataset, ItemList, QueryInput, RecQuery, Vocabulary
@@ -256,7 +256,9 @@ class BiasConfig(BaseModel, extra="forbid"):
     Configuration for :class:`BiasScorer`.
     """
 
-    entities: set[Literal["user", "item"]] = {"user", "item"}
+    entities: Annotated[
+        set[Literal["user", "item"]], PlainSerializer(lambda s: sorted(s), return_type=list[str])
+    ] = {"user", "item"}
     """
     The entities to compute biases for, in addition to global bais.  Defaults to
     users and items.

--- a/lenskit/lenskit/basic/candidates.py
+++ b/lenskit/lenskit/basic/candidates.py
@@ -27,7 +27,7 @@ class TrainingCandidateSelectorBase(Component[ItemList], Trainable):
     """
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         if hasattr(self, "items_") and not options.retrain:
             return
 

--- a/lenskit/lenskit/basic/candidates.py
+++ b/lenskit/lenskit/basic/candidates.py
@@ -6,7 +6,8 @@ import numpy as np
 from typing_extensions import override
 
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
-from lenskit.pipeline import Component, Trainable
+from lenskit.pipeline import Component
+from lenskit.training import Trainable, TrainingOptions
 
 _logger = logging.getLogger(__name__)
 
@@ -21,13 +22,15 @@ class TrainingCandidateSelectorBase(Component[ItemList], Trainable):
 
     config: None
     items_: Vocabulary
-
-    @property
-    def is_trained(self) -> bool:
-        return hasattr(self, "items_")
+    """
+    List of known items from the training data.
+    """
 
     @override
-    def train(self, data: Dataset):
+    def train(self, data: Dataset, options: TrainingOptions):
+        if hasattr(self, "items_") and not options.retrain:
+            return
+
         self.items_ = data.items.copy()
 
     def __str__(self):

--- a/lenskit/lenskit/basic/candidates.py
+++ b/lenskit/lenskit/basic/candidates.py
@@ -33,9 +33,6 @@ class TrainingCandidateSelectorBase(Component[ItemList], Trainable):
 
         self.items_ = data.items.copy()
 
-    def __str__(self):
-        return self.__class__.__name__
-
 
 class AllTrainingItemsCandidateSelector(TrainingCandidateSelectorBase):
     """

--- a/lenskit/lenskit/basic/history.py
+++ b/lenskit/lenskit/basic/history.py
@@ -32,7 +32,7 @@ class UserTrainingHistoryLookup(Component[ItemList], Trainable):
     training_data_: Dataset
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         # TODO: find a better data structure for this
         if hasattr(self, "training_data_") and not options.retrain:
             return
@@ -91,7 +91,7 @@ class KnownRatingScorer(Component[ItemList], Trainable):
         self.source = source
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         if hasattr(self, "matrix_") and not options.retrain:
             return
 

--- a/lenskit/lenskit/basic/history.py
+++ b/lenskit/lenskit/basic/history.py
@@ -53,9 +53,6 @@ class UserTrainingHistoryLookup(Component[ItemList], Trainable):
 
         return query
 
-    def __str__(self):
-        return self.__class__.__name__
-
 
 class KnownRatingScorer(Component[ItemList], Trainable):
     """
@@ -137,6 +134,3 @@ class KnownRatingScorer(Component[ItemList], Trainable):
             items.ids(), fill_value=0.0 if self.score == "indicator" else np.nan
         )
         return ItemList(items, scores=scores.values)  # type: ignore
-
-    def __str__(self):
-        return self.__class__.__name__

--- a/lenskit/lenskit/basic/popularity.py
+++ b/lenskit/lenskit/basic/popularity.py
@@ -47,7 +47,7 @@ class PopScorer(Component[ItemList], Trainable):
     item_scores_: np.ndarray[int, np.dtype[np.float32]]
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         if hasattr(self, "item_scores_") and not options.retrain:
             return
 
@@ -106,7 +106,7 @@ class TimeBoundedPopScore(PopScorer):
     config: TimeBoundedPopConfig
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         if hasattr(self, "item_scores_") and not options.retrain:
             return
 

--- a/lenskit/lenskit/knn/item.py
+++ b/lenskit/lenskit/knn/item.py
@@ -114,7 +114,7 @@ class ItemKNNScorer(Component[ItemList], Trainable):
 
     @override
     @inference_mode
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         """
         Train a model.
 

--- a/lenskit/lenskit/knn/user.py
+++ b/lenskit/lenskit/knn/user.py
@@ -100,7 +100,7 @@ class UserKNNScorer(Component[ItemList], Trainable):
     "Centered but un-normalized rating matrix (COO) to find neighbor ratings."
 
     @override
-    def train(self, data: Dataset, options: TrainingOptions):
+    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()):
         """
         "Train" a user-user CF model.  This memorizes the rating data in a format that is usable
         for future computations.

--- a/lenskit/lenskit/knn/user.py
+++ b/lenskit/lenskit/knn/user.py
@@ -19,7 +19,7 @@ import structlog
 import torch
 from pydantic import BaseModel, PositiveFloat, PositiveInt, field_validator
 from scipy.sparse import csc_array
-from typing_extensions import NamedTuple, Optional, Self, override
+from typing_extensions import NamedTuple, Optional, override
 
 from lenskit import util
 from lenskit.data import Dataset, FeedbackType, ItemList, QueryInput, RecQuery
@@ -28,7 +28,8 @@ from lenskit.diagnostics import DataWarning
 from lenskit.logging import get_logger
 from lenskit.math.sparse import normalize_sparse_rows, safe_spmv, torch_sparse_to_scipy
 from lenskit.parallel.config import ensure_parallel_init
-from lenskit.pipeline import Component, Trainable
+from lenskit.pipeline import Component
+from lenskit.training import Trainable, TrainingOptions
 
 _log = get_logger(__name__)
 
@@ -98,12 +99,8 @@ class UserKNNScorer(Component[ItemList], Trainable):
     user_ratings_: csc_array
     "Centered but un-normalized rating matrix (COO) to find neighbor ratings."
 
-    @property
-    def is_trained(self) -> bool:
-        return hasattr(self, "users_")
-
     @override
-    def train(self, data: Dataset) -> Self:
+    def train(self, data: Dataset, options: TrainingOptions):
         """
         "Train" a user-user CF model.  This memorizes the rating data in a format that is usable
         for future computations.
@@ -111,6 +108,9 @@ class UserKNNScorer(Component[ItemList], Trainable):
         Args:
             ratings(pandas.DataFrame): (user, item, rating) data for collaborative filtering.
         """
+        if hasattr(self, "user_ratings_") and not options.retrain:
+            return
+
         ensure_parallel_init()
         rmat = data.interaction_matrix("torch", field="rating" if self.config.explicit else None)
         assert rmat.is_sparse_csr
@@ -133,8 +133,6 @@ class UserKNNScorer(Component[ItemList], Trainable):
         self.users_ = data.users.copy()
         self.user_means_ = means
         self.items_ = data.items.copy()
-
-        return self
 
     @override
     def __call__(self, query: QueryInput, items: ItemList) -> ItemList:

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -17,7 +17,6 @@ from .common import RecPipelineBuilder, topn_pipeline
 from .components import (
     Component,
     PipelineFunction,
-    Trainable,
 )
 from .config import PipelineConfig
 from .nodes import Node
@@ -32,7 +31,6 @@ __all__ = [
     "PipelineState",
     "Node",
     "PipelineFunction",
-    "Trainable",
     "PipelineConfig",
     "Lazy",
     "Component",

--- a/lenskit/lenskit/pipeline/components.py
+++ b/lenskit/lenskit/pipeline/components.py
@@ -30,8 +30,6 @@ from typing import (
 
 from pydantic import JsonValue, TypeAdapter
 
-from lenskit.data.dataset import Dataset
-
 from .types import Lazy
 
 P = ParamSpec("P")
@@ -39,49 +37,6 @@ T = TypeVar("T")
 # COut is only return, so Component[U] can be assigned to Component[T] if U ≼ T.
 COut = TypeVar("COut", covariant=True)
 PipelineFunction: TypeAlias = Callable[..., COut]
-
-
-@runtime_checkable
-class Trainable(Protocol):  # pragma: nocover
-    """
-    Interface for components that can learn parameters from training data. It
-    supports trainingand checking if a component has already been trained.
-    Trained components need to be picklable.
-
-    .. note::
-
-        Trainable components must also implement ``__call__``.
-
-    .. note::
-
-        A future LensKit version will add support for extracting model
-        parameters a la Pytorch's ``state_dict``, but this capability was not
-        ready for 2025.1.
-
-    Stability:
-        Full
-    """
-
-    @property
-    def is_trained(self) -> bool:
-        """
-        Check if this model has already been trained.
-        """
-        raise NotImplementedError()
-
-    def train(self, data: Dataset) -> None:
-        """
-        Train the pipeline component to learn its parameters from a training
-        dataset.
-
-        Args:
-            data:
-                The training dataset.
-            retrain:
-                If ``True``, retrain the model even if it has already been
-                trained.
-        """
-        raise NotImplementedError()
 
 
 @runtime_checkable

--- a/lenskit/lenskit/testing/_components.py
+++ b/lenskit/lenskit/testing/_components.py
@@ -84,6 +84,7 @@ class TrainingTests:
         yield model
 
     def test_skip_retrain(self, ml_ds: Dataset):
+        self.maybe_skip_nojit()
         model = self.component()
         if not isinstance(model, Trainable):
             skip(f"component {model.__class__.__name__} is not trainable")

--- a/lenskit/lenskit/testing/_components.py
+++ b/lenskit/lenskit/testing/_components.py
@@ -8,7 +8,8 @@ import numpy as np
 from pytest import approx, fixture, skip
 
 from lenskit.data import Dataset, ItemList, MatrixDataset, RecQuery
-from lenskit.pipeline import Component, Trainable
+from lenskit.pipeline import Component
+from lenskit.training import Trainable, TrainingOptions
 
 from ._markers import jit_enabled
 
@@ -78,13 +79,8 @@ class TrainingTests:
 
         model = self.component()
         if isinstance(model, Trainable):
-            model.train(ml_ds)
+            model.train(ml_ds, TrainingOptions())
         yield model
-
-    def test_basic_trained(self, ml_ds: Dataset, trained_model: Component):
-        assert isinstance(trained_model, self.component)
-        if isinstance(trained_model, Trainable):
-            assert trained_model.is_trained
 
 
 class ScorerTests(TrainingTests):
@@ -239,7 +235,7 @@ class ScorerTests(TrainingTests):
 
         model = self.component()
         assert isinstance(model, Trainable)
-        model.train(ds)
+        model.train(ds, TrainingOptions())
 
         good_u = rng.choice(ml_ds.users.ids(), 10, replace=False)
         for u in set(good_u) | set(drop_u):

--- a/lenskit/lenskit/testing/_components.py
+++ b/lenskit/lenskit/testing/_components.py
@@ -96,8 +96,8 @@ class TrainingTests:
         t1 = perf_counter()
         model.train(ml_ds, TrainingOptions(retrain=False))
         t2 = perf_counter()
-        # that should be very fast
-        assert t2 - t1 < 0.001
+        # that should be very fast, let's say 10ms
+        assert t2 - t1 < 0.01
         # the model shouldn't have changed
         v2_data = pickle.dumps(model)
         assert v2_data == v1_data

--- a/lenskit/lenskit/training.py
+++ b/lenskit/lenskit/training.py
@@ -1,0 +1,94 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2024 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+"""
+Interfaces and support for model training.
+"""
+
+# pyright: strict
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import (
+    Protocol,
+    runtime_checkable,
+)
+
+import numpy as np
+
+from lenskit.data.dataset import Dataset
+from lenskit.random import RNGInput, random_generator
+
+
+@dataclass
+class TrainingOptions:
+    """
+    Options and context settings that govern model training.
+    """
+
+    retrain: bool = True
+    """
+    Whether the model should retrain if it is already trained.  If ``False``,
+    the model should cleanly skip training if it is already trained.
+    """
+
+    device: str | None = None
+    """
+    The device on which to train (e.g. ``'cuda'``).  May be ignored if the model
+    does not support the specified device.
+    """
+
+    rng: RNGInput = None
+    """
+    Random number generator to use for any randomness in the training process.
+    This option contains any `SPEC 7`_-compatible random number generator
+    specification; the :func:`~lenskit.random.random_generator` will convert
+    that into a NumPy :class:`~numpy.random.Generator`.
+    """
+
+    _generator: np.random.Generator | None = None
+
+    def random_generator(self) -> np.random.Generator:
+        """
+        Obtain a random generator from the configured RNG or seed.
+        """
+        if self._generator is None:
+            self._generator = random_generator(self.rng)
+        return self._generator
+
+
+@runtime_checkable
+class Trainable(Protocol):  # pragma: nocover
+    """
+    Interface for components and objects that can learn parameters from training
+    data. It supports training and checking if a component has already been
+    trained.  The resulting model should be pickleable.  Trainable objects are
+    usually also components.
+
+    .. note::
+
+        Trainable components must also implement ``__call__``.
+
+    .. note::
+
+        A future LensKit version will add support for extracting model
+        parameters a la Pytorch's ``state_dict``, but this capability was not
+        ready for 2025.1.
+
+    Stability:
+        Full
+    """
+
+    def train(self, data: Dataset, options: TrainingOptions) -> None:
+        """
+        Train the model to learn its parameters from a training dataset.
+
+        Args:
+            data:
+                The training dataset.
+            options:
+                The training options.
+        """
+        raise NotImplementedError()

--- a/lenskit/lenskit/training.py
+++ b/lenskit/lenskit/training.py
@@ -22,7 +22,7 @@ from lenskit.data.dataset import Dataset
 from lenskit.random import RNGInput, random_generator
 
 
-@dataclass
+@dataclass(frozen=True)
 class TrainingOptions:
     """
     Options and context settings that govern model training.
@@ -48,15 +48,17 @@ class TrainingOptions:
     that into a NumPy :class:`~numpy.random.Generator`.
     """
 
-    _generator: np.random.Generator | None = None
-
     def random_generator(self) -> np.random.Generator:
         """
         Obtain a random generator from the configured RNG or seed.
+
+        .. note::
+
+            Each call to this method will return a fresh generator from the same
+            seed.  Components should call it once at the beginning of their
+            training procesess.
         """
-        if self._generator is None:
-            self._generator = random_generator(self.rng)
-        return self._generator
+        return random_generator(self.rng)
 
 
 @runtime_checkable

--- a/lenskit/tests/pipeline/test_train.py
+++ b/lenskit/tests/pipeline/test_train.py
@@ -9,7 +9,7 @@ from typing import Any
 from lenskit.data.dataset import Dataset
 from lenskit.data.vocab import Vocabulary
 from lenskit.pipeline import Pipeline
-from lenskit.pipeline.components import Trainable
+from lenskit.training import Trainable, TrainingOptions
 
 
 def test_train(ml_ds: Dataset):
@@ -33,11 +33,7 @@ class TestComponent:
     def __call__(self, *, item: int) -> bool:
         return self.items.number(item, "none") is not None
 
-    @property
-    def is_trained(self) -> bool:
-        return hasattr(self, "items")
-
-    def train(self, data: Dataset):
+    def train(self, data: Dataset, options: TrainingOptions):
         # we just memorize the items
         self.items = data.items
 


### PR DESCRIPTION
This moves `Trainable` to a new `lenskit.training` module, and adds an `options` parameter of type `TrainingOptions` to provide options to the model training process, including a train-time RNG.