### PR TITLE
Separate PipelineBuilder from Pipeline and update run api

### DIFF
--- a/docs/api/pipeline.rst
+++ b/docs/api/pipeline.rst
@@ -15,6 +15,7 @@ Pipeline Classes
     :caption: Data Sets
 
     ~lenskit.pipeline.Pipeline
+    ~lenskit.pipeline.PipelineBuilder
     ~lenskit.pipeline.PipelineState
     ~lenskit.pipeline.Node
     ~lenskit.pipeline.Lazy

--- a/docs/guide/pipeline.rst
+++ b/docs/guide/pipeline.rst
@@ -169,9 +169,6 @@ The :meth:`~Pipeline.run` method takes two types of inputs:
     obtained (e.g. initial item scores and final rankings, which may have
     altered scores).
 
-    If no components are specified, it is the same as specifying the last
-    component that was added to the pipeline.
-
 *   Keyword arguments specifying the values for the pipeline's inputs, as defined by
     calls to :meth:`Pipeline.create_input`.
 

--- a/docs/guide/pipeline.rst
+++ b/docs/guide/pipeline.rst
@@ -326,11 +326,11 @@ The convenience methods are equivalent to the following pipeline code:
     # allow candidate items to be optionally specified
     items = pipe.create_input('items', ItemList, None)
     # look up a user's history in the training data
-    history = pipe.add_component('history-lookup', LookupTrainingHistory(), query=query)
+    history = pipe.add_component('history-lookup', LookupTrainingHistory, query=query)
     # find candidates from the training data
     default_candidates = pipe.add_component(
         'candidate-selector',
-        UnratedTrainingItemsCandidateSelector(),
+        UnratedTrainingItemsCandidateSelector,
         query=history,
     )
     # if the client provided items as a pipeline input, use those; otherwise
@@ -339,7 +339,7 @@ The convenience methods are equivalent to the following pipeline code:
     # score the candidate items using the specified scorer
     score = pipe.add_component('scorer', scorer, query=query, items=candidates)
     # rank the items by score
-    recommend = pipe.add_component('ranker', TopNRanker(50), items=score)
+    recommend = pipe.add_component('ranker', TopNRanker, {'n': 50}, items=score)
     pipe.alias('recommender', recommend)
     pipe.default_component('recommender')
     pipe = pipe.build()
@@ -463,6 +463,32 @@ Finally, you can directly pass configuration parameters to the component constru
     }>
 
 See :ref:`conventions` for more conventions for component design.
+
+Adding Components to the Pipeline
+---------------------------------
+
+You can add components to the pipeline in two ways:
+
+*   Instantiate the component with its configuration options and pass it to
+    :meth:`PipelineBuilder.add_component`::
+
+        builder.add_component('component-name', MyComponent(option='value'))
+
+    When you convert the pipeline into
+    a configuration or clone it, the component will be re-instantiated from its
+    configuration.
+
+*   Pass the component class and configuration separately to
+    :meth:`PipelineBuilder.add_component`::
+
+        builder.add_component('component-name', MyComponent, MyConfig(option='value'))
+
+    Alternatively::
+
+        builder.add_component('component-name', MyComponent, {'option': 'value'}))
+
+When you use the second approach, :meth:`PipelineBuilder.build` instantiates the
+component from the provided configuration.
 
 POPROX and Other Integrators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guide/pipeline.rst
+++ b/docs/guide/pipeline.rst
@@ -171,6 +171,9 @@ you can do a couple of things:
     :class:`PipelineConfig` that can be serialized and reloaded from JSON, YAML,
     or similar formats.
 
+Building a pipeline resolves default connections, instantiates components from their
+configurations, and checks for cycles.
+
 .. _pipeline-execution:
 
 Execution

--- a/docs/guide/pipeline.rst
+++ b/docs/guide/pipeline.rst
@@ -134,16 +134,16 @@ These input connections are specified via keyword arguments to the
 component's input name(s) and the node or data to which each input should be
 wired.
 
-..
-    You can also use :meth:`Pipeline.add_default` to specify default connections. For example,
-    you can specify a default for ``user``::
 
-        pipe.add_default('user', user_history)
+You can also use :meth:`Pipeline.set_default` to specify default connections.
+For example, you can specify a default for inputs named ``user``::
 
-    With this default in place, if a component has an input named ``user`` and that
-    input is not explicitly connected to a node, then the ``user_history`` node will
-    be used to supply its value.  Judicious use of defaults can reduce the amount of
-    code overhead needed to wire common pipelines.
+    pipe.set_default('user', user_history)
+
+With this default in place, if a component has an input named ``user`` and that
+input is not explicitly connected to a node, then the ``user_history`` node will
+be used to supply its value.  Judicious use of defaults can reduce the amount of
+code overhead needed to wire common pipelines.
 
 .. note::
 

--- a/lenskit/lenskit/basic/history.py
+++ b/lenskit/lenskit/basic/history.py
@@ -29,6 +29,7 @@ class UserTrainingHistoryLookup(Component[ItemList], Trainable):
         Caller
     """
 
+    config: None
     training_data_: Dataset
 
     @override
@@ -72,6 +73,7 @@ class KnownRatingScorer(Component[ItemList], Trainable):
             in the query as the source of score data.
     """
 
+    config: None
     score: Literal["rating", "indicator"] | None
     source: Literal["training", "query"]
 

--- a/lenskit/lenskit/batch/_runner.py
+++ b/lenskit/lenskit/batch/_runner.py
@@ -147,7 +147,7 @@ class BatchPipelineRunner:
 
         n_users = len(test_data)
         log = _log.bind(
-            name=pipeline.name, hash=pipeline.config_hash(), n_queries=n_users, n_jobs=self.n_jobs
+            name=pipeline.name, hash=pipeline.config_hash, n_queries=n_users, n_jobs=self.n_jobs
         )
         log.info("beginning batch run")
 

--- a/lenskit/lenskit/pipeline/__init__.py
+++ b/lenskit/lenskit/pipeline/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from lenskit.diagnostics import PipelineError, PipelineWarning
 
 from ._impl import CloneMethod, Pipeline
