### PR TITLE
Rename RunAnalysis.compute to .measure

### DIFF
--- a/docs/guide/GettingStarted.ipynb
+++ b/docs/guide/GettingStarted.ipynb
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
     "ran.add_metric(NDCG())\n",
     "ran.add_metric(RBP())\n",
     "ran.add_metric(RecipRank())\n",
-    "results = ran.compute(all_recs, all_test)"
+    "results = ran.measure(all_recs, all_test)"
    ]
   },
   {
@@ -383,7 +383,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dev-full",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/docs/guide/batch.rst
+++ b/docs/guide/batch.rst
@@ -58,9 +58,9 @@ Generate recommendations:
 
 And measure their results:
 
-    >>> measure = RunAnalysis()
-    >>> measure.add_metric(RBP())
-    >>> scores = measure.compute(recs, split.test)
+    >>> ra = RunAnalysis()
+    >>> ra.add_metric(RBP())
+    >>> scores = ra.measure(recs, split.test)
     >>> scores.list_summary()    # doctest: +ELLIPSIS
               mean    median     std
     metric

--- a/lenskit/lenskit/metrics/_quick.py
+++ b/lenskit/lenskit/metrics/_quick.py
@@ -60,13 +60,13 @@ def quick_measure_model(
     rra.add_metric(Hit())
     rra.add_metric(Recall())
 
-    result = rra.compute(outs.output("recommendations"), split.test)
+    result = rra.measure(outs.output("recommendations"), split.test)
 
     if predicts_ratings:
         pra = RunAnalysis()
         pra.add_metric(RMSE())
         pra.add_metric(MAE())
-        pr = pra.compute(outs.output("predictions"), split.test)
+        pr = pra.measure(outs.output("predictions"), split.test)
         result.merge_from(pr)
 
     return result

--- a/lenskit/lenskit/metrics/bulk.py
+++ b/lenskit/lenskit/metrics/bulk.py
@@ -219,6 +219,20 @@ class RunAnalysis:
     def compute(
         self, outputs: ItemListCollection[K1], test: ItemListCollection[K2]
     ) -> RunAnalysisResult:
+        """
+        Deprecated alias for :meth:`measure`.
+
+        .. deprecated:: 2025.1.1
+            Use :meth:`measure` instead.
+        """
+        return self.measure(outputs, test)
+
+    def measure(
+        self, outputs: ItemListCollection[K1], test: ItemListCollection[K2]
+    ) -> RunAnalysisResult:
+        """
+        Measure a set of outputs against a set of dest data.
+        """
         index = pd.MultiIndex.from_tuples(outputs.keys())
         index.names = list(outputs.key_fields)
 

--- a/lenskit/tests/batch/test_batch_pipeline.py
+++ b/lenskit/tests/batch/test_batch_pipeline.py
@@ -116,7 +116,7 @@ def test_bias_batch(ml_split: TTSplit, ncpus: int | None):
 
     pa = RunAnalysis()
     pa.add_metric(RMSE())
-    pred_acc = pa.compute(preds, ml_split.test)
+    pred_acc = pa.measure(preds, ml_split.test)
     pas = pred_acc.list_summary()
     print(pas)
     assert pas.loc["RMSE", "mean"] == approx(0.949, rel=0.1)
@@ -125,7 +125,7 @@ def test_bias_batch(ml_split: TTSplit, ncpus: int | None):
     ra = RunAnalysis()
     ra.add_metric(NDCG())
     ra.add_metric(RBP())
-    rec_acc = ra.compute(recs, ml_split.test)
+    rec_acc = ra.measure(recs, ml_split.test)
     ras = rec_acc.list_summary()
     print(ras)
 
@@ -149,7 +149,7 @@ def test_pop_batch_recommend(ml_split: TTSplit, ncpus: int | None):
     ra = RunAnalysis()
     ra.add_metric(NDCG())
     ra.add_metric(RBP())
-    rec_acc = ra.compute(recs, ml_split.test)
+    rec_acc = ra.measure(recs, ml_split.test)
     ras = rec_acc.list_summary()
     print(ras)
 

--- a/lenskit/tests/eval/test_bulk_metrics.py
+++ b/lenskit/tests/eval/test_bulk_metrics.py
@@ -21,7 +21,7 @@ def test_bulk_measure_function(ml_ratings: pd.DataFrame):
     )
     truth = ItemListCollection.from_df(ml_ratings, USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN)
 
-    metrics = bms.compute(data, truth)
+    metrics = bms.measure(data, truth)
     stats = metrics.list_summary()
     assert stats.loc["length", "mean"] == approx(ml_ratings["user_id"].value_counts().mean())
     assert stats.loc["RMSE", "mean"] == approx(0)
@@ -38,7 +38,7 @@ def test_recs(demo_recs):
     bms.add_metric(RBP)
     bms.add_metric(RecipRank)
 
-    metrics = bms.compute(recs, split.test)
+    metrics = bms.measure(recs, split.test)
     scores = metrics.list_metrics()
     stats = metrics.list_summary()
     print(stats)
@@ -60,7 +60,7 @@ def test_recs_multi(demo_recs):
     bms.add_metric(RBP)
     bms.add_metric(RecipRank)
 
-    metrics = bms.compute(il2, split.test)
+    metrics = bms.measure(il2, split.test)
     scores = metrics.list_metrics()
     stats = metrics.list_summary("rep")
     print(stats)

--- a/lenskit/tests/eval/test_predict_metrics.py
+++ b/lenskit/tests/eval/test_predict_metrics.py
@@ -115,7 +115,7 @@ def test_batch_rmse(ml_100k):
     pa.add_metric(RMSE())
     pa.add_metric(MAE())
 
-    metrics = pa.compute(preds, split.test)
+    metrics = pa.measure(preds, split.test)
 
     umdf = metrics.list_metrics(fill_missing=False)
     mdf = metrics.list_summary()


### PR DESCRIPTION
This renames the `RunAnalysis.compute` method to `.measure`, to be clearer. `.compute` is kept as a deprecated alias.