### PR TITLE
Update and make consistent model configurations

### DIFF
--- a/docs/guide/migrating.rst
+++ b/docs/guide/migrating.rst
@@ -189,6 +189,7 @@ the pipeline, you will call :py:meth:`~lenskit.pipeline.Pipeline.train`::
 
 See :ref:`pipeline` for more details on pipelines and how you can reconfigure
 them for very different ways of turning scoring models into full recommenders.
+This replaces the old ``fit`` method on algorithm objects.
 
 .. note::
 
@@ -196,6 +197,8 @@ them for very different ways of turning scoring models into full recommenders.
     ambiguous and promotes confusion about very different things.  Instead, we
     have “pipelines” consisting of ”components”, some of which may be ”models”
     (for scoring, ranking, etc.).
+
+.. _migrate-component-config:
 
 Configuration Components
 ........................
@@ -233,11 +236,6 @@ when you call :py:func:`~lenskit.pipeline.topn_pipeline`).
     The input specifying the user identifier is now called a ``query``, in order
     to support recommendation tasks beyond simple user-based recommendation such
     as context-based or session-based recommendation.
-
-.. note::
-
-    We are considering adding a more ergonomic interface to obtain
-    recommendations from pipelines.
 
 Batch Inference
 ---------------
@@ -282,3 +280,39 @@ functionality.  See :ref:`evaluation` for details on metrics and analysis.
 
 :py:mod:`lenskit.metrics.RunAnalysis` replaces the old ``RecListAnalysis``, and
 provides better defaults (e.g. how users without recommendations are handled).
+
+Model Configuration Changes
+---------------------------
+
+In line with the new component configuration framework (see
+:ref:`migrate-component-config`) and to make configuration more consistent
+between models, we have changed several configuration options and defaults.
+
+These changes for the most popular models are below:
+
+Cross-Model Standardization
+...........................
+
+*   All configuration options must be named, no positional options are accepted.
+*   Any model that uses training epochs now uses the configuration option
+    ``epochs`` (was previously ``iterations`` on some models).
+*   Latent-feature models use the configuration option ``embedding_size`` to
+    declare the embedding size.
+
+ALS
+...
+
+The ALS models have the following configuration changes:
+
+*   ``epochs`` and ``embedding_size`` as noted above.  ``features`` is accepted
+    as an input alias for ``embedding_size``.
+*   ``save_user_embeddings`` is now ``user_embeddings``, with three options:
+    ``True``, ``False``, and ``"prefer"``.
+
+k-NN
+....
+
+The k-NN models have the following changes:
+
+*   Max neighbors is now called ``max_nbrs`` instead of ``nnbrs`` (``k`` is
+    accepted as an input alias).

--- a/lenskit/lenskit/knn/user.py
+++ b/lenskit/lenskit/knn/user.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 import structlog
 import torch
-from pydantic import BaseModel, PositiveFloat, PositiveInt, field_validator
+from pydantic import AliasChoices, BaseModel, Field, PositiveFloat, PositiveInt, field_validator
 from scipy.sparse import csc_array
 from typing_extensions import NamedTuple, Optional, override
 
@@ -37,7 +37,7 @@ _log = get_logger(__name__)
 class UserKNNConfig(BaseModel, extra="forbid"):
     "Configuration for :class:`ItemKNNScorer`."
 
-    k: PositiveInt = 20
+    max_nbrs: PositiveInt = Field(20, validation_alias=AliasChoices("max_nbrs", "k"))
     """
     The maximum number of neighbors for scoring each item.
     """
@@ -207,7 +207,7 @@ class UserKNNScorer(Component[ItemList], Trainable):
             kn_idxs,
             kn_sims,
             self.user_ratings_,
-            self.config.k,
+            self.config.max_nbrs,
             self.config.min_nbrs,
             self.config.explicit,
         )

--- a/lenskit/tests/models/test_als_explicit.py
+++ b/lenskit/tests/models/test_als_explicit.py
@@ -181,7 +181,7 @@ def test_als_predict_no_user_features_basic(rng: np.random.Generator, ml_ds: Dat
     assert algo.users_ is not None
     assert algo.user_features_ is not None
 
-    algo_no_user_features = BiasedMFScorer(features=5, epochs=10, save_user_features=False)
+    algo_no_user_features = BiasedMFScorer(features=5, epochs=10, user_embeddings=False)
     algo_no_user_features.train(ml_ds)
 
     assert algo_no_user_features.user_features_ is None

--- a/lenskit/tests/models/test_als_explicit.py
+++ b/lenskit/tests/models/test_als_explicit.py
@@ -44,7 +44,7 @@ def test_als_basic_build():
     assert algo.user_features_.shape == (3, 20)
     assert algo.item_features_.shape == (3, 20)
 
-    assert algo.config.features == 20
+    assert algo.config.embedding_size == 20
     assert len(algo.users_) == 3
     assert len(algo.items_) == 3
 
@@ -213,7 +213,7 @@ def test_als_train_large(ml_ratings, ml_ds: Dataset):
     assert algo.user_features_ is not None
 
     assert algo.bias_.global_bias == approx(ml_ratings.rating.mean())
-    assert algo.config.features == 20
+    assert algo.config.embedding_size == 20
     assert len(algo.items_) == ml_ds.item_count
     assert len(algo.users_) == ml_ds.user_count
 

--- a/lenskit/tests/models/test_als_implicit.py
+++ b/lenskit/tests/models/test_als_implicit.py
@@ -250,7 +250,7 @@ def test_als_predict_no_user_features_basic(ml_ratings: pd.DataFrame, ml_ds: Dat
 
     user_data = ml_ds.user_row(u)
 
-    algo_no_user_features = ImplicitMFScorer(features=5, epochs=10, save_user_features=False)
+    algo_no_user_features = ImplicitMFScorer(features=5, epochs=10, user_embeddings=False)
     algo_no_user_features.train(ml_ds)
     query = RecQuery(u, user_data)
     preds_no_user_features = algo_no_user_features(query, ItemList(items))

--- a/lenskit/tests/models/test_knn_item_item.py
+++ b/lenskit/tests/models/test_knn_item_item.py
@@ -76,7 +76,7 @@ def test_ii_config():
     cfg = model.dump_config()
     print(cfg)
     assert cfg["feedback"] == "explicit"
-    assert cfg["k"] == 30
+    assert cfg["max_nbrs"] == 30
 
 
 def test_ii_train():


### PR DESCRIPTION
This has 3 improvements to model configuration and behavior:

- Document model configuration updates in migration guide.
- Use `embedding_size` (with `features` alias) for embedding models.
- Use `max_nbrs` (with alias `k`) for neighborhood models.
- Support `"prefer"` option for ALS user embeddings.