+from .builder import PipelineBuilder
 from .common import RecPipelineBuilder, topn_pipeline
 from .components import (
     Component,
@@ -25,6 +26,7 @@ from .types import Lazy
 
 __all__ = [
     "Pipeline",
+    "PipelineBuilder",
     "CloneMethod",
     "PipelineError",
     "PipelineWarning",

--- a/lenskit/lenskit/pipeline/_impl.py
+++ b/lenskit/lenskit/pipeline/_impl.py
@@ -1,6 +1,7 @@
 # pyright: strict
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import replace
 from uuid import NAMESPACE_URL, uuid5
 
@@ -59,9 +60,14 @@ class Pipeline:
     _default: Node[Any] | None = None
     _hash: str | None = None
 
-    def __init__(self, config: config.PipelineConfig, nodes: dict[str, Node[Any]]):
+    def __init__(self, config: config.PipelineConfig, nodes: Iterable[Node[Any]]):
+        self._nodes = {}
+        for node in nodes:
+            if isinstance(node, ComponentInstanceNode):
+                raise RuntimeError("pipeline is not fully instantiated")
+            self._nodes[node.name] = node
+
         self._config = config
-        self._nodes = dict(nodes)
         self._aliases = {a: self.node(t) for (a, t) in config.aliases.items()}
         if config.default:
             self._default = self.node(config.default)

--- a/lenskit/lenskit/pipeline/_impl.py
+++ b/lenskit/lenskit/pipeline/_impl.py
@@ -203,6 +203,9 @@ class Pipeline:
                 case _:
                     pass
 
+        if self._default:
+            clone.default_component(self._default.name)
+
         return clone.build()
 
     @property

--- a/lenskit/lenskit/pipeline/builder.py
+++ b/lenskit/lenskit/pipeline/builder.py
@@ -1,0 +1,684 @@
+"""
+LensKit pipeline builder.
+"""
+
+# pyright: strict
+from __future__ import annotations
+
+import typing
+import warnings
+from dataclasses import replace
+from types import FunctionType, UnionType
+from uuid import NAMESPACE_URL, uuid4, uuid5
+
+from numpy.random import BitGenerator, Generator, SeedSequence
+from typing_extensions import Any, Literal, Self, TypeAlias, TypeVar, cast, overload
+
+from lenskit.data import Dataset
+from lenskit.diagnostics import PipelineError, PipelineWarning
+from lenskit.logging import get_logger
+from lenskit.training import Trainable, TrainingOptions
+
+from . import config
+from ._impl import Pipeline
+from .components import (  # type: ignore # noqa: F401
+    Component,
+    PipelineFunction,
+    fallback_on_none,
+    instantiate_component,
+)
+from .config import PipelineConfig
+from .nodes import ND, ComponentNode, InputNode, LiteralNode, Node
+from .types import parse_type_string
+
+_log = get_logger(__name__)
+
+# common type var for quick use
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+
+CloneMethod: TypeAlias = Literal["config", "pipeline-config"]
+NAMESPACE_LITERAL_DATA = uuid5(NAMESPACE_URL, "https://ns.lenskit.org/literal-data/")
+
+
+class PipelineBuilder:
+    """
+    Builder for LensKit recommendation pipelines.  :ref:`Pipelines <pipeline>`
+    are the core abstraction for using LensKit models and other components to
+    produce recommendations in a useful way.  They allow you to wire together
+    components in (mostly) abitrary graphs, train them on data, and serialize
+    the resulting pipelines to disk for use elsewhere.
+
+    The builder configures and builds pipelines that can then be run. If you
+    have a scoring model and just want to generate recommenations with a default
+    setup and minimal configuration, see :func:`~lenskit.pipeline.topn_pipeline`
+    or :class:`~lenskit.pipeline.RecPipelineBuilder`.
+
+    Args:
+        name:
+            A name for the pipeline.
+        version:
+            A numeric version for the pipeline.
+
+    Stability:
+        Caller
+    """
+
+    name: str | None = None
+    """
+    The pipeline name.
+    """
+    version: str | None = None
+    """
+    The pipeline version string.
+    """
+
+    _nodes: dict[str, Node[Any]]
+    _aliases: dict[str, Node[Any]]
+    _defaults: dict[str, Node[Any]]
+    _components: dict[str, PipelineFunction[Any] | Component[Any]]
+    _hash: str | None = None
+    _last: Node[Any] | None = None
+    _anon_nodes: set[str]
+    "Track generated node names."
+
+    def __init__(self, name: str | None = None, version: str | None = None):
+        self.name = name
+        self.version = version
+        self._nodes = {}
+        self._aliases = {}
+        self._defaults = {}
+        self._components = {}
+        self._anon_nodes = set()
+        self._clear_caches()
+
+    def meta(self, *, include_hash: bool = True) -> config.PipelineMeta:
+        """
+        Get the metadata (name, version, hash, etc.) for this pipeline without
+        returning the whole config.
+
+        Args:
+            include_hash:
+                Whether to include a configuration hash in the metadata.
+        """
+        meta = config.PipelineMeta(name=self.name, version=self.version)
+        if include_hash:
+            meta.hash = self.config_hash()
+        return meta
+
+    @property
+    def nodes(self) -> list[Node[object]]:
+        """
+        Get the nodes in the pipeline graph.
+        """
+        return list(self._nodes.values())
+
+    @overload
+    def node(self, node: str, *, missing: Literal["error"] = "error") -> Node[object]: ...
+    @overload
+    def node(self, node: str, *, missing: Literal["none"] | None) -> Node[object] | None: ...
+    @overload
+    def node(self, node: Node[T]) -> Node[T]: ...
+    def node(
+        self, node: str | Node[Any], *, missing: Literal["error", "none"] | None = "error"
+    ) -> Node[object] | None:
+        """
+        Get the pipeline node with the specified name.  If passed a node, it
+        returns the node or fails if the node is not a member of the pipeline.
+
+        Args:
+            node:
+                The name of the pipeline node to look up, or a node to check for
+                membership.
+
+        Returns:
+            The pipeline node, if it exists.
+
+        Raises:
+            KeyError:
+                The specified node does not exist.
+        """
+        if isinstance(node, Node):
+            self._check_member_node(node)
+            return node
+        elif node in self._aliases:
+            return self._aliases[node]
+        elif node in self._nodes:
+            return self._nodes[node]
+        elif missing == "none" or missing is None:
+            return None
+        else:
+            raise KeyError(f"node {node}")
+
+    def create_input(self, name: str, *types: type[T] | None) -> Node[T]:
+        """
+        Create an input node for the pipeline.  Pipelines expect their inputs to
+        be provided when they are run.
+
+        Args:
+            name:
+                The name of the input.  The name must be unique in the pipeline
+                (among both components and inputs).
+            types:
+                The allowable types of the input; input data can be of any
+                specified type.  If ``None`` is among the allowed types, the
+                input can be omitted.
+
+        Returns:
+            A pipeline node representing this input.
+
+        Raises:
+            ValueError:
+                a node with the specified ``name`` already exists.
+        """
+        self._check_available_name(name)
+
+        rts: set[type[T | None]] = set()
+        for t in types:
+            if t is None:
+                rts.add(type(None))
+            elif isinstance(t, UnionType):
+                rts |= set(typing.get_args(t))
+            else:
+                rts.add(t)
+
+        node = InputNode[Any](name, types=rts)
+        self._nodes[name] = node
+        self._clear_caches()
+        return node
+
+    def literal(self, value: T, *, name: str | None = None) -> LiteralNode[T]:
+        """
+        Create a literal node (a node with a fixed value).
+
+        .. note::
+            Literal nodes cannot be serialized witih :meth:`get_config` or
+            :meth:`save_config`.
+        """
+        if name is None:
+            name = str(uuid4())
+            self._anon_nodes.add(name)
+        node = LiteralNode(name, value, types=set([type(value)]))
+        self._nodes[name] = node
+        self._clear_caches()
+        return node
+
+    def set_default(self, name: str, node: Node[Any] | object) -> None:
+        """
+        Set the default wiring for a component input.  Components that declare
+        an input parameter with the specified ``name`` but no configured input
+        will be wired to this node.
+
+        This is intended to be used for things like wiring up `user` parameters
+        to semi-automatically receive the target user's identity and history.
+
+        Args:
+            name:
+                The name of the parameter to set a default for.
+            node:
+                The node or literal value to wire to this parameter.
+        """
+        if not isinstance(node, Node):
+            node = self.literal(node)
+        self._defaults[name] = node
+        self._clear_caches()
+
+    def get_default(self, name: str) -> Node[Any] | None:
+        """
+        Get the default wiring for an input name.
+        """
+        return self._defaults.get(name, None)
+
+    def alias(self, alias: str, node: Node[Any] | str) -> None:
+        """
+        Create an alias for a node.  After aliasing, the node can be retrieved
+        from :meth:`node` using either its original name or its alias.
+
+        Args:
+            alias:
+                The alias to add to the node.
+            node:
+                The node (or node name) to alias.
+
+        Raises:
+            ValueError:
+                if the alias is already used as an alias or node name.
+        """
+        node = self.node(node)
+        self._check_available_name(alias)
+        self._aliases[alias] = node
+        self._clear_caches()
+
+    def add_component(
+        self, name: str, obj: Component[ND] | PipelineFunction[ND], **inputs: Node[Any] | object
+    ) -> Node[ND]:
+        """
+        Add a component and connect it into the graph.
+
+        Args:
+            name:
+                The name of the component in the pipeline.  The name must be
+                unique in the pipeline (among both components and inputs).
+            obj:
+                The component itself.
+            inputs:
+                The component's input wiring.  See :ref:`pipeline-connections`
+                for details.
+
+        Returns:
+            The node representing this component in the pipeline.
+        """
+        self._check_available_name(name)
+
+        node = ComponentNode(name, obj)
+        self._nodes[name] = node
+        self._components[name] = obj
+
+        self.connect(node, **inputs)
+
+        self._clear_caches()
+        self._last = node
+        return node
+
+    def replace_component(
+        self,
+        name: str | Node[ND],
+        obj: Component[ND] | PipelineFunction[ND],
+        **inputs: Node[Any] | object,
+    ) -> Node[ND]:
+        """
+        Replace a component in the graph.  The new component must have a type
+        that is compatible with the old component.  The old component's input
+        connections will be replaced (as the new component may have different
+        inputs), but any connections that use the old component to supply an
+        input will use the new component instead.
+        """
+        if isinstance(name, Node):
+            name = name.name
+
+        node = ComponentNode(name, obj)
+        self._nodes[name] = node
+        self._components[name] = obj
+
+        self.connect(node, **inputs)
+
+        self._clear_caches()
+        return node
+
+    def connect(self, obj: str | Node[Any], **inputs: Node[Any] | str | object):
+        """
+        Provide additional input connections for a component that has already
+        been added.  See :ref:`pipeline-connections` for details.
+
+        Args:
+            obj:
+                The name or node of the component to wire.
+            inputs:
+                The component's input wiring.  For each keyword argument in the
+                component's function signature, that argument can be provided
+                here with an input that the pipeline will provide to that
+                argument of the component when the pipeline is run.
+        """
+        if isinstance(obj, Node):
+            node = obj
+        else:
+            node = self.node(obj)
+        if not isinstance(node, ComponentNode):
+            raise TypeError(f"only component nodes can be wired, not {node}")
+
+        for k, n in inputs.items():
+            if isinstance(n, Node):
+                n = cast(Node[Any], n)
+                self._check_member_node(n)
+                node.connections[k] = n.name
+            else:
+                lit = self.literal(n)
+                node.connections[k] = lit.name
+
+        self._clear_caches()
+
+    def component_configs(self) -> dict[str, dict[str, Any]]:
+        """
+        Get the configurations for the components.  This is the configurations
+        only, it does not include pipeline inputs or wiring.
+        """
+        return {
+            name: comp.dump_config()
+            for (name, comp) in self._components.items()
+            if isinstance(comp, Component)
+        }
+
+    def clone(self, how: CloneMethod = "config") -> Pipeline:
+        """
+        Clone the pipeline, optionally including trained parameters.
+
+        The ``how`` parameter controls how the pipeline is cloned, and what is
+        available in the clone pipeline.  It can be one of the following values:
+
+        ``"config"``
+            Create fresh component instances using the configurations of the
+            components in this pipeline.  When applied to a trained pipeline,
+            the clone does **not** have the original's learned parameters. This
+            is the default clone method.
+        ``"pipeline-config"``
+            Round-trip the entire pipeline through :meth:`get_config` and
+            :meth:`from_config`.
+
+        Args:
+            how:
+                The mechanism to use for cloning the pipeline.
+
+        Returns:
+            A new pipeline with the same components and wiring, but fresh
+            instances created by round-tripping the configuration.
+        """
+        if how == "pipeline-config":
+            cfg = self.get_config()
+            return self.from_config(cfg)
+        elif how != "config":  # pragma: nocover
+            raise NotImplementedError("only 'config' cloning is currently supported")
+
+        clone = PipelineBuilder()
+
+        for node in self.nodes:
+            match node:
+                case InputNode(name, types=types):
+                    if types is None:
+                        types = set[type]()
+                    clone.create_input(name, *types)
+                case LiteralNode(name, value):
+                    clone._nodes[name] = LiteralNode(name, value)
+                case ComponentNode(name, comp, _inputs, wiring):
+                    if isinstance(comp, FunctionType):
+                        comp = comp
+                    elif isinstance(comp, Component):
+                        comp = comp.__class__(comp.config)  # type: ignore
+                    else:
+                        comp = comp.__class__()  # type: ignore
+                    cn = clone.add_component(node.name, comp)  # type: ignore
+                    for wn, wt in wiring.items():
+                        clone.connect(cn, **{wn: clone.node(wt)})
+                case _:  # pragma: nocover
+                    raise RuntimeError(f"invalid node {node}")
+
+        for n, t in self._aliases.items():
+            clone.alias(n, t.name)
+
+        for n, t in self._defaults.items():
+            clone.set_default(n, clone.node(t.name))
+
+        return clone
+
+    def get_config(self, *, include_hash: bool = True) -> PipelineConfig:
+        """
+        Get this pipeline's configuration for serialization.  The configuration
+        consists of all inputs and components along with their configurations
+        and input connections.  It can be serialized to disk (in JSON, YAML, or
+        a similar format) to save a pipeline.
+
+        The configuration does **not** include any trained parameter values,
+        although the configuration may include things such as paths to
+        checkpoints to load such parameters, depending on the design of the
+        components in the pipeline.
+
+        .. note::
+            Literal nodes (from :meth:`literal`, or literal values wired to
+            inputs) cannot be serialized, and this method will fail if they
+            are present in the pipeline.
+        """
+        meta = self.meta(include_hash=False)
+        cfg = PipelineConfig(meta=meta)
+
+        # We map anonymous nodes to hash-based names for stability.  If we ever
+        # allow anonymous components, this will need to be adjusted to maintain
+        # component ordering, but it works for now since only literals can be
+        # anonymous. First handle the anonymous nodes, so we have that mapping:
+        remapped: dict[str, str] = {}
+        for an in self._anon_nodes:
+            node = self._nodes.get(an, None)
+            match node:
+                case None:
+                    # skip nodes that no longer exist
+                    continue
+                case LiteralNode(name, value):
+                    lit = config.PipelineLiteral.represent(value)
+                    sname = str(uuid5(NAMESPACE_LITERAL_DATA, lit.model_dump_json()))
+                    _log.debug("renamed anonymous node %s to %s", name, sname)
+                    remapped[name] = sname
+                    cfg.literals[sname] = lit
+                case _:
+                    # the pipeline only generates anonymous literal nodes right now
+                    raise RuntimeError(f"unexpected anonymous node {node}")
+
+        # Now we go over all named nodes and add them to the config:
+        for node in self.nodes:
+            if node.name in remapped:
+                continue
+
+            match node:
+                case InputNode():
+                    cfg.inputs.append(config.PipelineInput.from_node(node))
+                case LiteralNode(name, value):
+                    cfg.literals[name] = config.PipelineLiteral.represent(value)
+                case ComponentNode(name):
+                    cfg.components[name] = config.PipelineComponent.from_node(node, remapped)
+                case _:  # pragma: nocover
+                    raise RuntimeError(f"invalid node {node}")
+
+        cfg.aliases = {a: t.name for (a, t) in self._aliases.items()}
+        cfg.defaults = {n: t.name for (n, t) in self._defaults.items()}
+
+        if include_hash:
+            cfg.meta.hash = config.hash_config(cfg)
+
+        return cfg
+
+    def config_hash(self) -> str:
+        """
+        Get a hash of the pipeline's configuration to uniquely identify it for
+        logging, version control, or other purposes.
+
+        The hash format and algorithm are not guaranteed, but is stable within a
+        LensKit version.  For the same version of LensKit and component code,
+        the same configuration will produce the same hash, so long as there are
+        no literal nodes.  Literal nodes will *usually* hash consistently, but
+        since literals other than basic JSON values are hashed by pickling, hash
+        stability depends on the stability of the pickle bytestream.
+
+        In LensKit 2025.1, the configuration hash is computed by computing the
+        JSON serialization of the pipeline configuration *without* a hash and
+        returning the hex-encoded SHA256 hash of that configuration.
+        """
+        if self._hash is None:
+            # get the config *without* a hash
+            cfg = self.get_config(include_hash=False)
+            self._hash = config.hash_config(cfg)
+        return self._hash
+
+    @classmethod
+    def from_config(cls, config: object) -> Self:
+        """
+        Reconstruct a pipeline from a serialized configuration.
+
+        Args:
+            config:
+                The configuration object, as loaded from JSON, TOML, YAML, or
+                similar. Will be validated into a :class:`PipelineConfig`.
+        Returns:
+            The configured (but not trained) pipeline.
+        Raises:
+            PipelineError:
+                If there is a configuration error reconstructing the pipeline.
+        Warns:
+            PipelineWarning:
+                If the configuration is funny but usable; for example, the
+                configuration includes a hash but the constructed pipeline does
+                not have a matching hash.
+        """
+        cfg = PipelineConfig.model_validate(config)
+        pipe = cls()
+        for inpt in cfg.inputs:
+            types: list[type[Any] | None] = []
+            if inpt.types is not None:
+                types += [parse_type_string(t) for t in inpt.types]
+            pipe.create_input(inpt.name, *types)
+
+        # we now add the components and other nodes in multiple passes to ensure
+        # that nodes are available before they are wired (since `connect` can
+        # introduce out-of-order dependencies).
+
+        # pass 1: add literals
+        for name, data in cfg.literals.items():
+            pipe.literal(data.decode(), name=name)
+
+        # pass 2: add components
+        to_wire: list[config.PipelineComponent] = []
+        for name, comp in cfg.components.items():
+            if comp.code.startswith("@"):
+                # ignore special nodes in first pass
+                continue
+
+            obj = instantiate_component(comp.code, comp.config)
+            pipe.add_component(name, obj)
+            to_wire.append(comp)
+
+        # pass 3: wiring
+        for name, comp in cfg.components.items():
+            if isinstance(comp.inputs, dict):
+                inputs = {n: pipe.node(t) for (n, t) in comp.inputs.items()}
+                pipe.connect(name, **inputs)
+            elif not comp.code.startswith("@"):
+                raise PipelineError(f"component {name} inputs must be dict, not list")
+
+        # pass 4: aliases
+        for n, t in cfg.aliases.items():
+            pipe.alias(n, t)
+
+        # pass 5: defaults
+        for n, t in cfg.defaults.items():
+            pipe.set_default(n, pipe.node(t))
+
+        if cfg.meta.hash is not None:
+            h2 = pipe.config_hash()
+            if h2 != cfg.meta.hash:
+                _log.warning("loaded pipeline does not match hash")
+                warnings.warn("loaded pipeline config does not match hash", PipelineWarning)
+
+        return pipe
+
+    def train(self, data: Dataset, options: TrainingOptions | None = None) -> None:
+        """
+        Trains the pipeline's trainable components (those implementing the
+        :class:`TrainableComponent` interface) on some training data.
+
+        .. admonition:: Random Number Generation
+            :class: note
+
+            If :attr:`TrainingOptions.rng` is set and is not a generator or bit
+            generator (i.e. it is a seed), then this method wraps the seed in a
+            :class:`~numpy.random.SeedSequence` and calls
+            :class:`~numpy.random.SeedSequence.spawn()` to generate a distinct
+            seed for each component in the pipeline.
+
+        Args:
+            data:
+                The dataset to train on.
+            options:
+                The training options.  If ``None``, default options are used.
+        """
+        log = _log.bind(pipeline=self.name)
+        if options is None:
+            options = TrainingOptions()
+
+        if isinstance(options.rng, SeedSequence):
+            seed = options.rng
+        elif options.rng is None or isinstance(options.rng, (Generator, BitGenerator)):
+            seed = None
+        else:
+            seed = SeedSequence(options.rng)
+
+        log.info("training pipeline components")
+        for name, comp in self._components.items():
+            clog = log.bind(name=name, component=comp)
+            if isinstance(comp, Trainable):
+                # spawn new seed if needed
+                c_opts = options if seed is None else replace(options, rng=seed.spawn(1)[0])
+                clog.info("training component")
+                comp.train(data, c_opts)
+            else:
+                clog.debug("training not required")
+
+    def use_first_of(self, name: str, primary: Node[T | None], fallback: Node[T]) -> Node[T]:
+        """
+        Ergonomic method to create a new node that returns the result of its
+        ``input`` if it is provided and not ``None``, and otherwise returns the
+        result of ``fallback``.  This method is used for things like filling in
+        optional pipeline inputs.  For example, if you want the pipeline to take
+        candidate items through an ``items`` input, but look them up from the
+        user's history and the training data if ``items`` is not supplied, you
+        would do:
+
+        .. code:: python
+
+            pipe = Pipeline()
+            # allow candidate items to be optionally specified
+            items = pipe.create_input('items', list[EntityId], None)
+            # find candidates from the training data (optional)
+            lookup_candidates = pipe.add_component(
+                'select-candidates', UnratedTrainingItemsCandidateSelector(),
+                user=history,
+            )
+            # if the client provided items as a pipeline input, use those; otherwise
+            # use the candidate selector we just configured.
+            candidates = pipe.use_first_of('candidates', items, lookup_candidates)
+
+        .. note::
+
+            This method does not distinguish between an input being unspecified
+            and explicitly specified as ``None``.
+
+        .. note::
+
+            This method does *not* implement item-level fallbacks, only
+            fallbacks at the level of entire results.  For item-level score
+            fallbacks, see :class:`~lenskit.basic.FallbackScorer`.
+
+        .. note::
+            If one of the fallback elements is a component ``A`` that depends on
+            another component or input ``B``, and ``B`` is missing or returns
+            ``None`` such that ``A`` would usually fail, then ``A`` will be
+            skipped and the fallback will move on to the next node. This works
+            with arbitrarily-deep transitive chains.
+
+        Args:
+            name:
+                The name of the node.
+            primary:
+                The node to use as the primary input, if it is available.
+            fallback:
+                The node to use if the primary input does not provide a value.
+        """
+        return self.add_component(name, fallback_on_none, primary=primary, fallback=fallback)
+
+    def build(self) -> Pipeline:
+        """
+        Build the pipeline.
+        """
+        return self  # type: ignore
+
+    def _check_available_name(self, name: str) -> None:
+        if name in self._nodes or name in self._aliases:
+            raise ValueError(f"pipeline already has node {name}")
+
+    def _check_member_node(self, node: Node[Any]) -> None:
+        nw = self._nodes.get(node.name)
+        if nw is not node:
+            raise PipelineError(f"node {node} not in pipeline")
+
+    def _clear_caches(self):
+        if "_hash" in self.__dict__:
+            del self._hash

--- a/lenskit/lenskit/pipeline/builder.py
+++ b/lenskit/lenskit/pipeline/builder.py
@@ -472,7 +472,9 @@ class PipelineBuilder:
         edges = deepcopy(self._edges)
         for node in self._nodes.values():
             if isinstance(node, ComponentNode):
-                c_ins = edges[node.name]
+                c_ins = edges.get(node.name, None)
+                if c_ins is None:
+                    edges[node.name] = c_ins = {}
                 for iname in node.inputs.keys():
                     if iname not in c_ins and iname in self._default_connections:
                         c_ins[iname] = self._default_connections[iname]

--- a/lenskit/lenskit/pipeline/builder.py
+++ b/lenskit/lenskit/pipeline/builder.py
@@ -399,7 +399,6 @@ class PipelineBuilder:
 
         # Check for cycles
         graph = {n: set(w.values()) for (n, w) in self._edges.items()}
-        print(graph)
         ts = TopologicalSorter(graph)
         try:
             ts.prepare()

--- a/lenskit/lenskit/pipeline/builder.py
+++ b/lenskit/lenskit/pipeline/builder.py
@@ -645,7 +645,7 @@ class PipelineBuilder:
         Build the pipeline.
         """
         config = self.build_config()
-        return Pipeline(config, self._nodes.values())
+        return Pipeline(config, [self._instantiate(n) for n in self._nodes.values()])
 
     def _instantiate(self, node: Node[ND]) -> Node[ND]:
         match node:

--- a/lenskit/lenskit/pipeline/builder.py
+++ b/lenskit/lenskit/pipeline/builder.py
@@ -156,7 +156,7 @@ class PipelineBuilder:
         else:
             raise KeyError(f"node {node}")
 
-    def create_input(self, name: str, *types: type[T] | None) -> Node[T]:
+    def create_input(self, name: str, *types: type[T] | UnionType | None) -> Node[T]:
         """
         Create an input node for the pipeline.  Pipelines expect their inputs to
         be provided when they are run.
@@ -638,7 +638,7 @@ class PipelineBuilder:
         Build the pipeline.
         """
         config = self.build_config()
-        return Pipeline(config, self._nodes)
+        return Pipeline(config, self._nodes.values())
 
     def _instantiate(self, node: Node[ND]) -> Node[ND]:
         match node:

--- a/lenskit/lenskit/pipeline/builder.py
+++ b/lenskit/lenskit/pipeline/builder.py
@@ -34,7 +34,7 @@ from .nodes import (
     LiteralNode,
     Node,
 )
-from .types import parse_type_string
+from .types import TypecheckWarning, parse_type_string
 
 _log = get_logger(__name__)
 
@@ -307,6 +307,8 @@ class PipelineBuilder:
         self._check_available_name(name)
 
         node = ComponentNode[ND].create(name, comp, config)
+        if node.types is None:
+            warnings.warn(f"cannot determine return type of component {comp}", TypecheckWarning)
         self._nodes[name] = node
 
         self.connect(node, **inputs)

--- a/lenskit/lenskit/pipeline/builder.py
+++ b/lenskit/lenskit/pipeline/builder.py
@@ -445,6 +445,8 @@ class PipelineBuilder:
         for n, t in self._default_connections.items():
             clone.default_connection(n, clone.node(t))
 
+        clone._default = self._default
+
         return clone
 
     def build_config(self, *, include_hash: bool = True) -> PipelineConfig:

--- a/lenskit/lenskit/pipeline/builder.py
+++ b/lenskit/lenskit/pipeline/builder.py
@@ -486,12 +486,12 @@ class PipelineBuilder:
                     cfg.literals[name] = config.PipelineLiteral.represent(value)
                 case ComponentNode(name):
                     c_cfg = config.PipelineComponent.from_node(node)
-                    c_cfg.inputs = edges.get(name, {}).copy()
+                    c_cfg.inputs = dict(sorted(edges.get(name, {}).items(), key=lambda kv: kv[0]))
                     cfg.components[name] = c_cfg
                 case _:  # pragma: nocover
                     raise RuntimeError(f"invalid node {node}")
 
-        cfg.aliases = {a: t.name for (a, t) in self._aliases.items()}
+        cfg.aliases = {a: t.name for (a, t) in sorted(self._aliases.items(), key=lambda kv: kv[0])}
 
         if self._default:
             cfg.default = self._default
@@ -584,7 +584,9 @@ class PipelineBuilder:
             h2 = builder.config_hash()
             if h2 != cfg.meta.hash:
                 _log.warning("loaded pipeline does not match hash")
-                warnings.warn("loaded pipeline config does not match hash", PipelineWarning)
+                warnings.warn(
+                    "loaded pipeline config does not match hash", PipelineWarning, stacklevel=2
+                )
 
         return builder
 

--- a/lenskit/lenskit/pipeline/common.py
+++ b/lenskit/lenskit/pipeline/common.py
@@ -8,6 +8,7 @@ from typing import Literal
 from lenskit.data import ID, ItemList, RecQuery
 
 from ._impl import Pipeline
+from .builder import PipelineBuilder
 from .components import Component
 
 
@@ -89,7 +90,7 @@ class RecPipelineBuilder:
         from lenskit.basic.composite import FallbackScorer
         from lenskit.basic.history import UserTrainingHistoryLookup
 
-        pipe = Pipeline(name=name)
+        pipe = PipelineBuilder(name=name)
 
         query = pipe.create_input("query", RecQuery, ID, ItemList)
 
@@ -121,8 +122,9 @@ class RecPipelineBuilder:
 
         rank = pipe.add_component("ranker", self._ranker, items=n_score, n=n_n)
         pipe.alias("recommender", rank)
+        pipe.default_component("recommender")
 
-        return pipe
+        return pipe.build()
 
 
 def topn_pipeline(
@@ -196,7 +198,7 @@ def predict_pipeline(
     from lenskit.basic.composite import FallbackScorer
     from lenskit.basic.history import UserTrainingHistoryLookup
 
-    pipe = Pipeline(name=name)
+    pipe = PipelineBuilder(name=name)
 
     query = pipe.create_input("query", RecQuery, ID, ItemList)
     items = pipe.create_input("items", ItemList)
@@ -214,4 +216,6 @@ def predict_pipeline(
         backup = pipe.add_component("fallback-predictor", fallback, query=lookup, items=items)
         pipe.add_component("rating-predictor", FallbackScorer(), primary=score, fallback=backup)
 
-    return pipe
+    pipe.default_component("rating-predictor")
+
+    return pipe.build()

--- a/lenskit/lenskit/pipeline/components.py
+++ b/lenskit/lenskit/pipeline/components.py
@@ -268,6 +268,8 @@ def instantiate_component(
 
 def component_inputs(
     component: Component[COut] | ComponentConstructor[Any, COut] | PipelineFunction[COut],
+    *,
+    warn_on_missing: bool = True,
 ) -> dict[str, type | None]:
     if isinstance(component, FunctionType):
         function = component
@@ -287,11 +289,12 @@ def component_inputs(
         if pt := types.get(param.name, None):
             inputs[param.name] = pt
         else:
-            warnings.warn(
-                f"parameter {param.name} of component {component} has no type annotation",
-                TypecheckWarning,
-                2,
-            )
+            if warn_on_missing:
+                warnings.warn(
+                    f"parameter {param.name} of component {component} has no type annotation",
+                    TypecheckWarning,
+                    2,
+                )
             inputs[param.name] = None
 
     return inputs

--- a/lenskit/lenskit/pipeline/components.py
+++ b/lenskit/lenskit/pipeline/components.py
@@ -270,10 +270,12 @@ def instantiate_component(
 def component_inputs(
     component: Component[COut] | ComponentConstructor[Any, COut] | PipelineFunction[COut],
 ) -> dict[str, type | None]:
-    if isinstance(component, (Component, type)):
-        function = component.__call__
-    else:
+    if isinstance(component, FunctionType):
         function = component
+    elif hasattr(component, "__call__"):
+        function = getattr(component, "__call__")
+    else:
+        raise TypeError("invalid component " + repr(component))
 
     types = get_type_hints(function)
     sig = signature(function)
@@ -299,11 +301,14 @@ def component_inputs(
 def component_return_type(
     component: Component[COut] | ComponentConstructor[Any, COut] | PipelineFunction[COut],
 ) -> type | None:
-    if isinstance(component, (Component, type)):
-        types = get_type_hints(component.__call__)
+    if isinstance(component, FunctionType):
+        function = component
+    elif hasattr(component, "__call__"):
+        function = getattr(component, "__call__")
     else:
-        types = get_type_hints(component)
-    print(types)
+        raise TypeError("invalid component " + repr(component))
+
+    types = get_type_hints(function)
     return types.get("return", None)
 
 

--- a/lenskit/lenskit/pipeline/components.py
+++ b/lenskit/lenskit/pipeline/components.py
@@ -54,7 +54,8 @@ Pure-function interface for pipeline functions.
 """
 
 
-class ComponentConstructor(ABC, Generic[CFG, COut]):
+@runtime_checkable
+class ComponentConstructor(Protocol, Generic[CFG, COut]):
     """
     Protocol for component constructors.
     """
@@ -63,9 +64,7 @@ class ComponentConstructor(ABC, Generic[CFG, COut]):
 
     def config_class(self) -> type[CFG] | None: ...
 
-    def __isinstance__(self, obj: Any) -> bool:
-        # FIXME: implement a more rigorous check for this
-        return isinstance(obj, type) and issubclass(obj, Component)
+    def validate_config(self, data: Any = None) -> CFG | None: ...
 
 
 @runtime_checkable

--- a/lenskit/lenskit/pipeline/components.py
+++ b/lenskit/lenskit/pipeline/components.py
@@ -35,6 +35,7 @@ from .types import Lazy
 
 P = ParamSpec("P")
 T = TypeVar("T")
+CFG = TypeVar("CFG", contravariant=True)
 CArgs = ParamSpec("CArgs", default=...)
 """
 Argument type for a component.  It is difficult to actually specify this, but
@@ -48,6 +49,21 @@ COut = TypeVar("COut", covariant=True, default=Any)
 Return type for a component.
 """
 PipelineFunction: TypeAlias = Callable[..., COut]
+"""
+Pure-function interface for pipeline functions.
+"""
+
+
+class ComponentConstructor(ABC, Generic[CFG, COut]):
+    """
+    Protocol for component constructors.
+    """
+
+    def __call__(self, config: CFG | None = None) -> Component[COut]: ...
+
+    def __isinstance__(self, obj: Any) -> bool:
+        # FIXME: implement a more rigorous check for this
+        return isinstance(obj, type) and issubclass(obj, Component)
 
 
 @runtime_checkable

--- a/lenskit/lenskit/pipeline/config.py
+++ b/lenskit/lenskit/pipeline/config.py
@@ -109,17 +109,14 @@ class PipelineComponent(BaseModel):
     with its default constructor parameters.
     """
 
-    inputs: dict[str, str] | list[str] = Field(default_factory=dict)
+    inputs: dict[str, str] = Field(default_factory=dict)
     """
     The component's input wirings, mapping input names to node names.  For
     certain meta-nodes, it is specified as a list instead of a dict.
     """
 
     @classmethod
-    def from_node(cls, node: ComponentNode[Any], mapping: dict[str, str] | None = None) -> Self:
-        if mapping is None:
-            mapping = {}
-
+    def from_node(cls, node: ComponentNode[Any]) -> Self:
         match node:
             case ComponentInstanceNode(_name, comp):
                 config = None
@@ -136,11 +133,7 @@ class PipelineComponent(BaseModel):
 
         code = f"{ctype.__module__}:{ctype.__qualname__}"
 
-        return cls(
-            code=code,
-            config=config,
-            inputs={n: mapping.get(t, t) for (n, t) in node.connections.items()},
-        )
+        return cls(code=code, config=config)
 
 
 class PipelineLiteral(BaseModel):

--- a/lenskit/lenskit/pipeline/nodes.py
+++ b/lenskit/lenskit/pipeline/nodes.py
@@ -5,10 +5,11 @@
 # SPDX-License-Identifier: MIT
 
 # pyright: strict
+from __future__ import annotations
 
 import warnings
 from inspect import Signature, signature
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from typing_extensions import Generic, TypeVar
 
@@ -91,6 +92,18 @@ class ComponentNode(Node[ND], Generic[ND]):
         super().__init__(name)
         self.connections = {}
 
+    @staticmethod
+    def create(
+        name: str,
+        comp: ComponentConstructor[CFG, ND] | Component[ND] | PipelineFunction[ND],
+        config: CFG | None = None,
+    ) -> ComponentNode[ND]:
+        if isinstance(comp, ComponentConstructor):
+            comp = cast(ComponentConstructor[CFG, ND], comp)
+            return ComponentConstructorNode(name, comp, config)
+        else:
+            return ComponentInstanceNode(name, comp)
+
     def _setup_signature(self, component: Callable[..., ND]):
         sig = signature(component, eval_str=True)
         if sig.return_annotation == Signature.empty:
@@ -118,7 +131,7 @@ class ComponentConstructorNode(ComponentNode[ND], Generic[ND]):
     constructor: ComponentConstructor[Any, ND]
     config: object | None
 
-    def __init__(self, name: str, constructor: ComponentConstructor[CFG, ND], config: CFG):
+    def __init__(self, name: str, constructor: ComponentConstructor[CFG, ND], config: CFG | None):
         self.constructor = constructor
         self.config = config
 

--- a/lenskit/lenskit/pipeline/nodes.py
+++ b/lenskit/lenskit/pipeline/nodes.py
@@ -86,14 +86,8 @@ class ComponentNode(Node[ND], Generic[ND]):
         Internal
     """
 
-    __match_args__ = ("name", "connections")
-
-    connections: dict[str, str]
-    "The component's input connections."
-
     def __init__(self, name: str):
         super().__init__(name)
-        self.connections = {}
 
     @staticmethod
     def create(
@@ -118,7 +112,7 @@ class ComponentNode(Node[ND], Generic[ND]):
 
 
 class ComponentConstructorNode(ComponentNode[ND], Generic[ND]):
-    __match_args__ = ("name", "constructor", "config", "connections")
+    __match_args__ = ("name", "constructor", "config")
     constructor: ComponentConstructor[Any, ND]
     config: object | None
 
@@ -135,7 +129,7 @@ class ComponentConstructorNode(ComponentNode[ND], Generic[ND]):
 
 
 class ComponentInstanceNode(ComponentNode[ND], Generic[ND]):
-    __match_args__ = ("name", "component", "connections")
+    __match_args__ = ("name", "component")
 
     component: Component[ND] | PipelineFunction[ND]
 
@@ -143,11 +137,9 @@ class ComponentInstanceNode(ComponentNode[ND], Generic[ND]):
         self,
         name: str,
         component: Component[ND] | PipelineFunction[ND],
-        connections: dict[str, str] | None = None,
     ):
         super().__init__(name)
         self.component = component
-        self.connections = connections or {}
         if rt := component_return_type(component):
             self.types = {rt}
 

--- a/lenskit/lenskit/pipeline/nodes.py
+++ b/lenskit/lenskit/pipeline/nodes.py
@@ -101,11 +101,15 @@ class ComponentNode(Node[ND], Generic[ND]):
         comp: ComponentConstructor[CFG, ND] | Component[ND] | PipelineFunction[ND],
         config: CFG | Mapping[str, JsonValue] | None = None,
     ) -> ComponentNode[ND]:
-        if isinstance(comp, Component) or not isinstance(comp, ComponentConstructor):
-            return ComponentInstanceNode(name, comp)  # type: ignore
-        else:
+        if isinstance(comp, Component):
+            return ComponentInstanceNode(name, cast(Component[ND], comp))
+        elif isinstance(comp, ComponentConstructor):
             comp = cast(ComponentConstructor[CFG, ND], comp)
             return ComponentConstructorNode(name, comp, comp.validate_config(config))
+        elif isinstance(comp, type):
+            return ComponentConstructorNode(name, comp, None)  # type: ignore
+        else:
+            return ComponentInstanceNode(name, comp)
 
     @property
     @abstractmethod

--- a/lenskit/lenskit/pipeline/runner.py
+++ b/lenskit/lenskit/pipeline/runner.py
@@ -114,7 +114,7 @@ class PipelineRunner:
         in_data = {}
         log = self.log.bind(node=name)
         trace(log, "processing inputs")
-        inputs = component_inputs(comp)
+        inputs = component_inputs(comp, warn_on_missing=False)
         for iname, itype in inputs.items():
             ilog = log.bind(input_name=iname, input_type=itype)
             trace(ilog, "resolving input")

--- a/lenskit/lenskit/pipeline/runner.py
+++ b/lenskit/lenskit/pipeline/runner.py
@@ -88,8 +88,8 @@ class PipelineRunner:
                 self.state[name] = value
             case InputNode(name, types=types):
                 self._inject_input(name, types, required)
-            case ComponentInstanceNode(name, comp, wiring):
-                self._run_component(name, comp, wiring, required)
+            case ComponentInstanceNode(name, comp):
+                self._run_component(name, comp, required)
             case _:  # pragma: nocover
                 raise PipelineError(f"invalid node {node}")
 
@@ -108,13 +108,13 @@ class PipelineRunner:
         self,
         name: str,
         comp: PipelineFunction[Any],
-        wiring: dict[str, str],
         required: bool,
     ) -> None:
         in_data = {}
         log = self.log.bind(node=name)
         trace(log, "processing inputs")
         inputs = component_inputs(comp, warn_on_missing=False)
