### PR TITLE
Add CLI plugin support

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -17274,8 +17274,8 @@ packages:
   timestamp: 1729655345825
 - pypi: .
   name: lenskit
-  version: 2025.1.1rc2.dev1+g1c71dc93.d20250228
-  sha256: f2e303ed5de2932ec21fe759ac6d0450203d2adca1edd05d21b3caaae4e11357
+  version: 2025.1.1rc2.dev2+ga88b9473.d20250228
+  sha256: 726f353109fe3056683b4262fece401322bc408c6f59b491cf023df624be1360
   requires_dist:
   - click~=8.1
   - humanize~=4.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -17274,8 +17274,8 @@ packages:
   timestamp: 1729655345825
 - pypi: .
   name: lenskit
-  version: 2025.1.1b12.dev26+g1c77cf61
-  sha256: cc7ec3371a63b64aef04b12990d1e7036601175ca1f1cc48218333b7cd726cd5
+  version: 2025.1.1rc2.dev1+g1c71dc93.d20250228
+  sha256: f2e303ed5de2932ec21fe759ac6d0450203d2adca1edd05d21b3caaae4e11357
   requires_dist:
   - click~=8.1
   - humanize~=4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ source = "https://github.com/lenskit/lkpy"
 [project.scripts]
 lenskit = "lenskit.cli:lenskit"
 
+[project.entry-points."lenskit.cli-plugins"]
+lenskit-data = "lenskit.cli.data:data"
+
 # configure build tools
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ source = "https://github.com/lenskit/lkpy"
 [project.scripts]
 lenskit = "lenskit.cli:lenskit"
 
-[project.entry-points."lenskit.cli-plugins"]
+[project.entry-points."lenskit.cli.plugins"]
 lenskit-data = "lenskit.cli.data:data"
 
 # configure build tools

--- a/src/lenskit/cli/__init__.py
+++ b/src/lenskit/cli/__init__.py
@@ -44,7 +44,7 @@ def version():
     console.print(f"LensKit version [bold cyan]{__version__}[/bold cyan].")
 
 
-cli_plugins = entry_points(group="lenskit.cli-plugins")
+cli_plugins = entry_points(group="lenskit.cli.plugins")
 for plugin in cli_plugins:
     cmd = plugin.load()
     lenskit.add_command(cmd)

--- a/src/lenskit/cli/__init__.py
+++ b/src/lenskit/cli/__init__.py
@@ -4,14 +4,14 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
+from importlib.metadata import entry_points
+
 import click
 
 from lenskit import __version__
 from lenskit.logging import LoggingConfig, console
 
-from .data import data
-
-__all__ = ["lenskit", "main"]
+__all__ = ["lenskit", "main", "version"]
 
 
 def main():
@@ -44,4 +44,7 @@ def version():
     console.print(f"LensKit version [bold cyan]{__version__}[/bold cyan].")
 
 
-lenskit.add_command(data)
+cli_plugins = entry_points(group="lenskit.cli-plugins")
+for plugin in cli_plugins:
+    cmd = plugin.load()
+    lenskit.add_command(cmd)


### PR DESCRIPTION
This makes CLI subcommands into plugins, so we can add more in other projects (e.g. `lenskit codex`). Only top-level subcommands can be added.