### PR TITLE
Make vocabularies immutable and stop using copy()

### DIFF
--- a/docs/guide/data.rst
+++ b/docs/guide/data.rst
@@ -53,11 +53,12 @@ Or obtain item statistics:
 Data Model and Key Concepts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The LensKit data model consists of **users**, **items**, and **interactions**,
-with fields providing additional (optional) data about each of these entities.
-The simplest valid LensKit data set is simply a list of user and item
-identifiers indicating which items each user has interacted with.  These may be
-augmented with ratings, timestamps, or any other attributes.
+The LensKit data model, detailed in :ref:`data-model` consists of **entities**
+(often *users* and *items*) and **interactions**, with attributes providing
+additional (optional) data about each of these entities. The simplest valid
+LensKit data set is simply a list of user and item identifiers indicating which
+items each user has interacted with.  These may be augmented with ratings,
+timestamps, or any other attributes.
 
 Data can be read from a range of sources, but ultimately resolves to a
 collection of tables (e.g. Pandas :class:`~pandas.DataFrame`) that record user,
@@ -81,13 +82,15 @@ Users and items have two identifiers:
   appears as a ``user_num`` or ``item_num`` column.  It is the only
   representation supported by NumPy and PyTorch array formats.
 
-  User and item numbers are assigned based on sorted identifiers in the initial
-  data source, so reloading the same data set will yield the same numbers.
-  Loading a subset, however, is not guaranteed to result in the same numbers, as
-  the subset may be missing some users or items.
+  User and item numbers are assigned based on identifiers in the initial data
+  source.  Adding all entities at once, or using one of the standard loaders,
+  will sort the identifiers before assigning numbers, so reloading the same data
+  set will yield the same numbers. Loading a subset, however, is not guaranteed
+  to result in the same numbers, as the subset may be missing some users or
+  items.
 
