### PR TITLE
Add PipelineCache to allow pipeline builders to cache component instances

### DIFF
--- a/docs/api/pipeline.rst
+++ b/docs/api/pipeline.rst
@@ -19,6 +19,7 @@ Pipeline Classes
     ~lenskit.pipeline.PipelineState
     ~lenskit.pipeline.Node
     ~lenskit.pipeline.Lazy
+    ~lenskit.pipeline.PipelineCache
 
 Component Interface
 -------------------

--- a/src/lenskit/pipeline/__init__.py
+++ b/src/lenskit/pipeline/__init__.py
@@ -14,6 +14,7 @@ from lenskit.diagnostics import PipelineError, PipelineWarning
 
 from ._impl import CloneMethod, Pipeline
 from .builder import PipelineBuilder
+from .cache import PipelineCache
 from .common import RecPipelineBuilder, predict_pipeline, topn_pipeline
 from .components import (
     Component,
@@ -36,6 +37,7 @@ __all__ = [
     "PipelineConfig",
     "Lazy",
     "Component",
+    "PipelineCache",
     "RecPipelineBuilder",
     "topn_pipeline",
     "predict_pipeline",

--- a/src/lenskit/pipeline/cache.py
+++ b/src/lenskit/pipeline/cache.py
@@ -1,0 +1,74 @@
+"""
+Pipeline caching support.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import JsonValue, TypeAdapter
+
+from lenskit.logging import get_logger
+
+from .components import ComponentConstructor
+from .types import type_string
+
+_log = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class PipelineCacheKey:
+    ctor_name: str
+    ctor: Callable[..., Any] = field(hash=False)
+    config: Mapping[str, JsonValue] | None
+
+
+class PipelineCache:
+    """
+    A cache to share components between pipelines.
+
+    This cache can be used by :class:`~lenskit.pipeline.PipelineBuilder` to
+    cache pipeline component instances between multiple pipelines using the same
+    components with the same configuration.
+    """
+
+    _cache: dict[PipelineCacheKey, Any]
+
+    def __init__(self):
+        self._cache = {}
+
+    def _make_key(self, ctor: ComponentConstructor[Any], config: object | None):
+        name = type_string(ctor)  # type: ignore
+        if config is not None:
+            config = TypeAdapter[Any](ctor.config_class()).dump_python(config, mode="json")
+            assert isinstance(config, dict)
+
+        return PipelineCacheKey(name, ctor, config)
+
+    def get_cached(self, ctor: ComponentConstructor[Any], config: object | None):
+        key = self._make_key(ctor, object)
+        return self._cache.get(key, None)
+
+    def cache(self, ctor: ComponentConstructor[Any], config: object | None, instance: object):
+        key = self._make_key(ctor, object)
+        self._cache[key] = instance
+
+    def get_instance(self, ctor: ComponentConstructor[Any], config: object | None):
+        """
+        Get a component instance from the cache, creating if it necessry.
+        """
+        key = self._make_key(ctor, config)
+        instance = self._cache.get(key, None)
+        if instance is None:
+            instance = ctor(config)
+            self._cache[key] = instance
+            _log.debug(
+                "instantiated component", component=ctor, config=config, n_cached=len(self._cache)
+            )
+        else:
+            _log.debug(
+                "found cached component", component=ctor, config=config, n_cached=len(self._cache)
+            )
+        return instance

--- a/src/lenskit/pipeline/cache.py
+++ b/src/lenskit/pipeline/cache.py
@@ -22,6 +22,9 @@ _log = get_logger(__name__)
 class PipelineCacheKey:
     ctor_name: str
     ctor: Callable[..., Any] = field(hash=False)
+
+    # this is not hashed because it's a dict, we can just do the slow ==.
+    # there aren't that many of them.
     config: Mapping[str, JsonValue] | None = field(hash=False, default=None)
 
 

--- a/src/lenskit/pipeline/cache.py
+++ b/src/lenskit/pipeline/cache.py
@@ -22,7 +22,7 @@ _log = get_logger(__name__)
 class PipelineCacheKey:
     ctor_name: str
     ctor: Callable[..., Any] = field(hash=False)
-    config: Mapping[str, JsonValue] | None
+    config: Mapping[str, JsonValue] | None = field(hash=False, default=None)
 
 
 class PipelineCache:

--- a/tests/pipeline/test_cache.py
+++ b/tests/pipeline/test_cache.py
@@ -1,0 +1,134 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2025 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+# pyright: strict
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic.dataclasses import dataclass as pydantic_dataclass
+
+from pytest import mark, raises
+
+from lenskit.diagnostics import PipelineError
+from lenskit.pipeline import Component, Pipeline, PipelineBuilder
+from lenskit.pipeline.nodes import ComponentInstanceNode
+
+
+@dataclass
+class PrefixConfigDC:
+    prefix: str = "UNDEFINED"
+
+
+class PrefixConfigM(BaseModel):
+    prefix: str = "UNDEFINED"
+
+
+@pydantic_dataclass
+class PrefixConfigPYDC:
+    prefix: str = "UNDEFINED"
+
+
+class PrefixerDC(Component[str]):
+    config: PrefixConfigDC
+
+    def __call__(self, msg: str) -> str:
+        return self.config.prefix + msg
+
+
+class PrefixerM(Component[str]):
+    config: PrefixConfigM
+
+    def __call__(self, msg: str) -> str:
+        return self.config.prefix + msg
+
+
+class PrefixerPYDC(Component[str]):
+    config: PrefixConfigPYDC
+
+    def __call__(self, msg: str) -> str:
+        return self.config.prefix + msg
+
+
+@dataclass
+class SuffixConfig:
+    suffix: str
+
+
+class Suffixer(Component[str]):
+    config: SuffixConfig
+
+    def __call__(self, msg: str) -> str:
+        return msg + self.config.suffix
+
+
+def lowercase(msg: str) -> str:
+    "Lowercase a string."
+    return msg.lower()
+
+
+@mark.parametrize("prefixer", [PrefixerDC, PrefixerM, PrefixerPYDC])
+def test_config_reuse_only(prefixer: type[Component]):
+    ccls = prefixer.config_class()  # type: ignore
+    assert ccls is not None
+
+    build = PipelineBuilder("test")
+    msg = build.create_input("msg", str)
+    build.add_component("prefix", prefixer, ccls(prefix="hello "), msg=msg)
+
+    p1 = build.build()
+    p2 = build.build()
+
+    n1 = p1.node("prefix")
+    assert isinstance(n1, ComponentInstanceNode)
+    c1 = n1.component
+
+    n2 = p2.node("prefix")
+    assert isinstance(n2, ComponentInstanceNode)
+    c2 = n2.component
+
+    assert c1 is c2
+
+    assert p1.run("prefix", msg="woozle") == "hello woozle"
+
+
+@mark.parametrize("prefixer", [PrefixerDC, PrefixerM, PrefixerPYDC])
+def test_config_reuse_one(prefixer: type[Component]):
+    ccls = prefixer.config_class()  # type: ignore
+    assert ccls is not None
+
+    build = PipelineBuilder("test")
+    msg = build.create_input("msg", str)
+    pm = build.add_component("prefix", prefixer, ccls(prefix="hello "), msg=msg)
+    build.add_component("suffix", Suffixer, {"suffix": " for now"}, msg=pm)
+
+    p1 = build.build()
+
+    build.replace_component("prefix", prefixer, ccls(prefix="goodbye "))
+    p2 = build.build()
+
+    n1 = p1.node("prefix")
+    assert isinstance(n1, ComponentInstanceNode)
+    c1 = n1.component
+
+    n2 = p2.node("prefix")
+    assert isinstance(n2, ComponentInstanceNode)
+    c2 = n2.component
+
+    assert c1 is not c2
+
+    n1 = p1.node("suffix")
+    assert isinstance(n1, ComponentInstanceNode)
+    c1 = n1.component
+
+    n2 = p2.node("suffix")
+    assert isinstance(n2, ComponentInstanceNode)
+    c2 = n2.component
+
+    assert c1 is c2
+
+    assert p1.run("suffix", msg="woozle") == "hello woozle for now"
+    assert p2.run("suffix", msg="woozle") == "goodbye woozle for now"

--- a/tests/pipeline/test_modify_pipeline.py
+++ b/tests/pipeline/test_modify_pipeline.py
@@ -6,12 +6,11 @@
 
 # pyright: strict
 from dataclasses import dataclass
-from typing import Literal
 
-from pytest import mark, raises
+from pytest import raises
 
 from lenskit.diagnostics import PipelineError
-from lenskit.pipeline import Component, Pipeline, PipelineBuilder
+from lenskit.pipeline import Component, PipelineBuilder
 from lenskit.pipeline.nodes import ComponentInstanceNode
 
 


### PR DESCRIPTION
This adds a cache, `PipelineCache`, that can be used by `PipelineBuilder` to reuse component instances between pipelines. This will help with resource use in some application settings. Closes #605.