### PR TITLE
Support auto-detecting key columns in ItemListCollection.from_df

### DIFF
--- a/src/lenskit/data/collection/_base.py
+++ b/src/lenskit/data/collection/_base.py
@@ -118,7 +118,7 @@ class ItemListCollection(Generic[KL], ABC):
 
     @staticmethod
     def from_df(
-        df: pd.DataFrame, key: type[K] | Sequence[Column] | Column, *others: Column
+        df: pd.DataFrame, key: type[K] | Sequence[Column] | Column | None = None, *others: Column
     ) -> MutableItemListCollection[Any]:
         """
         Create an item list collection from a data frame.
@@ -286,10 +286,6 @@ class ItemListCollection(Generic[KL], ABC):
             return ilc
         elif layout == "flat":
             tbl = dataset.read_pandas()
-
-            if key is None:
-                warnings.warn("no key specified, inferring from _id columns", DataWarning)
-                key = [n for n in tbl.column_names if n.endswith("_id") and n != "item_id"]
 
             return cls.from_df(tbl.to_pandas(), key)
         else:  # pragma: nocover

--- a/src/lenskit/data/collection/_list.py
+++ b/src/lenskit/data/collection/_list.py
@@ -84,7 +84,12 @@ class ListILC(MutableItemListCollection[K], Generic[K]):
         return ilc
 
     @classmethod
-    def from_df(cls, df: pd.DataFrame, key: type[K] | Sequence[Column] | Column, *others: Column):
+    def from_df(
+        cls,
+        df: pd.DataFrame,
+        key: type[K] | Sequence[Column] | Column | None = None,
+        *others: Column,
+    ):
         """
         Create an item list collection from a data frame.
 
@@ -107,7 +112,12 @@ class ListILC(MutableItemListCollection[K], Generic[K]):
             fields = key_fields(key)
             columns = fields + others
         else:
-            if isinstance(key, Column):
+            if key is None:
+                warnings.warn(
+                    "no key specified, inferring from _id columns", DataWarning, stacklevel=2
+                )
+                key = [n for n in df.columns.names if n.endswith("_id") and n != "item_id"]
+            elif isinstance(key, Column):
                 key = [key]
             columns = tuple(key) + others
             fields = [column_name(c) for c in key]

--- a/src/lenskit/data/collection/_list.py
+++ b/src/lenskit/data/collection/_list.py
@@ -6,11 +6,14 @@ import pandas as pd
 import pyarrow as pa
 
 from lenskit.diagnostics import DataWarning
+from lenskit.logging import get_logger
 
 from ..adapt import Column, column_name, normalize_columns
 from ..items import ItemList
 from ._base import ItemListCollection, MutableItemListCollection
 from ._keys import ID, GenericKey, K, Ko, create_key_type, key_dict, key_fields
+
+_log = get_logger(__name__)
 
 
 class ListILC(MutableItemListCollection[K], Generic[K]):
@@ -122,6 +125,8 @@ class ListILC(MutableItemListCollection[K], Generic[K]):
             columns = tuple(key) + others
             fields = [column_name(c) for c in key]
             key = create_key_type(*fields)  # type: ignore
+
+        _log.debug("converting ILC from dataframe", key=key, rows=len(df))
 
         df = normalize_columns(df, *columns)
         ilc = cls(key)  # type: ignore

--- a/src/lenskit/data/collection/_list.py
+++ b/src/lenskit/data/collection/_list.py
@@ -116,7 +116,7 @@ class ListILC(MutableItemListCollection[K], Generic[K]):
                 warnings.warn(
                     "no key specified, inferring from _id columns", DataWarning, stacklevel=2
                 )
-                key = [n for n in df.columns.names if n.endswith("_id") and n != "item_id"]
+                key = [n for n in df.columns if n.endswith("_id") and n != "item_id"]
             elif isinstance(key, Column):
                 key = [key]
             columns = tuple(key) + others


### PR DESCRIPTION
This moves the key column auto-detection logic from the `load_parquet` method to `from_df`, so that it can be used with Pandas data frames as well.