### PR TITLE
Migrate HPF to configuration object and fix BiasConfig serialization

### DIFF
--- a/lenskit-hpf/lenskit/hpf.py
+++ b/lenskit-hpf/lenskit/hpf.py
@@ -8,7 +8,7 @@ import logging
 
 import hpfrec
 import numpy as np
-from pydantic import BaseModel
+from pydantic import BaseModel, JsonValue
 from typing_extensions import override
 
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
@@ -18,6 +18,7 @@ _logger = logging.getLogger(__name__)
 
 
 class HPFConfig(BaseModel, extra="allow"):
+    __pydantic_extra__: dict[str, JsonValue]
     features: int = 50
 
 
@@ -61,9 +62,9 @@ class HPFScorer(Component[ItemList], Trainable):
             }
         )
 
-        hpf = hpfrec.HPF(self.config.features, reindex=False, **self.config.__pydantic_extra__)
+        hpf = hpfrec.HPF(self.config.features, reindex=False, **self.config.__pydantic_extra__)  # type: ignore
 
-        _logger.info("fitting HPF model with %d features", self.features)
+        _logger.info("fitting HPF model with %d features", self.config.features)
         hpf.fit(log)
 
         self.users_ = data.users

--- a/lenskit-hpf/tests/test_hpf.py
+++ b/lenskit-hpf/tests/test_hpf.py
@@ -28,7 +28,7 @@ class TestHPF(BasicComponentTests, ScorerTests):
 
 @mark.slow
 def test_hpf_train_large(tmp_path, ml_ratings):
-    algo = hpf.HPFScorer(20)
+    algo = hpf.HPFScorer(features=20)
     ratings = ml_ratings.assign(rating=ml_ratings.rating + 0.5)
     ds = from_interactions_df(ratings)
     algo.train(ds)
@@ -57,7 +57,7 @@ def test_hpf_train_large(tmp_path, ml_ratings):
 
 @mark.slow
 def test_hpf_train_binary(tmp_path, ml_ratings):
-    algo = hpf.HPFScorer(20)
+    algo = hpf.HPFScorer(features=20)
     ratings = ml_ratings.drop(columns=["timestamp", "rating"])
     ds = from_interactions_df(ratings)
     algo.train(ds)

--- a/lenskit/lenskit/basic/bias.py
+++ b/lenskit/lenskit/basic/bias.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 import logging
 from collections.abc import Container
 from dataclasses import dataclass
-from typing import Literal
+from typing import Annotated, Literal
 
 import numpy as np
 import torch
-from pydantic import BaseModel, NonNegativeFloat
+from pydantic import BaseModel, NonNegativeFloat, PlainSerializer
 from typing_extensions import Self, TypeAlias, overload
 
 from lenskit.data import ID, Dataset, ItemList, QueryInput, RecQuery, Vocabulary
@@ -256,7 +256,9 @@ class BiasConfig(BaseModel, extra="forbid"):
     Configuration for :class:`BiasScorer`.
     """
 
-    entities: set[Literal["user", "item"]] = {"user", "item"}
+    entities: Annotated[
+        set[Literal["user", "item"]], PlainSerializer(lambda s: sorted(s), return_type=list[str])
+    ] = {"user", "item"}
     """
     The entities to compute biases for, in addition to global bais.  Defaults to
     users and items.


### PR DESCRIPTION
This brings a couple small cleanups from #596:

- migrate HPF to the configuration object design
- fix BiasConfig serialization to sort the entity list for deterministic serialization