### PR TITLE
Use counts instead of ratings in HPF

### DIFF
--- a/docs/releases/2025.rst
+++ b/docs/releases/2025.rst
@@ -87,6 +87,8 @@ however, documented here.
 * Bias is no longer optional for :class:`~lenksit.als.BiasedMFScorer` and
   :class:`~lenskit.funksvd.FunkSVD`; both are inherently biased models, and
   FunkSVD is not commonly used.
+* :class:`lenskit.hpf.HPF` no longer uses ratings as synthetic counts by
+  default.
 
 Bug Fixes
 ~~~~~~~~~

--- a/src/lenskit/data/relationships.py
+++ b/src/lenskit/data/relationships.py
@@ -322,7 +322,7 @@ class MatrixRelationshipSet(RelationshipSet):
         nnz = self._table.num_rows
 
         colinds = self._table.column(num_col_name(self.col_type)).to_numpy()
-        if attribute is None:
+        if attribute is None or (attribute == "count" and "count" not in self._table.column_names):
             values = np.ones(nnz, dtype=np.float32)
         else:
             values = self._table.column(attribute).to_numpy()
@@ -365,7 +365,7 @@ class MatrixRelationshipSet(RelationshipSet):
 
         colinds = self._table.column(num_col_name(self.col_type)).to_numpy()
         colinds = torch.tensor(colinds)
-        if attribute is None:
+        if attribute is None or (attribute == "count" and "count" not in self._table.column_names):
             values = torch.ones(nnz, dtype=torch.float32)
         elif pa.types.is_timestamp(self._table.field(attribute).type):
             vals = self._table.column(attribute)

--- a/tests/data/test_dataset_matrix.py
+++ b/tests/data/test_dataset_matrix.py
@@ -352,3 +352,13 @@ def test_matrix_rows_by_num(rng: np.random.Generator, ml_ratings: pd.DataFrame, 
         timestamps = row.field("timestamp")
         assert timestamps is not None
         assert np.all(timestamps == urows["timestamp"])
+
+
+def test_count_synthetic(ml_ds: Dataset):
+    """
+    Test that interaction matrices synthesize a count attribute.
+    """
+
+    matrix = ml_ds.interactions().matrix().scipy("count")
+    assert isinstance(matrix, sps.csr_array)
+    assert np.all(matrix.data == 1.0)


### PR DESCRIPTION
This corrects an error in HPF, where we were using ratings as synthetic counts. This now uses the `count` attribute by default.