### PR TITLE
Fix logic for monitors in nested workers

### DIFF
--- a/src/lenskit/logging/worker.py
+++ b/src/lenskit/logging/worker.py
@@ -92,6 +92,7 @@ class WorkerContext:
         global _active_context
         if _active_context is not None:
             raise RuntimeError("worker context already active")
+        _active_context = self
 
         self.zmq = zmq.Context()
         self._log_handler = ZMQLogHandler(self.zmq, self.config)
@@ -112,11 +113,13 @@ class WorkerContext:
         _log.debug("log context activated")
 
     def shutdown(self):
+        global _active_context
         root = getLogger()
         root.removeHandler(self._log_handler)
 
         self._log_handler.shutdown()
         self.zmq.term()
+        _active_context = None
 
     def send_task(self, task: Task):
         self._log_handler.send_task(task)

--- a/src/lenskit/parallel/config.py
+++ b/src/lenskit/parallel/config.py
@@ -131,13 +131,21 @@ def get_parallel_config() -> ParallelConfig:
     return _config
 
 
-def subprocess_config() -> ParallelConfig:
+def subprocess_config(
+    processes: int | None = None,
+    threads: int | None = None,
+    backend_threads: int | None = None,
+    child_threads: int | None = None,
+) -> ParallelConfig:
     """
     Get a parallel configuration for a subprocess.
     """
     cfg = get_parallel_config()
     return ParallelConfig(
-        processes=1, threads=1, backend_threads=cfg.child_threads, child_threads=1
+        processes=processes or 1,
+        threads=threads or 1,
+        backend_threads=backend_threads or cfg.child_threads,
+        child_threads=child_threads or 1,
     )
 
 

--- a/src/lenskit/parallel/ray.py
+++ b/src/lenskit/parallel/ray.py
@@ -50,7 +50,17 @@ _log = get_logger(__name__)
 
 def ensure_cluster():
     if not ray.is_initialized():
-        init_cluster()
+        _log.debug("Ray is not initialized, initializing")
+        try:
+            init_cluster()
+        except ValueError as e:
+            _log.debug("Ray initialization failed", exception=e)
+            if "existing cluster" in str(e):
+                _log.info("Ray cluster already started, reusing")
+                _log.warn("existing Ray cluster may not properly throttle LensKit jobs")
+                ray.init()
+            else:
+                raise e
 
 
 def init_cluster(

--- a/src/lenskit/parallel/ray.py
+++ b/src/lenskit/parallel/ray.py
@@ -120,7 +120,7 @@ def training_worker_cpus() -> int:
 
 class RayOpInvoker(ModelOpInvoker[A, R], Generic[M, A, R]):
     function: InvokeOp[M, A, R]
-    model_ref: ray.ObjectID
+    model_ref: ray.ObjectRef
 
     def __init__(
         self,
@@ -128,7 +128,10 @@ class RayOpInvoker(ModelOpInvoker[A, R], Generic[M, A, R]):
         func: InvokeOp[M, A, R],
     ):
         _log.debug("persisting to Ray cluster")
-        self.model_ref = ray.put(model)
+        if isinstance(model, ray.ObjectRef):
+            self.model_ref = model
+        else:
+            self.model_ref = ray.put(model)
         self.function = func
         slots = {}
         if LK_PROCESS_SLOT in ray.cluster_resources():

--- a/src/lenskit/parallel/ray.py
+++ b/src/lenskit/parallel/ray.py
@@ -64,6 +64,10 @@ def init_cluster(
     """
     Initialize or connect to a Ray cluster, with the LensKit options.
 
+    The resulting cluster can be used by an invoker, or it can be used directly.
+    The Ray invoker uses batching, though, so it only works well with many small
+    tasks.
+
     Args:
         num_cpus:
             The total number of CPUs to allow. Defaults to

--- a/src/lenskit/parallel/ray.py
+++ b/src/lenskit/parallel/ray.py
@@ -126,7 +126,6 @@ class RayOpInvoker(ModelOpInvoker[A, R], Generic[M, A, R]):
         self,
         model: M,
         func: InvokeOp[M, A, R],
-        worker_parallel: ParallelConfig | None = None,
     ):
         _log.debug("persisting to Ray cluster")
         self.model_ref = ray.put(model)

--- a/src/lenskit/parallel/ray.py
+++ b/src/lenskit/parallel/ray.py
@@ -132,6 +132,18 @@ def training_worker_cpus() -> int:
     return _worker_parallel.total_threads
 
 
+def is_ray_worker() -> bool:
+    """
+    Determine whether the current process is running on a Ray worker.
+    """
+    # logic adapted from https://discuss.ray.io/t/how-to-know-if-code-is-running-on-ray-worker/15642
+    if RAY_AVAILABLE and ray.is_initialized():
+        ctx = ray.get_runtime_context()
+        return ctx.worker.mode == ray.WORKER_MODE
+    else:
+        return False
+
+
 class RayOpInvoker(ModelOpInvoker[A, R], Generic[M, A, R]):
     function: InvokeOp[M, A, R]
     model_ref: ray.ObjectRef


### PR DESCRIPTION
This adds more nuanced logic to monitors when a monitor is started in a worker process, to attempt to fix the problems we are seeing with extra monitors running. The monitor still runs, but it doesn't create a new listener. Closes #607.