### PR TITLE
rename "Lenskit" to LensKit for consistency

### DIFF
--- a/lenskit/lenskit/logging/_proxy.py
+++ b/lenskit/lenskit/logging/_proxy.py
@@ -36,10 +36,10 @@ def get_logger(
     """
     if remove_private:
         name = re.sub(r"\._.*", "", name)
-    return LenskitProxyLogger(None, logger_factory_args=[name], initial_values=init_als)  # type: ignore
+    return LensKitProxyLogger(None, logger_factory_args=[name], initial_values=init_als)  # type: ignore
 
 
-class LenskitProxyLogger(BoundLoggerLazyProxy):
+class LensKitProxyLogger(BoundLoggerLazyProxy):
     """
     Lazy proxy logger for LensKit.  This is based on Structlog's lazy proxy,
     with using a filtering logger by default when structlog is not configured.

--- a/lenskit/lenskit/parallel/pool.py
+++ b/lenskit/lenskit/parallel/pool.py
@@ -37,7 +37,7 @@ def multiprocess_executor(
     if n_jobs is None:
         n_jobs = cfg.processes
 
-    ctx = LenskitMPContext(sp_config)
+    ctx = LensKitMPContext(sp_config)
     return ProcessPoolExecutor(n_jobs, ctx)
 
 
@@ -56,7 +56,7 @@ class ProcessPoolOpInvoker(ModelOpInvoker[A, R], Generic[M, A, R]):
         log.debug("persisting function")
         if worker_parallel is None:
             worker_parallel = ParallelConfig(1, 1, get_parallel_config().child_threads, 1)
-        ctx = LenskitMPContext(worker_parallel)
+        ctx = LensKitMPContext(worker_parallel)
 
         log.debug("initializing shared memory")
         self.manager = SharedMemoryManager()
@@ -88,7 +88,7 @@ class ProcessPoolOpInvoker(ModelOpInvoker[A, R], Generic[M, A, R]):
         _log.debug("process pool shut down")
 
 
-class LenskitProcess(SpawnProcess):
+class LensKitProcess(SpawnProcess):
     "LensKit worker process implementation."
 
     def __init__(
@@ -115,7 +115,7 @@ class LenskitProcess(SpawnProcess):
                     ctx.send_task(task)
 
 
-class LenskitMPContext(SpawnContext):
+class LensKitMPContext(SpawnContext):
     "LensKit multiprocessing context."
 
     _log_config: WorkerLogConfig
@@ -126,4 +126,4 @@ class LenskitMPContext(SpawnContext):
         self._parallel_config = parallel
 
     def Process(self, *args: Any, **kwargs: Any) -> SpawnProcess:
-        return LenskitProcess(self._log_config, self._parallel_config, *args, **kwargs)
+        return LensKitProcess(self._log_config, self._parallel_config, *args, **kwargs)


### PR DESCRIPTION
This is a small internal tweak to rename a few classes called `LenskitXX` to `LensKitXX` for consistency with branding.