-  Methods that add additional users or items will assign numbers based on the
-  sorted identifiers that do not yet have numbers.
+  Adding additional users or items to a data set builder will assign numbers
+  based on the sorted identifiers that do not yet have numbers.
 
 Identifiers and numbers can be mapped to each other with the user and item
 *vocabularies* (:attr:`~Dataset.users` and :attr:`~Dataset.items`, see the

--- a/lenskit-funksvd/lenskit/funksvd.py
+++ b/lenskit-funksvd/lenskit/funksvd.py
@@ -306,8 +306,8 @@ class FunkSVDScorer(Trainable, Component[ItemList]):
         train(context, params, model, timer)
         _logger.info("finished model training in %s", timer)
 
-        self.users_ = data.users.copy()
-        self.items_ = data.items.copy()
+        self.users_ = data.users
+        self.items_ = data.items
         self.user_features_ = model.user_features
         self.item_features_ = model.item_features
 

--- a/lenskit-sklearn/lenskit/sklearn/svd.py
+++ b/lenskit-sklearn/lenskit/sklearn/svd.py
@@ -92,8 +92,8 @@ class BiasedSVDScorer(Component[ItemList], Trainable):
         _log.info("[%s] training SVD (k=%d)", timer, self.factorization_.n_components)  # type: ignore
         Xt = self.factorization_.fit_transform(r_mat)  # type: ignore
         self.user_components_ = Xt
-        self.users_ = data.users.copy()
-        self.items_ = data.items.copy()
+        self.users_ = data.users
+        self.items_ = data.items
         _log.info("finished model training in %s", timer)
 
     @override

--- a/lenskit/lenskit/basic/bias.py
+++ b/lenskit/lenskit/basic/bias.py
@@ -126,7 +126,7 @@ class BiasModel:
             i_bias = np.zeros(ncols, dtype=np.float32)
             np.divide(sums, counts, out=i_bias, where=counts > 0)
 
-            model.items = data.items.copy()
+            model.items = data.items
             model.item_biases = i_bias
             centered -= i_bias[ratings.col]
             _logger.info("computed biases for %d items", len(i_bias))
@@ -140,7 +140,7 @@ class BiasModel:
             u_bias = np.zeros(nrows, dtype=np.float32)
             np.divide(sums, counts, out=u_bias, where=counts > 0)
 
-            model.users = data.users.copy()
+            model.users = data.users
             model.user_biases = u_bias
             _logger.info("computed biases for %d users", len(u_bias))
 

--- a/lenskit/lenskit/basic/candidates.py
+++ b/lenskit/lenskit/basic/candidates.py
@@ -31,7 +31,7 @@ class TrainingCandidateSelectorBase(Component[ItemList], Trainable):
         if hasattr(self, "items_") and not options.retrain:
             return
 
-        self.items_ = data.items.copy()
+        self.items_ = data.items
 
 
 class AllTrainingItemsCandidateSelector(TrainingCandidateSelectorBase):

--- a/lenskit/lenskit/basic/popularity.py
+++ b/lenskit/lenskit/basic/popularity.py
@@ -52,7 +52,7 @@ class PopScorer(Component[ItemList], Trainable):
             return
 
         _log.info("counting item popularity")
-        self.items_ = data.items.copy()
+        self.items_ = data.items
         stats = data.item_stats()
         scores = stats["count"].reindex(self.items_.ids())
         self.item_scores_ = np.require(
@@ -125,5 +125,5 @@ class TimeBoundedPopScore(PopScorer):
 
             item_scores = super()._train_internal(counts)
 
-        self.items_ = data.items.copy()
+        self.items_ = data.items
         self.item_scores_ = np.require(item_scores.reindex(self.items_.ids()).values, np.float32)

--- a/lenskit/lenskit/data/dataset.py
+++ b/lenskit/lenskit/data/dataset.py
@@ -144,8 +144,7 @@ class Dataset:
             tbl = self._data.tables[name]
             id_name = id_col_name(name)
             ids = tbl.column(id_name)
-            index = pd.Index(np.asarray(ids), name=id_name)
-            vocab = Vocabulary(index, name=name)
+            vocab = Vocabulary(ids, name=name, reorder=False)
             self._entities[name] = EntitySet(name, schema, vocab, tbl)
 
         for name, schema in self._data.schema.relationships.items():

--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -444,7 +444,8 @@ class ItemList:
         if vocabulary is not None and vocabulary is not self._vocab:
             # we need to translate vocabulary
             ids = self.ids()
-            return vocabulary.numbers(ids, missing=missing)
+            mta = MTArray(vocabulary.numbers(ids, missing=missing))
+            return mta.to(format)
 
         if self._numbers is None:
             if self._vocab is None:
@@ -452,7 +453,7 @@ class ItemList:
             assert self._ids is not None
             self._numbers = MTArray(self._vocab.numbers(self._ids, missing="negative"))
 
-        if missing == "error" and np.any(self._numbers.to("numpy") < 0):
+        if missing == "error" and np.any(self._numbers.numpy() < 0):
             raise KeyError("item IDs")
         return self._numbers.to(format)
 

--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -199,6 +199,12 @@ class ItemList:
         if item_nums is not None:
             if not len(item_nums):  # type: ignore
                 item_nums = np.ndarray(0, dtype=np.int32)
+            if isinstance(item_nums, np.ndarray):
+                item_nums = np.require(item_nums, dtype=np.int32)
+            elif isinstance(item_nums, pa.Array):
+                item_nums = item_nums.cast(pa.int32())
+            elif torch.is_tensor(item_nums):
+                item_nums = item_nums.to(torch.int32)
             self._numbers = MTArray(item_nums)
             check_1d(self._numbers, getattr(self, "_len", None), label="item_nums")
             self._len = self._numbers.shape[0]

--- a/lenskit/lenskit/data/items.py
+++ b/lenskit/lenskit/data/items.py
@@ -435,7 +435,7 @@ class ItemList:
             RuntimeError: if the item list was not created with numbers or a
             :class:`Vocabulary`.
         """
-        if vocabulary is not None and not vocabulary.compatible_with_numbers_from(self._vocab):
+        if vocabulary is not None and vocabulary is not self._vocab:
             # we need to translate vocabulary
             ids = self.ids()
             return vocabulary.numbers(ids, missing=missing)

--- a/lenskit/lenskit/data/vocab.py
+++ b/lenskit/lenskit/data/vocab.py
@@ -30,6 +30,10 @@ class Vocabulary:
     entitie ID vocabularies in :class:`~lenskit.data.Dataset`, but it can also
     be used for things like item tags.
 
+    IDs in a vocabulary must be unique.  Constructing a vocabulary with
+    ``reorder=True`` ensures uniqueness (and sorts the IDs), but does not
+    preserve the order of IDs in the original input.
+
     It is currently a wrapper around :class:`pandas.Index`, but this fact is not
     part of the stable public API.
 
@@ -39,9 +43,9 @@ class Vocabulary:
         name:
             The vocabulary name.
         reorder:
-            If ``True`` (the default), sort and deduplicate the IDs.  If
-            ``False``, use the IDs as-is, in which case they must already be
-            unique and sorted.
+            If ``True``, sort and deduplicate the IDs.  If ``False`` (the
+            default), use the IDs as-is (assigning each to their position in the
+            input sequence).
 
     Stability:
         Caller

--- a/lenskit/lenskit/knn/user.py
+++ b/lenskit/lenskit/knn/user.py
@@ -132,9 +132,9 @@ class UserKNNScorer(Component[ItemList], Trainable):
 
         self.user_vectors_ = normed
         self.user_ratings_ = torch_sparse_to_scipy(rmat).tocsc()
-        self.users_ = data.users.copy()
+        self.users_ = data.users
         self.user_means_ = means
-        self.items_ = data.items.copy()
+        self.items_ = data.items
 
     @override
     def __call__(self, query: QueryInput, items: ItemList) -> ItemList:

--- a/lenskit/tests/data/test_builder_entities.py
+++ b/lenskit/tests/data/test_builder_entities.py
@@ -1,6 +1,5 @@
 # pyright: strict
 import numpy as np
-import pandas as pd
 import pyarrow as pa
 
 from pytest import raises

--- a/lenskit/tests/data/test_itemlist.py
+++ b/lenskit/tests/data/test_itemlist.py
@@ -14,7 +14,7 @@ import torch
 import hypothesis.extra.numpy as nph
 import hypothesis.strategies as st
 from hypothesis import given, settings
-from pytest import raises, warns
+from pytest import mark, raises, warns
 
 from lenskit.data import Dataset, ItemList
 from lenskit.data.vocab import Vocabulary
@@ -255,6 +255,45 @@ def test_numbers_alt_vocab():
     av = Vocabulary(["A", "B"] + ITEMS)
     nums = il.numbers(vocabulary=av)
     assert np.all(nums == np.arange(2, 7))
+
+
+@mark.parametrize("src", ["ids", "numbers"])
+def test_numbers_numpy(src):
+    match src:
+        case "ids":
+            il = ItemList(item_ids=ITEMS, vocabulary=VOCAB)
+        case "numbers":
+            il = ItemList(item_nums=np.arange(5), vocabulary=VOCAB)
+
+    nums = il.numbers(format="numpy")
+    assert isinstance(nums, np.ndarray)
+    assert np.all(nums == np.arange(5))
+
+
+@mark.parametrize("src", ["ids", "numbers"])
+def test_numbers_torch(src):
+    match src:
+        case "ids":
+            il = ItemList(item_ids=ITEMS, vocabulary=VOCAB)
+        case "numbers":
+            il = ItemList(item_nums=np.arange(5), vocabulary=VOCAB)
+
+    nums = il.numbers(format="torch")
+    assert torch.is_tensor(nums)
+    assert torch.all(nums == torch.arange(5))
+
+
+@mark.parametrize("src", ["ids", "numbers"])
+def test_numbers_arrow(src):
+    match src:
+        case "ids":
+            il = ItemList(item_ids=ITEMS, vocabulary=VOCAB)
+        case "numbers":
+            il = ItemList(item_nums=np.arange(5), vocabulary=VOCAB)
+
+    nums = il.numbers(format="arrow")
+    assert isinstance(nums, pa.Int32Array)
+    assert np.all(nums.to_numpy() == np.arange(5))
 
 
 def test_pandas_df():

--- a/lenskit/tests/data/test_itemlist.py
+++ b/lenskit/tests/data/test_itemlist.py
@@ -269,6 +269,10 @@ def test_numbers_numpy(src):
     assert isinstance(nums, np.ndarray)
     assert np.all(nums == np.arange(5))
 
+    nums = il.numbers(format="numpy", vocabulary=Vocabulary(ITEMS))
+    assert isinstance(nums, np.ndarray)
+    assert np.all(nums == np.arange(5))
+
 
 @mark.parametrize("src", ["ids", "numbers"])
 def test_numbers_torch(src):
@@ -282,6 +286,10 @@ def test_numbers_torch(src):
     assert torch.is_tensor(nums)
     assert torch.all(nums == torch.arange(5))
 
+    nums = il.numbers(format="torch", vocabulary=Vocabulary(ITEMS))
+    assert torch.is_tensor(nums)
+    assert torch.all(nums == torch.arange(5))
+
 
 @mark.parametrize("src", ["ids", "numbers"])
 def test_numbers_arrow(src):
@@ -292,6 +300,10 @@ def test_numbers_arrow(src):
             il = ItemList(item_nums=np.arange(5), vocabulary=VOCAB)
 
     nums = il.numbers(format="arrow")
+    assert isinstance(nums, pa.Int32Array)
+    assert np.all(nums.to_numpy() == np.arange(5))
+
+    nums = il.numbers(format="arrow", vocabulary=Vocabulary(ITEMS))
     assert isinstance(nums, pa.Int32Array)
     assert np.all(nums.to_numpy() == np.arange(5))
 

--- a/lenskit/tests/data/test_vocab.py
+++ b/lenskit/tests/data/test_vocab.py
@@ -8,6 +8,7 @@
 Tests for the Vocabulary class.
 """
 
+import pickle
 from uuid import UUID
 
 import numpy as np
@@ -195,3 +196,16 @@ def test_all_terms(initial: set[int] | set[str]):
     terms = vocab.terms()
     assert isinstance(terms, np.ndarray)
     assert all(terms == tl)
+
+
+@given(st.one_of(st.lists(st.integers()), st.lists(st.uuids()), st.lists(st.emails())))
+def test_pickle(initial: list[int | str | UUID]):
+    vocab = Vocabulary(initial, reorder=True)
+
+    blob = pickle.dumps(vocab)
+    v2 = pickle.loads(blob)
+
+    assert v2 is not vocab
+    assert len(v2) == len(vocab)
+    assert np.all(v2.ids() == vocab.ids())
+    assert v2 == vocab

--- a/lenskit/tests/data/test_vocab.py
+++ b/lenskit/tests/data/test_vocab.py
@@ -27,7 +27,7 @@ from lenskit.diagnostics import DataWarning
     )
 )
 def test_create_basic(keys: set[int | str | UUID]):