+        wiring = self.pipe.node_input_connections(name)
         for iname, itype in inputs.items():
             ilog = log.bind(input_name=iname, input_type=itype)
             trace(ilog, "resolving input")

--- a/lenskit/lenskit/pipeline/runner.py
+++ b/lenskit/lenskit/pipeline/runner.py
@@ -19,7 +19,7 @@ from lenskit.logging import get_logger, trace
 
 from ._impl import Pipeline
 from .components import PipelineFunction
-from .nodes import ComponentNode, InputNode, LiteralNode, Node
+from .nodes import ComponentInstanceNode, InputNode, LiteralNode, Node
 from .types import Lazy, is_compatible_data
 
 _log = get_logger(__name__)
@@ -48,7 +48,7 @@ class PipelineRunner:
         self.log = _log.bind(pipeline=pipe.name)
         self.pipe = pipe
         self.inputs = inputs
-        self.status = {n.name: "pending" for n in pipe.nodes}
+        self.status = {n.name: "pending" for n in pipe.nodes()}
         self.state = {}
 
     def run(self, node: Node[Any], *, required: bool = True) -> Any:
@@ -88,7 +88,7 @@ class PipelineRunner:
                 self.state[name] = value
             case InputNode(name, types=types):
                 self._inject_input(name, types, required)
