### PR TITLE
[MINOR:fix link] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use the latest development version, install directly from GitHub:
 
     pip install -U git+https://github.com/lenskit/lkpy
 
-Then see [Getting Started](https://lkpy.lenskit.org/en/latest/GettingStarted.html)
+Then see [Getting Started](https://lkpy.lenskit.org/en/stable/GettingStarted.html)
 
 ## Developing
 


### PR DESCRIPTION
Getting started link doesn't resolve on /latest.

There also seems to be a general issue with the /latest branch since it shows a completely different documentation page than the one on readthedocs. (see: https://lkpy.lenskit.org/en/latest vs https://lkpy.lenskit.org/en/stable/index.html)