-    vocab = Vocabulary(keys)
+    vocab = Vocabulary(keys, reorder=True)
     assert vocab.size == len(keys)
     assert len(vocab) == len(keys)
 
@@ -43,7 +43,7 @@ def test_create_basic(keys: set[int | str | UUID]):
 )
 def test_create_nonunique(keys: list[int | str | UUID]):
     uq = set(keys)
-    vocab = Vocabulary(keys)
+    vocab = Vocabulary(keys, reorder=True)
     assert vocab.size == len(uq)
     assert len(vocab) == len(uq)
 
@@ -58,9 +58,9 @@ def test_create_nonunique(keys: list[int | str | UUID]):
     )
 )
 def test_equal(keys: list[int | str | UUID]):
-    vocab = Vocabulary(keys)
+    vocab = Vocabulary(keys, reorder=True)
 
-    v2 = Vocabulary(keys)
+    v2 = Vocabulary(keys, reorder=True)
     assert v2 == vocab
 
 
@@ -69,8 +69,8 @@ def test_not_equal(keys: list[int], oks: set[int]):
     uq = set(keys)
     assume(oks != uq)
 
-    vocab = Vocabulary(keys)
-    v2 = Vocabulary(oks)
+    vocab = Vocabulary(keys, reorder=True)
+    v2 = Vocabulary(oks, reorder=True)
     assert v2 != vocab
 
 