-            case ComponentNode(name, comp, inputs, wiring):
+            case ComponentInstanceNode(name, comp, inputs, wiring):
                 self._run_component(name, comp, inputs, wiring, required)
             case _:  # pragma: nocover
                 raise PipelineError(f"invalid node {node}")

--- a/lenskit/lenskit/pipeline/runner.py
+++ b/lenskit/lenskit/pipeline/runner.py
@@ -116,9 +116,12 @@ class PipelineRunner:
         trace(log, "processing inputs")
         inputs = component_inputs(comp)
         for iname, itype in inputs.items():
+            ilog = log.bind(input_name=iname, input_type=itype)
+            trace(ilog, "resolving input")
             # look up the input wiring for this parameter input
             snode = None
             if src := wiring.get(iname, None):
+                trace(ilog, "resolving from wiring")
                 snode = self.pipe.node(src)
 
             # check if this is a lazy node

--- a/lenskit/lenskit/testing/_components.py
+++ b/lenskit/lenskit/testing/_components.py
@@ -25,7 +25,7 @@ class BasicComponentTests:
         inst = self.component()
         assert inst is not None
 
-        if self.component._config_class() is not None:
+        if self.component.config_class() is not None:
             assert inst.config is not None
         else:
             assert inst.config is None

--- a/lenskit/tests/basic/test_bias.py
+++ b/lenskit/tests/basic/test_bias.py
@@ -18,8 +18,7 @@ from lenskit.basic import BiasModel, BiasScorer
 from lenskit.data import Dataset, from_interactions_df
 from lenskit.data.items import ItemList
 from lenskit.operations import predict, recommend
