### PR TITLE
Make sure components work with forward references to configuration types

### DIFF
--- a/tests/pipeline/test_component_config.py
+++ b/tests/pipeline/test_component_config.py
@@ -20,6 +20,13 @@ from lenskit.pipeline.components import Component, ComponentConstructor
 from lenskit.pipeline.nodes import ComponentConstructorNode
 
 
+class EarlyConfig(Component[str]):
+    config: PrefixConfigDC
+
+    def __call__(self, msg: str) -> str:
+        return self.config.prefix + msg
+
+
 @dataclass
 class PrefixConfigDC:
     prefix: str = "UNDEFINED"


### PR DESCRIPTION
This fixes configuration classes so we can forward-reference configuration types, and config checking will be deferred to instantiation time.