@@ -87,7 +87,7 @@ def test_not_equal(keys: list[int], oks: set[int]):
     ),
 )
 def test_contains(keys: set[int] | set[str] | set[UUID], qs: set[int | str | UUID]):
-    vocab = Vocabulary(keys)
+    vocab = Vocabulary(keys, reorder=True)
 
     for qk in qs:
         if qk in keys:
@@ -105,7 +105,7 @@ def test_contains(keys: set[int] | set[str] | set[UUID], qs: set[int | str | UUI
 def test_lookup_id_index(keys: set[int | str | UUID]):
     klist = sorted(keys)
 
-    vocab = Vocabulary(keys)
+    vocab = Vocabulary(keys, reorder=True)
     assert vocab.size == len(klist)
     assert len(vocab) == len(klist)
 
@@ -126,7 +126,7 @@ def test_lookup_id_index(keys: set[int | str | UUID]):
 def test_lookup_bad_id(keys: set[int | str | UUID], key: int | str | UUID):
     assume(key not in keys)
 
-    vocab = Vocabulary(keys)
+    vocab = Vocabulary(keys, reorder=True)
 
     assert vocab.number(key, missing=None) is None
 
@@ -144,7 +144,7 @@ def test_lookup_bad_id(keys: set[int | str | UUID], key: int | str | UUID):
 def test_lookup_bad_number(keys: set[int | str | UUID], num: int):
     assume(num < 0 or num >= len(keys))
 
-    vocab = Vocabulary(keys)
+    vocab = Vocabulary(keys, reorder=True)
 
     with raises(IndexError):
         vocab.term(num)


### PR DESCRIPTION
This makes vocabularies immutable (or at least read-only), and stops using copy and the advanced hash-based compatibility checking.