-from lenskit.pipeline import Pipeline
-from lenskit.pipeline.common import topn_pipeline
+from lenskit.pipeline import Pipeline, PipelineBuilder, topn_pipeline
 from lenskit.testing import BasicComponentTests, ScorerTests
 
 _log = logging.getLogger(__name__)
@@ -303,7 +302,7 @@ def test_bias_save():
 
 
 def test_bias_pipeline(ml_ds: Dataset):
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     user = pipe.create_input("user", int)
     items = pipe.create_input("items")
 
@@ -311,6 +310,7 @@ def test_bias_pipeline(ml_ds: Dataset):
     bias.train(ml_ds)
     out = pipe.add_component("bias", bias, query=user, items=items)
 
+    pipe = pipe.build()
     res = pipe.run(out, user=2, items=ItemList(item_ids=[10, 11, -1]))
 
     assert len(res) == 3
@@ -323,7 +323,7 @@ def test_bias_pipeline(ml_ds: Dataset):
 
 def test_bias_topn(ml_ds: Dataset):
     pipe = topn_pipeline(BiasScorer(), predicts_ratings=True, n=10)
-    print(pipe.get_config())
+    print(pipe.config)
     pipe.train(ml_ds)
 
     res = predict(pipe, 2, ItemList(item_ids=[10, 11, -1]))
@@ -338,7 +338,7 @@ def test_bias_topn(ml_ds: Dataset):
 
 def test_bias_topn_run_length(ml_ds: Dataset):
     pipe = topn_pipeline(BiasScorer(), predicts_ratings=True, n=100)
-    print(pipe.get_config())
+    print(pipe.config)
     pipe.train(ml_ds)
 
     res = predict(pipe, 2, items=ItemList(item_ids=[10, 11, -1]))

--- a/lenskit/tests/basic/test_composite.py
+++ b/lenskit/tests/basic/test_composite.py
@@ -20,8 +20,7 @@ from lenskit.data import Dataset
 from lenskit.data.items import ItemList
 from lenskit.data.types import ID
 from lenskit.operations import predict, score
-from lenskit.pipeline import Pipeline
-from lenskit.pipeline.common import RecPipelineBuilder
+from lenskit.pipeline import Pipeline, PipelineBuilder, RecPipelineBuilder
 from lenskit.testing import BasicComponentTests
 
 _log = logging.getLogger(__name__)
@@ -32,7 +31,7 @@ class TestFallbackScorer(BasicComponentTests):
 
 
 def test_fallback_fill_missing(ml_ds: Dataset):
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     user = pipe.create_input("user", int)
     items = pipe.create_input("items")
 
@@ -44,6 +43,7 @@ def test_fallback_fill_missing(ml_ds: Dataset):
     fallback = FallbackScorer()
     score = pipe.add_component("mix", fallback, scores=s1, backup=s2)
 
+    pipe = pipe.build()
     pipe.train(ml_ds)
 
     # the first 2 of these are rated, the 3rd does not exist, and the other 2 are not rated
@@ -66,7 +66,7 @@ def test_fallback_double_bias(rng: np.random.Generator, ml_ds: Dataset):
     builder.predicts_ratings(fallback=BiasScorer(damping=0))
     pipe = builder.build("double-bias")
 
-    _log.info("pipeline configuration: %s", pipe.get_config().model_dump_json(indent=2))
+    _log.info("pipeline configuration: %s", pipe.config.model_dump_json(indent=2))
 
     pipe.train(ml_ds)
 

--- a/lenskit/tests/pipeline/test_component_config.py
+++ b/lenskit/tests/pipeline/test_component_config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from typing import Any
 
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -15,7 +16,7 @@ from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pytest import mark
 
 from lenskit.pipeline import PipelineBuilder
-from lenskit.pipeline.components import Component
+from lenskit.pipeline.components import Component, ComponentConstructor
 
 
 @dataclass
@@ -85,12 +86,10 @@ def test_auto_config_roundtrip(prefixer: type[Component]):
 
 
 @mark.parametrize("prefixer", [PrefixerDC, PrefixerM, PrefixerPYDC])
-def test_pipeline_config(prefixer: type[Component]):
-    comp = prefixer(prefix="scroll named ")
-
+def test_pipeline_config(prefixer: ComponentConstructor[Any, str]):
     pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
-    pipe.add_component("prefix", comp, msg=msg)
+    pipe.add_component("prefix", prefixer, {"prefix": "scroll named "}, msg=msg)
 
     pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"

--- a/lenskit/tests/pipeline/test_component_config.py
+++ b/lenskit/tests/pipeline/test_component_config.py
@@ -14,7 +14,7 @@ from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from pytest import mark
 
-from lenskit.pipeline import Pipeline
+from lenskit.pipeline import PipelineBuilder
 from lenskit.pipeline.components import Component
 
 
@@ -88,10 +88,11 @@ def test_auto_config_roundtrip(prefixer: type[Component]):
 def test_pipeline_config(prefixer: type[Component]):
     comp = prefixer(prefix="scroll named ")
 
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.add_component("prefix", comp, msg=msg)
 
+    pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
 
     config = pipe.component_configs()
@@ -105,15 +106,15 @@ def test_pipeline_config(prefixer: type[Component]):
 def test_pipeline_config_roundtrip(prefixer: type[Component]):
     comp = prefixer(prefix="scroll named ")
 
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.add_component("prefix", comp, msg=msg)
 
-    assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
+    assert pipe.build().run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
 
     config = pipe.get_config()
     print(config.model_dump_json(indent=2))
 
-    p2 = Pipeline.from_config(config)
+    p2 = PipelineBuilder.from_config(config)
     assert p2.node("prefix", missing="none") is not None
-    assert p2.run(msg="READ ME") == "scroll named READ ME"
+    assert p2.build().run(msg="READ ME") == "scroll named READ ME"

--- a/lenskit/tests/pipeline/test_component_config.py
+++ b/lenskit/tests/pipeline/test_component_config.py
@@ -109,6 +109,7 @@ def test_pipeline_config_roundtrip(prefixer: type[Component]):
     pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.add_component("prefix", comp, msg=msg)
+    pipe.default_component("prefix")
 
     assert pipe.build().run("prefix", msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
 

--- a/lenskit/tests/pipeline/test_component_util.py
+++ b/lenskit/tests/pipeline/test_component_util.py
@@ -5,12 +5,12 @@ from lenskit.pipeline.components import Component, component_inputs, component_r
 
 
 @dataclass
-class TestConfig:
+class XConfig:
     suffix: str = ""
 
 
-class TestComp(Component):
-    config: TestConfig
+class XComp(Component):
+    config: XConfig
 
     def __call__(self, msg: str) -> str:
         return msg + self.config.suffix
@@ -39,13 +39,13 @@ def test_single_function_input():
 
 
 def test_component_class_input():
-    inputs = component_inputs(TestComp)
+    inputs = component_inputs(XComp)
     assert len(inputs) == 1
     assert inputs["msg"] is str
 
 
 def test_component_object_input():
-    inputs = component_inputs(TestComp())
+    inputs = component_inputs(XComp())
     assert len(inputs) == 1
     assert inputs["msg"] is str
 
@@ -80,12 +80,12 @@ def test_function_return():
 
 
 def test_class_return():
-    rt = component_return_type(TestComp)
+    rt = component_return_type(XComp)
     assert rt is str
 
 
 def test_instance_return():
-    rt = component_return_type(TestComp())
+    rt = component_return_type(XComp())
     assert rt is str
 
 

--- a/lenskit/tests/pipeline/test_component_util.py
+++ b/lenskit/tests/pipeline/test_component_util.py
@@ -1,0 +1,80 @@
+# pyright: strict
+from dataclasses import dataclass
+
+from lenskit.pipeline.components import Component, component_inputs, component_return_type
+
+
+@dataclass
+class TestConfig:
+    suffix: str = ""
+
+
+class TestComp(Component):
+    config: TestConfig
+
+    def __call__(self, msg: str) -> str:
+        return msg + self.config.suffix
+
+
+def test_empty_input():
+    def func() -> int:
+        return 9
+
+    inputs = component_inputs(func)
+    assert not inputs
+
+
+def test_single_function_input():
+    def func(x: int) -> int:
+        return 9 + x
+
+    inputs = component_inputs(func)
+    assert len(inputs) == 1
+    assert inputs["x"] is int
+
+
+def test_component_class_input():
+    inputs = component_inputs(TestComp)
+    assert len(inputs) == 1
+    assert inputs["msg"] is str
+
+
+def test_component_object_input():
+    inputs = component_inputs(TestComp())
+    assert len(inputs) == 1
+    assert inputs["msg"] is str
+
+
+def test_component_unknown_input():
+    def func(x) -> int:  # type: ignore
+        return x + 5  # type: ignore
+
+    inputs = component_inputs(func)  # type: ignore
+    assert len(inputs) == 1
+    assert inputs["x"] is None
+
+
+def test_function_return():
+    def func(x: int) -> int:
+        return x + 5
+
+    rt = component_return_type(func)
+    assert rt is int
+
+
+def test_class_return():
+    rt = component_return_type(TestComp)
+    assert rt is str
+
+
+def test_instance_return():
+    rt = component_return_type(TestComp())
+    assert rt is str
+
+
+def test_unknown_return():
+    def func():
+        pass
+
+    rt = component_return_type(func)
+    assert rt is None

--- a/lenskit/tests/pipeline/test_component_util.py
+++ b/lenskit/tests/pipeline/test_component_util.py
@@ -16,6 +16,11 @@ class TestComp(Component):
         return msg + self.config.suffix
 
 
+class CallObj:
+    def __call__(self, q: str) -> bytes:
+        return q.encode()
+
+
 def test_empty_input():
     def func() -> int:
         return 9
@@ -54,6 +59,18 @@ def test_component_unknown_input():
     assert inputs["x"] is None
 
 
+def test_callable_object_input():
+    inputs = component_inputs(CallObj())
+    assert len(inputs) == 1
+    assert inputs["q"] is str
+
+
+def test_callable_class_input():
+    inputs = component_inputs(CallObj)
+    assert len(inputs) == 1
+    assert inputs["q"] is str
+
+
 def test_function_return():
     def func(x: int) -> int:
         return x + 5
@@ -78,3 +95,13 @@ def test_unknown_return():
 
     rt = component_return_type(func)
     assert rt is None
+
+
+def test_callable_object_return():
+    rt = component_return_type(CallObj())
+    assert rt is bytes
+
+
+def test_callable_class_return():
+    rt = component_return_type(CallObj)
+    assert rt is bytes

--- a/lenskit/tests/pipeline/test_fallback.py
+++ b/lenskit/tests/pipeline/test_fallback.py
@@ -6,11 +6,11 @@
 
 from pytest import fail, raises
 
-from lenskit.pipeline import Pipeline
+from lenskit.pipeline import PipelineBuilder
 
 
 def test_fallback_input():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
 
@@ -28,12 +28,13 @@ def test_fallback_input():
     fb = pipe.use_first_of("fill-operand", b, nn)
     na = pipe.add_component("add", add, x=nd, y=fb)
 
+    pipe = pipe.build()
     # 3 * 2 + -3 = 3
     assert pipe.run(na, a=3) == 3
 
 
 def test_fallback_only_run_if_needed():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
 
@@ -51,11 +52,12 @@ def test_fallback_only_run_if_needed():
     fb = pipe.use_first_of("fill-operand", b, nn)
     na = pipe.add_component("add", add, x=nd, y=fb)
 
+    pipe = pipe.build()
     assert pipe.run(na, a=3, b=8) == 14
 
 
 def test_fallback_fail_with_missing_options():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
 
@@ -73,13 +75,14 @@ def test_fallback_fail_with_missing_options():
     fb = pipe.use_first_of("fill-operand", b, nn)
     na = pipe.add_component("add", add, x=nd, y=fb)
 
+    pipe = pipe.build()
     with raises(TypeError, match="no data available"):
         pipe.run(na, a=3)
 
 
 def test_fallback_transitive():
     "test that a fallback works if a dependency's dependency fails"
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     ia = pipe.create_input("a", int)
     ib = pipe.create_input("b", int)
 
@@ -92,13 +95,14 @@ def test_fallback_transitive():
     # use the first that succeeds
     c = pipe.use_first_of("result", c1, c2)
 
+    pipe = pipe.build()
     # omitting the first input should result in the second component
     assert pipe.run(c, b=17) == 34
 
 
 def test_fallback_transitive_deeper():
     "deeper transitive fallback test"
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
 
@@ -112,12 +116,13 @@ def test_fallback_transitive_deeper():
     nn = pipe.add_component("negate", negative, x=nd)
     nr = pipe.use_first_of("fill-operand", nn, b)
 
+    pipe = pipe.build()
     assert pipe.run(nr, b=8) == 8
 
 
 def test_fallback_transitive_nodefail():
     "deeper transitive fallback test"
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
 
@@ -135,5 +140,6 @@ def test_fallback_transitive_nodefail():
     nn = pipe.add_component("negate", negative, x=nd)
     nr = pipe.use_first_of("fill-operand", nn, b)
 
+    pipe = pipe.build()
     assert pipe.run(nr, a=2, b=8) == -4
     assert pipe.run(nr, a=-7, b=8) == 8

--- a/lenskit/tests/pipeline/test_pipeline.py
+++ b/lenskit/tests/pipeline/test_pipeline.py
@@ -222,7 +222,6 @@ def test_simple_graph():
     pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
-    pipe.default_component("b")
 
     def double(x: int) -> int:
         return x * 2
@@ -232,6 +231,7 @@ def test_simple_graph():
 
     nd = pipe.add_component("double", double, x=a)
     na = pipe.add_component("add", add, x=nd, y=b)
+    pipe.default_component("add")
 
     pipe = pipe.build()
     assert pipe.run(a=1, b=7) == 9

--- a/lenskit/tests/pipeline/test_pipeline.py
+++ b/lenskit/tests/pipeline/test_pipeline.py
@@ -221,6 +221,7 @@ def test_simple_graph():
     pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
+    pipe.default_component("b")
 
     def double(x: int) -> int:
         return x * 2
@@ -303,6 +304,7 @@ def test_default_wiring():
 
     nd = pipe.add_component("double", double, x=a)
     na = pipe.add_component("add", add, x=nd)
+    pipe.default_component(na)
 
     pipe = pipe.build()
     assert pipe.run(a=1, b=7) == 9
@@ -385,7 +387,7 @@ def test_invalid_type():
 
     pipe = pipe.build()
     with raises(TypeError):
-        pipe.run(a=1, b="seven")
+        pipe.run("add", a=1, b="seven")
 
 
 def test_run_by_alias():

--- a/lenskit/tests/pipeline/test_pipeline.py
+++ b/lenskit/tests/pipeline/test_pipeline.py
@@ -436,7 +436,7 @@ def test_run_all():
     assert state.meta is not None
     assert state.meta.name == "test"
     assert state.meta.version == "7.2"
-    assert state.meta.hash == pipe.config_hash()
+    assert state.meta.hash == pipe.config_hash
 
 
 def test_run_all_limit():

--- a/lenskit/tests/pipeline/test_pipeline.py
+++ b/lenskit/tests/pipeline/test_pipeline.py
@@ -239,7 +239,6 @@ def test_simple_graph():
     assert pipe.run(nd, a=3, b=7) == 6
 
 
-@mark.xfail(reason="cycle detection not yet implemented")
 def test_cycle():
     pipe = PipelineBuilder()
     b = pipe.create_input("b", int)

--- a/lenskit/tests/pipeline/test_pipeline.py
+++ b/lenskit/tests/pipeline/test_pipeline.py
@@ -10,7 +10,7 @@ from uuid import UUID
 import numpy as np
 from typing_extensions import assert_type
 
-from pytest import raises, warns
+from pytest import mark, raises, warns
 
 from lenskit.pipeline import PipelineBuilder, PipelineError
 from lenskit.pipeline.nodes import InputNode, Node
@@ -239,6 +239,7 @@ def test_simple_graph():
     assert pipe.run(nd, a=3, b=7) == 6
 
 
+@mark.xfail(reason="cycle detection not yet implemented")
 def test_cycle():
     pipe = PipelineBuilder()
     b = pipe.create_input("b", int)

--- a/lenskit/tests/pipeline/test_pipeline.py
+++ b/lenskit/tests/pipeline/test_pipeline.py
@@ -204,6 +204,7 @@ def test_chain():
 
     ni = pipe.add_component("incr", incr, x=x)
     nt = pipe.add_component("triple", triple, x=ni)
+    pipe.default_component(nt)
 
     pipe = pipe.build()
     # run default pipe

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -41,6 +41,7 @@ def test_pipeline_clone():
     pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.add_component("prefix", comp, msg=msg)
+    pipe.default_component("prefix")
 
     pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
@@ -62,6 +63,7 @@ def test_pipeline_clone_with_function():
     msg = pipe.create_input("msg", str)
     pfx = pipe.add_component("prefix", comp, msg=msg)
     pipe.add_component("exclaim", exclaim, msg=pfx)
+    pipe.default_component("prefix")
 
     pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH!"
@@ -78,6 +80,7 @@ def test_pipeline_clone_with_nonconfig_class():
     msg = pipe.create_input("msg", str)
     pfx = pipe.add_component("prefix", comp, msg=msg)
     pipe.add_component("question", Question(), msg=pfx)
+    pipe.default_component("prefix")
 
     pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH?"
@@ -90,8 +93,9 @@ def test_pipeline_clone_with_nonconfig_class():
 def test_clone_defaults():
     pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
-    pipe.set_default("msg", msg)
+    pipe.default_connection("msg", msg)
     pipe.add_component("return", exclaim)
+    pipe.default_component("prefix")
 
     pipe = pipe.build()
     assert pipe.run(msg="hello") == "hello!"
@@ -118,7 +122,7 @@ def test_clone_alias():
 def test_clone_hash():
     pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
-    pipe.set_default("msg", msg)
+    pipe.default_connection("msg", msg)
     excl = pipe.add_component("exclaim", exclaim)
     pipe.alias("return", excl)
 
@@ -128,4 +132,4 @@ def test_clone_hash():
     p2 = pipe.clone()
 
     assert p2.run("return", msg="hello") == "hello!"
-    assert p2.config_hash() == pipe.config_hash()
+    assert p2.config_hash == pipe.config_hash

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -4,10 +4,10 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-import json
+# pyright: strict
 from dataclasses import dataclass
 
-from lenskit.pipeline import Pipeline
+from lenskit.pipeline import PipelineBuilder
 from lenskit.pipeline.components import Component
 from lenskit.pipeline.nodes import ComponentNode
 
@@ -38,10 +38,11 @@ def exclaim(msg: str) -> str:
 def test_pipeline_clone():
     comp = Prefixer(PrefixConfig("scroll named "))
 
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.add_component("prefix", comp, msg=msg)
 
+    pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
 
     p2 = pipe.clone()
@@ -57,11 +58,12 @@ def test_pipeline_clone():
 def test_pipeline_clone_with_function():
     comp = Prefixer(prefix="scroll named ")
 
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pfx = pipe.add_component("prefix", comp, msg=msg)
     pipe.add_component("exclaim", exclaim, msg=pfx)
 
+    pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH!"
 
     p2 = pipe.clone()
@@ -72,11 +74,12 @@ def test_pipeline_clone_with_function():
 def test_pipeline_clone_with_nonconfig_class():
     comp = Prefixer(prefix="scroll named ")
 
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pfx = pipe.add_component("prefix", comp, msg=msg)
     pipe.add_component("question", Question(), msg=pfx)
 
+    pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH?"
 
     p2 = pipe.clone()
@@ -85,11 +88,12 @@ def test_pipeline_clone_with_nonconfig_class():
 
 
 def test_clone_defaults():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.set_default("msg", msg)
     pipe.add_component("return", exclaim)
 
+    pipe = pipe.build()
     assert pipe.run(msg="hello") == "hello!"
 
     p2 = pipe.clone()
@@ -98,11 +102,12 @@ def test_clone_defaults():
 
 
 def test_clone_alias():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     excl = pipe.add_component("exclaim", exclaim, msg=msg)
     pipe.alias("return", excl)
 
+    pipe = pipe.build()
     assert pipe.run("return", msg="hello") == "hello!"
 
     p2 = pipe.clone()
@@ -111,12 +116,13 @@ def test_clone_alias():
 
 
 def test_clone_hash():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.set_default("msg", msg)
     excl = pipe.add_component("exclaim", exclaim)
     pipe.alias("return", excl)
 
+    pipe = pipe.build()
     assert pipe.run("return", msg="hello") == "hello!"
 
     p2 = pipe.clone()

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 from lenskit.pipeline import PipelineBuilder
 from lenskit.pipeline.components import Component
-from lenskit.pipeline.nodes import ComponentNode
+from lenskit.pipeline.nodes import ComponentInstanceNode, ComponentNode
 
 
 @dataclass
@@ -36,19 +36,18 @@ def exclaim(msg: str) -> str:
 
 
 def test_pipeline_clone():
-    comp = Prefixer(PrefixConfig("scroll named "))
-
     pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
-    pipe.add_component("prefix", comp, msg=msg)
+    pipe.add_component("prefix", Prefixer, PrefixConfig(prefix="scroll named "), msg=msg)
     pipe.default_component("prefix")
 
     pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH"
+    comp = pipe.node("prefix").component  # type: ignore
 
     p2 = pipe.clone()
     n2 = p2.node("prefix")
-    assert isinstance(n2, ComponentNode)
+    assert isinstance(n2, ComponentInstanceNode)
     assert isinstance(n2.component, Prefixer)
     assert n2.component is not comp
     assert n2.component.config.prefix == comp.config.prefix

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 from lenskit.pipeline import PipelineBuilder
 from lenskit.pipeline.components import Component
-from lenskit.pipeline.nodes import ComponentInstanceNode, ComponentNode
+from lenskit.pipeline.nodes import ComponentInstanceNode
 
 
 @dataclass
@@ -50,7 +50,7 @@ def test_pipeline_clone():
     assert isinstance(n2, ComponentInstanceNode)
     assert isinstance(n2.component, Prefixer)
     assert n2.component is not comp
-    assert n2.component.config.prefix == comp.config.prefix
+    assert n2.component.config.prefix == comp.config.prefix  # type: ignore
 
     assert p2.run(msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE"
 
@@ -62,7 +62,7 @@ def test_pipeline_clone_with_function():
     msg = pipe.create_input("msg", str)
     pfx = pipe.add_component("prefix", comp, msg=msg)
     pipe.add_component("exclaim", exclaim, msg=pfx)
-    pipe.default_component("prefix")
+    pipe.default_component("exclaim")
 
     pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH!"
@@ -79,7 +79,7 @@ def test_pipeline_clone_with_nonconfig_class():
     msg = pipe.create_input("msg", str)
     pfx = pipe.add_component("prefix", comp, msg=msg)
     pipe.add_component("question", Question(), msg=pfx)
-    pipe.default_component("prefix")
+    pipe.default_component("question")
 
     pipe = pipe.build()
     assert pipe.run(msg="FOOBIE BLETCH") == "scroll named FOOBIE BLETCH?"

--- a/lenskit/tests/pipeline/test_pipeline_clone.py
+++ b/lenskit/tests/pipeline/test_pipeline_clone.py
@@ -95,7 +95,7 @@ def test_clone_defaults():
     msg = pipe.create_input("msg", str)
     pipe.default_connection("msg", msg)
     pipe.add_component("return", exclaim)
-    pipe.default_component("prefix")
+    pipe.default_component("return")
 
     pipe = pipe.build()
     assert pipe.run(msg="hello") == "hello!"

--- a/lenskit/tests/pipeline/test_pipeline_state.py
+++ b/lenskit/tests/pipeline/test_pipeline_state.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
+# pyright: strict
 from pytest import raises
 
 from lenskit.pipeline import PipelineState

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -131,7 +131,7 @@ def test_round_trip_single_node():
     r2 = p2.node("return")
     assert isinstance(r2, ComponentInstanceNode)
     assert r2.component is msg_ident
-    assert r2.connections == {"msg": "msg"}
+    assert p2._edges["return"] == {"msg": "msg"}
 
     p2 = p2.build()
     assert p2.run("return", msg="foo") == "foo"
@@ -153,7 +153,7 @@ def test_configurable_component():
     assert isinstance(r2, ComponentInstanceNode)
     assert isinstance(r2.component, Prefixer)
     assert r2.component is not pfx
-    assert r2.connections == {"msg": "msg"}
+    assert p2._edges["prefix"] == {"msg": "msg"}
 
     p2 = p2.build()
     assert p2.run("prefix", msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE"
@@ -268,7 +268,7 @@ def test_alias_node():
     pipe = pipe.build()
     assert pipe.run("result", a=5, b=7) == 17
 
-    p2 = pipe.clone("pipeline-config")
+    p2 = pipe.clone()
     assert p2.run("result", a=5, b=7) == 17
 
 
@@ -283,7 +283,7 @@ def test_literal():
     assert pipe.run(msg="HACKEM MUCHE") == "hello, HACKEM MUCHE"
 
     print(pipe.config.model_dump_json(indent=2))
-    p2 = pipe.clone("pipeline-config")
+    p2 = pipe.clone()
     assert p2.run(msg="FOOBIE BLETCH") == "hello, FOOBIE BLETCH"
 
 
@@ -294,12 +294,12 @@ def test_literal_array():
     pipe.add_component("add", add, x=np.arange(10), y=a)
     pipe.default_component("add")
 
+    print("pipeline:", pipe.build_config().model_dump_json(indent=2))
     pipe = pipe.build()
     res = pipe.run(a=5)
     assert np.all(res == np.arange(5, 15))
 
-    print(pipe.config.model_dump_json(indent=2))
-    p2 = pipe.clone("pipeline-config")
+    p2 = pipe.clone()
     assert np.all(p2.run(a=5) == np.arange(5, 15))
 
 

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -158,8 +158,8 @@ def test_configurable_component():
     p2 = p2.build()
     assert p2.run("prefix", msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE"
 
-    print("hash:", pipe.config_hash())
-    assert pipe.config_hash() is not None
+    print("hash:", pipe.config_hash)
+    assert pipe.config_hash is not None
     assert p2.config_hash == pipe.config_hash
 
 
@@ -276,6 +276,7 @@ def test_literal():
     msg = pipe.create_input("msg", str)
 
     pipe.add_component("prefix", msg_prefix, prefix=pipe.literal("hello, "), msg=msg)
+    pipe.default_component("prefix")
 
     pipe = pipe.build()
     assert pipe.run(msg="HACKEM MUCHE") == "hello, HACKEM MUCHE"
@@ -290,6 +291,7 @@ def test_literal_array():
     a = pipe.create_input("a", int)
 
     pipe.add_component("add", add, x=np.arange(10), y=a)
+    pipe.default_component("prefix")
 
     pipe = pipe.build()
     res = pipe.run(a=5)

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -163,11 +163,12 @@ def test_configurable_component():
     assert p2.config_hash == pipe.config_hash
 
 
-def test_save_defaults():
+def test_save_with_defaults():
     pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.default_connection("msg", msg)
     pipe.add_component("return", msg_ident)
+    pipe.default_component("return")
 
     cfg = pipe.build_config()
 

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -17,7 +17,7 @@ from pytest import fail, warns
 from lenskit.pipeline import PipelineBuilder, PipelineWarning
 from lenskit.pipeline.components import Component
 from lenskit.pipeline.config import PipelineConfig
-from lenskit.pipeline.nodes import ComponentNode, InputNode
+from lenskit.pipeline.nodes import ComponentInstanceNode, ComponentNode, InputNode
 
 _log = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ def test_round_trip_single_node():
     p2 = PipelineBuilder.from_config(cfg)
     assert len(p2.nodes()) == 2
     r2 = p2.node("return")
-    assert isinstance(r2, ComponentNode)
+    assert isinstance(r2, ComponentInstanceNode)
     assert r2.component is msg_ident
     assert r2.connections == {"msg": "msg"}
 
@@ -150,7 +150,7 @@ def test_configurable_component():
     p2 = PipelineBuilder.from_config(cfg)
     assert len(p2.nodes()) == 2
     r2 = p2.node("prefix")
-    assert isinstance(r2, ComponentNode)
+    assert isinstance(r2, ComponentInstanceNode)
     assert isinstance(r2.component, Prefixer)
     assert r2.component is not pfx
     assert r2.connections == {"msg": "msg"}

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -160,7 +160,7 @@ def test_configurable_component():
 
     print("hash:", pipe.config_hash)
     assert pipe.config_hash is not None
-    assert p2.config_hash == pipe.config_hash
+    assert p2.config_hash == pipe.config_hash()
 
 
 def test_save_with_defaults():

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -292,7 +292,7 @@ def test_literal_array():
     a = pipe.create_input("a", int)
 
     pipe.add_component("add", add, x=np.arange(10), y=a)
-    pipe.default_component("prefix")
+    pipe.default_component("add")
 
     pipe = pipe.build()
     res = pipe.run(a=5)

--- a/lenskit/tests/pipeline/test_save_load.py
+++ b/lenskit/tests/pipeline/test_save_load.py
@@ -14,7 +14,7 @@ from typing_extensions import assert_type
 
 from pytest import fail, warns
 
-from lenskit.pipeline import Pipeline, PipelineWarning
+from lenskit.pipeline import PipelineBuilder, PipelineWarning
 from lenskit.pipeline.components import Component
 from lenskit.pipeline.config import PipelineConfig
 from lenskit.pipeline.nodes import ComponentNode, InputNode
@@ -60,7 +60,7 @@ def msg_prefix(prefix: str, msg: str) -> str:
 
 def test_serialize_input():
     "serialize with one input node"
-    pipe = Pipeline("test")
+    pipe = PipelineBuilder("test")
     pipe.create_input("user", int, str)
 
     cfg = pipe.get_config()
@@ -73,13 +73,13 @@ def test_serialize_input():
 
 def test_round_trip_input():
     "serialize with one input node"
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     pipe.create_input("user", int, str)
 
     cfg = pipe.get_config()
     print(cfg)
 
-    p2 = Pipeline.from_config(cfg)
+    p2 = PipelineBuilder.from_config(cfg)
     i2 = p2.node("user")
     assert isinstance(i2, InputNode)
     assert i2.name == "user"
@@ -88,13 +88,13 @@ def test_round_trip_input():
 
 def test_round_trip_optional_input():
     "serialize with one input node"
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     pipe.create_input("user", int, str, None)
 
     cfg = pipe.get_config()
     assert cfg.inputs[0].types == {"int", "str", "None"}
 
-    p2 = Pipeline.from_config(cfg)
+    p2 = PipelineBuilder.from_config(cfg)
     i2 = p2.node("user")
     assert isinstance(i2, InputNode)
     assert i2.name == "user"
@@ -102,7 +102,7 @@ def test_round_trip_optional_input():
 
 
 def test_config_single_node():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
 
     pipe.add_component("return", msg_ident, msg=msg)
@@ -119,25 +119,26 @@ def test_config_single_node():
 
 
 def test_round_trip_single_node():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
 
     pipe.add_component("return", msg_ident, msg=msg)
 
     cfg = pipe.get_config()
 
-    p2 = Pipeline.from_config(cfg)
+    p2 = PipelineBuilder.from_config(cfg)
     assert len(p2.nodes) == 2
     r2 = p2.node("return")
     assert isinstance(r2, ComponentNode)
     assert r2.component is msg_ident
     assert r2.connections == {"msg": "msg"}
 
+    p2 = p2.build()
     assert p2.run("return", msg="foo") == "foo"
 
 
 def test_configurable_component():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
 
     pfx = Prefixer(prefix="scroll named ")
@@ -146,7 +147,7 @@ def test_configurable_component():
     cfg = pipe.get_config()
     assert cfg.components["prefix"].config == {"prefix": "scroll named "}
 
-    p2 = Pipeline.from_config(cfg)
+    p2 = PipelineBuilder.from_config(cfg)
     assert len(p2.nodes) == 2
     r2 = p2.node("prefix")
     assert isinstance(r2, ComponentNode)
@@ -154,6 +155,7 @@ def test_configurable_component():
     assert r2.component is not pfx
     assert r2.connections == {"msg": "msg"}
 
+    p2 = p2.build()
     assert p2.run("prefix", msg="HACKEM MUCHE") == "scroll named HACKEM MUCHE"
 
     print("hash:", pipe.config_hash())
@@ -162,22 +164,25 @@ def test_configurable_component():
 
 
 def test_save_defaults():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
     pipe.set_default("msg", msg)
     pipe.add_component("return", msg_ident)
 
+    cfg = pipe.get_config()
+
+    pipe = pipe.build()
     assert pipe.run(msg="hello") == "hello"
 
-    cfg = pipe.get_config()
-    p2 = Pipeline.from_config(cfg)
+    p2 = PipelineBuilder.from_config(cfg)
 
+    p2 = p2.build()
     assert p2.run(msg="hello") == "hello"
 
 
 def test_hashes_different():
-    p1 = Pipeline()
-    p2 = Pipeline()
+    p1 = PipelineBuilder()
+    p2 = PipelineBuilder()
 
     a1 = p1.create_input("a", int)
     a2 = p2.create_input("a", int)
@@ -194,10 +199,11 @@ def test_hashes_different():
     _log.info("p1 stage 2 hash: %s", p1.config_hash())
     _log.info("p2 stage 2 hash: %s", p2.config_hash())
     assert p1.config_hash() != p2.config_hash()
+    assert p1.build().config_hash() != p2.build().config_hash()
 
 
 def test_save_with_fallback():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
 
@@ -211,14 +217,15 @@ def test_save_with_fallback():
     print(json)
     c2 = PipelineConfig.model_validate_json(json)
 
-    p2 = Pipeline.from_config(c2)
+    p2 = PipelineBuilder.from_config(c2)
 
+    p2 = p2.build()
     # 3 * 2 + -3 = 3
     assert p2.run("fill-operand", "add", a=3) == (-3, 3)
 
 
 def test_hash_validate():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     msg = pipe.create_input("msg", str)
 
     pfx = Prefixer(prefix="scroll named ")
@@ -231,24 +238,25 @@ def test_hash_validate():
     print("modified config:", cfg.model_dump_json(indent=2))
 
     with warns(PipelineWarning):
-        Pipeline.from_config(cfg)
+        PipelineBuilder.from_config(cfg)
 
 
 def test_alias_input():
     "just an input node and an alias"
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     user = pipe.create_input("user", int, str)
 
     pipe.alias("person", user)
 
     cfg = pipe.get_config()
 
-    p2 = Pipeline.from_config(cfg)
+    p2 = PipelineBuilder.from_config(cfg)
+    p2 = p2.build()
     assert p2.run("person", user=32) == 32
 
 
 def test_alias_node():
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     a = pipe.create_input("a", int)
     b = pipe.create_input("b", int)
 
@@ -256,6 +264,7 @@ def test_alias_node():
     na = pipe.add_component("add", add, x=nd, y=b)
     pipe.alias("result", na)
 
+    pipe = pipe.build()
     assert pipe.run("result", a=5, b=7) == 17
 
     p2 = pipe.clone("pipeline-config")
@@ -263,11 +272,12 @@ def test_alias_node():
 
 
 def test_literal():
-    pipe = Pipeline("literal-prefix")
+    pipe = PipelineBuilder("literal-prefix")
     msg = pipe.create_input("msg", str)
 
     pipe.add_component("prefix", msg_prefix, prefix=pipe.literal("hello, "), msg=msg)
 
+    pipe = pipe.build()
     assert pipe.run(msg="HACKEM MUCHE") == "hello, HACKEM MUCHE"
 
     print(pipe.get_config().model_dump_json(indent=2))
@@ -276,11 +286,12 @@ def test_literal():
 
 
 def test_literal_array():
-    pipe = Pipeline("literal-add-array")
+    pipe = PipelineBuilder("literal-add-array")
     a = pipe.create_input("a", int)
 
     pipe.add_component("add", add, x=np.arange(10), y=a)
 
+    pipe = pipe.build()
     res = pipe.run(a=5)
     assert np.all(res == np.arange(5, 15))
 
@@ -291,12 +302,13 @@ def test_literal_array():
 
 def test_stable_with_literals():
     "test that two identical pipelines have the same hash, even with literals"
-    p1 = Pipeline("literal-add-array")
+    p1 = PipelineBuilder("literal-add-array")
     a = p1.create_input("a", int)
     p1.add_component("add", add, x=np.arange(10), y=a)
 
-    p2 = Pipeline("literal-add-array")
+    p2 = PipelineBuilder("literal-add-array")
     a = p2.create_input("a", int)
     p2.add_component("add", add, x=np.arange(10), y=a)
 
     assert p1.config_hash() == p2.config_hash()
+    assert p1.build().config_hash() == p2.build().config_hash()

--- a/lenskit/tests/pipeline/test_train.py
+++ b/lenskit/tests/pipeline/test_train.py
@@ -18,6 +18,7 @@ def test_train(ml_ds: Dataset):
 
     tc: Trainable = TestComponent()
     pipe.add_component("test", tc, item=item)
+    pipe.default_component("test")
 
     pipe = pipe.build()
     pipe.train(ml_ds)

--- a/lenskit/tests/pipeline/test_train.py
+++ b/lenskit/tests/pipeline/test_train.py
@@ -8,17 +8,18 @@ from typing import Any
 
 from lenskit.data.dataset import Dataset
 from lenskit.data.vocab import Vocabulary
-from lenskit.pipeline import Pipeline
+from lenskit.pipeline import PipelineBuilder
 from lenskit.training import Trainable, TrainingOptions
 
 
 def test_train(ml_ds: Dataset):
-    pipe = Pipeline()
+    pipe = PipelineBuilder()
     item = pipe.create_input("item", int)
 
     tc: Trainable = TestComponent()
     pipe.add_component("test", tc, item=item)
 
+    pipe = pipe.build()
     pipe.train(ml_ds)
 
     # return true for an item that exists


### PR DESCRIPTION
This makes several significant changes to the pipeline API:

- `PipelineBuilder` and `Pipeline` are now separate, and `Pipeline` is intended to be immutable.
- The `run` method is now takes a tuple instead of varargs, so that its return type can be more obvious.
- Config hashes are now properties.
- Default input connections are resolved at build time, not run time (and are no longer included in configurations).

Closes #604.