### PR TITLE
Add StochasticTopNSampler to be correct version of "softmax" sampler

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -36,6 +36,7 @@ them need to be installed separately.
     :recursive:
 
     lenskit.basic
+    lenskit.stochastic
     lenskit.knn
     lenskit.als
     lenskit.sklearn

--- a/docs/guide/rankers.rst
+++ b/docs/guide/rankers.rst
@@ -20,7 +20,7 @@ use this ranker by default.
 Stochastic Ranking
 ~~~~~~~~~~~~~~~~~~
 
-- :class:`lenskit.basic.SoftmaxRanker` computes a randomized Plackett-Luce
+- :class:`lenskit.stochastic.StochasticTopNRanker` computes a randomized
   ranking, where each item is selected with probability proportional to its
   score.
 - :class:`lenskit.basic.RandomSelector` selects items uniformly at random.

--- a/docs/releases/2025.rst
+++ b/docs/releases/2025.rst
@@ -9,6 +9,12 @@ information on how to upgrade your code.
 
 .. _SPEC0: https://scientific-python.org/specs/spec-0000/
 
+.. _2025.3.0:
+
+2025.3.0 (in progress)
+----------------------
+
+-   Replace broken “softmax” sampler with a proper stochastic sampler (:pr:`667`).
 
 .. _2025.2.0:
 

--- a/src/lenskit/basic/random.py
+++ b/src/lenskit/basic/random.py
@@ -4,6 +4,8 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
+import warnings
+
 import numpy as np
 from pydantic import BaseModel
 
@@ -89,6 +91,15 @@ class SoftmaxRanker(Component[ItemList]):
     Vieira`_.  It expects a scored list of input items, and samples ``n`` items,
     with selection probabilities proportional to their scores.
 
+    .. warning::
+
+        This ranker does not actually compute a softmax
+
+    .. deprecated:: 2025.3
+
+        This ranker has been replaced with the :class:`StochasticTopNRanker`. It
+        will be removed in LensKit 2026.
+
     .. note::
 
         Negative scores are clamped to (approximately) zero.
@@ -112,6 +123,9 @@ class SoftmaxRanker(Component[ItemList]):
     def __init__(self, config: RandomConfig | None = None, **kwargs):
         super().__init__(config, **kwargs)
         self._rng_factory = derivable_rng(self.config.rng)
+        warnings.warn(
+            "SoftmaxRanker is deprecated, use StochasticTopNRanker instead", DeprecationWarning, 2
+        )
 
     def __call__(
         self, items: ItemList, query: QueryInput | None = None, n: int | None = None

--- a/src/lenskit/basic/random.py
+++ b/src/lenskit/basic/random.py
@@ -97,8 +97,9 @@ class SoftmaxRanker(Component[ItemList]):
 
     .. deprecated:: 2025.3
 
-        This ranker has been replaced with the :class:`StochasticTopNRanker`. It
-        will be removed in LensKit 2026.
+        This ranker has been replaced with the
+        :class:`lenskit.stochastic.StochasticTopNRanker`. It will be removed in
+        LensKit 2026.
 
     .. note::
 

--- a/src/lenskit/data/items.py
+++ b/src/lenskit/data/items.py
@@ -10,6 +10,7 @@ Primary item-list abstraction.
 
 from __future__ import annotations
 
+import io
 import warnings
 from typing import overload
 
@@ -728,10 +729,20 @@ class ItemList:
     def __str__(self) -> str:
         return f"<ItemList of {self._len} items>"
 
-    def __repr__(self) -> str:
-        fnames = ", ".join(self._fields.keys())
+    def __repr__(self) -> str:  # pragma: nocover
+        out = io.StringIO()
         nf = len(self._fields)
-        return f"<ItemList of {self._len} items with {nf} fields ({fnames})>"
+        print(f"<ItemList of {self._len} items with {nf} fields", "{", file=out)
+
+        if self._numbers is not None:
+            print("  numbers:", self._numbers.numpy(), file=out)
+        if self._ids is not None:
+            print("  ids:", self._ids, file=out)
+        for name, f in self._fields.items():
+            print(f"  {name}:", f.numpy(), file=out)
+        print("}>", end="", file=out)
+
+        return out.getvalue()
 
 
 def _arrow_type(dtype: np.dtype) -> pa.DataType:

--- a/src/lenskit/stochastic/__init__.py
+++ b/src/lenskit/stochastic/__init__.py
@@ -1,0 +1,7 @@
+"""
+Components for generating sochastic outputs in LensKit pipelines.
+"""
+
+from ._ranker import StochasticTopNConfig, StochasticTopNRanker
+
+__all__ = ["StochasticTopNConfig", "StochasticTopNRanker"]

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -35,7 +35,8 @@ class StochasticTopNConfig:
     """
     Scalar multiplier to apply to scores prior to transformation.  This is
     equivalent to the :math:`\\beta` parameter for parameterized softmax
-    transformation.
+    transformation.  Larger values will decrease the entropy of the sampled
+    rankings.
     """
 
 

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -98,6 +98,8 @@ class StochasticTopNRanker(Component[ItemList]):
         if n < 0 or n > N:
             n = N
 
+        # scale the scores — with softmax, this is the equivalent of β.
+        # see: https://en.wikipedia.org/wiki/Softmax_function
         scores = scores[valid_mask] * self.config.scale
         match self.config.transform:
             case "linear":

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -104,6 +104,7 @@ class StochasticTopNRanker(Component[ItemList]):
                 lb = np.min(scores).item()
                 ub = np.max(scores).item()
                 r = ub - lb
+                # scale weights twice to reduce risk of floating-point error
                 weights = scores - lb
                 weights /= r
                 tot = np.sum(weights)
@@ -111,6 +112,7 @@ class StochasticTopNRanker(Component[ItemList]):
                     weights /= tot
                 else:
                     weights = np.ones_like(weights) / len(weights)
+                weights = np.log(np.maximum(weights, 1.0e-6))
             case "softmax":
                 weights = scores - logsumexp(scores)
             case None:

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 import numpy as np
-from scipy.special import logsumexp
+from scipy.special import softmax
 
 from lenskit.data import ItemList
 from lenskit.data.query import QueryInput, RecQuery
@@ -118,7 +118,7 @@ class StochasticTopNRanker(Component[ItemList]):
                 if weights is None:
                     weights = np.ones_like(scores) / len(scores)
             case "softmax":
-                weights = np.exp(scores - logsumexp(scores))
+                weights = softmax(scores)
             case None:
                 weights = scores
 

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -117,14 +117,15 @@ class StochasticTopNRanker(Component[ItemList]):
 
                 if weights is None:
                     weights = np.ones_like(scores) / len(scores)
-                weights = np.maximum(weights, 1.0e-6)
             case "softmax":
                 weights = np.exp(scores - logsumexp(scores))
             case None:
                 weights = scores
 
+        # positive instead of negative, because we take top-N instead of bottom
         keys = np.log(rng.uniform(0, 1, N))
-        keys /= weights
+        # smoooth very small weights to avoid divide-by-zero
+        keys /= np.maximum(weights, np.finfo("f4").smallest_normal)
 
         picked = argtopn(keys, n)
         return ItemList(valid_items[picked], ordered=True)

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -108,9 +108,9 @@ class StochasticTopNRanker(Component[ItemList]):
                 r = ub - lb
                 # scale weights twice to reduce risk of floating-point error
                 weights = scores - lb
-                weights /= r
-                tot = np.sum(weights)
-                if tot > 0:
+                if r > 0:
+                    weights /= r
+                    tot = np.sum(weights)
                     weights /= tot
                 else:
                     weights = np.ones_like(weights) / len(weights)

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -117,16 +117,14 @@ class StochasticTopNRanker(Component[ItemList]):
 
                 if weights is None:
                     weights = np.ones_like(scores) / len(scores)
-                weights = np.log(np.maximum(weights, 1.0e-6))
+                weights = np.maximum(weights, 1.0e-6)
             case "softmax":
-                weights = scores - logsumexp(scores)
+                weights = np.exp(scores - logsumexp(scores))
             case None:
                 weights = scores
 
-        # this is the exponential noise transform from Tim Vieira's post, transformed
-        # into logarithmic space.
         keys = np.log(rng.uniform(0, 1, N))
-        keys /= np.exp(weights)
+        keys /= weights
 
         picked = argtopn(keys, n)
         return ItemList(valid_items[picked], ordered=True)

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -118,6 +118,8 @@ class StochasticTopNRanker(Component[ItemList]):
             case None:
                 weights = scores
 
+        # this is the exponential noise transform from Tim Vieira's post, transformed
+        # into logarithmic space.
         keys = np.log(-np.log(rng.uniform(0, 1, N)))
         keys -= weights
 

--- a/src/lenskit/stochastic/_ranker.py
+++ b/src/lenskit/stochastic/_ranker.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from scipy.special import logsumexp
+
+from lenskit.data import ItemList
+from lenskit.data.query import QueryInput, RecQuery
+from lenskit.pipeline import Component
+from lenskit.random import DerivableSeed, RNGFactory, derivable_rng
+from lenskit.stats import argtopn
+
+
+@dataclass
+class StochasticTopNConfig:
+    """
+    Configuration for :class:`StochasticTopNRanker`.
+    """
+
+    n: int | None = None
+    """
+    The number of items to select. -1 or ``None`` to return all scored items.
+    """
+
+    rng: DerivableSeed = None
+    """
+    Random number generator configuration.
+    """
+
+    transform: Literal["softmax", "linear"] | None = "softmax"
+    """
+    Transformation to apply to scores prior to ranking.
+    """
+    scale: float = 1.0
+    """
+    Scalar multiplier to apply to scores prior to transformation.  This is
+    equivalent to the :math:`\\beta` parameter for parameterized softmax
+    transformation.
+    """
+
+
+class StochasticTopNRanker(Component[ItemList]):
+    """
+    Stochastic top-N ranking with optional weight transformation.
+
+    This uses the exponential sampling method, a more efficient approximation of
+    Plackett-Luce sampling than even the Gumbell trick, as documented by `Tim
+    Vieira`_.  It expects a scored list of input items, and samples ``n`` items,
+    with selection probabilities proportional to their scores.  Scores can be
+    optionally rescaled (inverse temperature) and transformed (e.g. softmax).
+
+    .. note::
+
+        Negative scores are clamped to (approximately) zero.
+
+    .. _`Tim Vieiera`: https://timvieira.github.io/blog/post/2019/09/16/algorithms-for-sampling-without-replacement/
+
+    Stability:
+        Caller
+
+    Args:
+        n:
+            The number of items to return (-1 to return unlimited).
+        rng:
+            The random number generator or specification (see :ref:`rng`).  This
+            class supports derivable RNGs.
+    """
+
+    config: StochasticTopNConfig
+    "Stochastic ranker configuration."
+
+    _rng_factory: RNGFactory
+
+    def __init__(self, config: StochasticTopNConfig | None = None, **kwargs):
+        super().__init__(config, **kwargs)
+        self._rng_factory = derivable_rng(self.config.rng)
+
+    def __call__(
+        self, items: ItemList, query: QueryInput | None = None, n: int | None = None
+    ) -> ItemList:
+        query = RecQuery.create(query)
+        rng = self._rng_factory(query)
+
+        scores = items.scores()
+        if scores is None:
+            raise ValueError("item list must have scores")
+
+        valid_mask = np.isfinite(scores)
+        valid_items = items[valid_mask]
+        N = len(valid_items)
+        if N == 0:
+            return ItemList(item_ids=[], scores=[], ordered=True)
+
+        if n is None or n < 0:
+            n = self.config.n or -1
+
+        if n < 0 or n > N:
+            n = N
+
+        scores = scores[valid_mask] * self.config.scale
+        match self.config.transform:
+            case "linear":
+                lb = np.min(scores).item()
+                ub = np.max(scores).item()
+                r = ub - lb
+                weights = scores - lb
+                weights /= r
+                tot = np.sum(weights)
+                if tot > 0:
+                    weights /= tot
+                else:
+                    weights = np.ones_like(weights) / len(weights)
+            case "softmax":
+                weights = scores - logsumexp(scores)
+            case None:
+                weights = scores
+
+        keys = np.log(-np.log(rng.uniform(0, 1, N)))
+        keys -= weights
+
+        picked = argtopn(keys, n)
+        return ItemList(valid_items[picked], ordered=True)

--- a/tests/basic/test_softmax.py
+++ b/tests/basic/test_softmax.py
@@ -173,4 +173,5 @@ def test_stochasticity(rng):
     pvals = np.array(pvals)
     _log.info("trial p-value statistics: mean=%.3f, median=%.3f", np.mean(pvals), np.median(pvals))
     # do 90% of trials pass the test?
+    # ALERT: this is broken
     assert np.sum(pvals < 0.05) >= 0.9

--- a/tests/stochastic/test_stochastic_ranker.py
+++ b/tests/stochastic/test_stochastic_ranker.py
@@ -1,0 +1,177 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2025 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import logging
+import pickle
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+from scipy.stats import kendalltau, permutation_test
+
+import hypothesis.extra.numpy as nph
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from lenskit.basic import PopScorer
+from lenskit.data.items import ItemList
+from lenskit.stochastic import StochasticTopNRanker
+from lenskit.testing import BasicComponentTests, ScorerTests, scored_lists
+
+_log = logging.getLogger(__name__)
+
+
+class TestSoftmax(BasicComponentTests):
+    component = StochasticTopNRanker
+
+
+@given(scored_lists(), st.sampled_from([None, "linear", "softmax"]))
+def test_unlimited_ranking(items: ItemList, transform):
+    topn = StochasticTopNRanker(transform=transform)
+    ranked = topn(items=items)
+
+    ids = items.ids()
+    scores = items.scores("numpy")
+    assert scores is not None
+    invalid = ~np.isfinite(scores)
+    _log.info("ranking %d items, %d invalid", len(ids), np.sum(invalid))
+
+    assert isinstance(ranked, ItemList)
+    assert len(ranked) <= len(items)
+    assert ranked.ordered
+    # all valid items are included
+    assert len(ranked) == np.sum(~invalid)
+
+    # the set of valid items matches
+    assert set(ids[~invalid]) == set(ranked.ids())
+
+    # the scores match
+    rank_s = ranked.scores("pandas", index="ids")
+    assert rank_s is not None
+    src_s = items.scores("pandas", index="ids")
+    assert src_s is not None
+
+    # make sure the scores were preserved properly
+    rank_s, src_s = rank_s.align(src_s, "left")
+    assert not np.any(np.isnan(src_s))
+    assert np.all(rank_s == src_s)
+
+
+@given(st.integers(min_value=1, max_value=100), scored_lists())
+def test_configured_truncation(n, items: ItemList):
+    topn = StochasticTopNRanker(n=n)
+    ranked = topn(items=items)
+
+    ids = items.ids()
+    scores = items.scores("numpy")
+    assert scores is not None
+    invalid = ~np.isfinite(scores)
+    _log.info("top %d of %d items, %d invalid", n, len(ids), np.sum(invalid))
+
+    val_items = items[~invalid]
+
+    assert isinstance(ranked, ItemList)
+    assert ranked.ordered
+    assert len(ranked) == min(n, len(val_items))
+
+    # the scores match
+    rank_s = ranked.scores("pandas", index="ids")
+    assert rank_s is not None
+    src_s = items.scores("pandas", index="ids")
+    assert src_s is not None
+    src_s = src_s[src_s.notna()]
+
+    # make sure the scores were preserved properly
+    rank_s, src_s = rank_s.align(src_s, "left")
+    assert not np.any(np.isnan(src_s))
+    assert np.all(rank_s == src_s)
+
+
+@given(st.integers(min_value=1, max_value=100), scored_lists())
+def test_runtime_truncation(n, items: ItemList):
+    topn = StochasticTopNRanker(rng="user")
+    ranked = topn(items=items, n=n)
+
+    ids = items.ids()
+    scores = items.scores("numpy")
+    assert scores is not None
+    invalid = ~np.isfinite(scores)
+    _log.info("top %d of %d items, %d invalid", n, len(ids), np.sum(invalid))
+
+    val_items = items[~invalid]
+
+    assert isinstance(ranked, ItemList)
+    assert ranked.ordered
+    assert len(ranked) == min(n, len(val_items))
+
+    # the scores match
+    rank_s = ranked.scores("pandas", index="ids")
+    assert rank_s is not None
+    src_s = items.scores("pandas", index="ids")
+    assert src_s is not None
+    src_s = src_s[src_s.notna()]
+
+    # make sure the scores were preserved properly
+    rank_s, src_s = rank_s.align(src_s, "left")
+    assert not np.any(np.isnan(src_s))
+    assert np.all(rank_s == src_s)
+
+
+def test_stochasticity(rng):
+    "Test that softmax is varying but order-consistent"
+    iids = np.arange(500)
+    scores = rng.normal(size=500)
+    scores = np.square(scores)
+    items = ItemList(item_ids=iids, scores=scores)
+    size = 50
+
+    TRIALS = 100
+    topn = StochasticTopNRanker(n=size)
+
+    _log.info("testing stochastic ranking: top %d of %d", size, len(items))
+
+    ranks = np.full((size, TRIALS), -1, dtype=np.int64)
+    scores = np.full((size, TRIALS), np.nan, dtype=np.float64)
+    for i in range(TRIALS):
+        ranked = topn(items)
+        assert len(ranked) == size
+        ranks[:, i] = ranked.ids()
+        scores[:, i] = ranked.scores()
+
+    id_counts = np.array([len(np.unique(ranks[i, :])) for i in range(size)])
+    try:
+        # at least half the positions should have more than 5 different items show up
+        assert np.sum(id_counts < 5) <= size / 2
+    except AssertionError as e:
+        _log.info("failed test with n=%d, N=%d", size, len(items))
+        _log.info("item counts: %s", id_counts)
+        _log.info("items:\n%s", items.to_df())
+        raise e
+
+    # We want to test that it is usually putting things in the correct order.
+    # We'll do this by computing Kendall's tau between the sampled ranking and
+    # the scores of those items.  We want most of the lists (90%) to have
+    # correlations statistically significnatly greater than zero (items tend to
+    # be in the correct order).
+    pvals = []
+    taus = []
+    for i in range(TRIALS):
+        r_items = ranks[:, i]
+        ranked = r_items >= 0
+        r_items = r_items[ranked]
+
+        rii = items[r_items]
+        trs = size - np.arange(size)
+
+        tau = kendalltau(trs, rii.scores(), alternative="greater")
+        taus.append(tau.statistic)
+        pvals.append(tau.pvalue)
+        _log.info("trial %d: 𝜏=%.3f, p=%.3f", i, tau.statistic, tau.pvalue)
+
+    pvals = np.array(pvals)
+    _log.info("trial p-value statistics: mean=%.3f, median=%.3f", np.mean(pvals), np.median(pvals))
+    # do 90% of trials pass the test?
+    assert np.sum(pvals < 0.05) >= 0.9

--- a/tests/stochastic/test_stochastic_ranker.py
+++ b/tests/stochastic/test_stochastic_ranker.py
@@ -15,6 +15,7 @@ from scipy.stats import kendalltau, permutation_test
 import hypothesis.extra.numpy as nph
 import hypothesis.strategies as st
 from hypothesis import given, settings
+from pytest import mark
 
 from lenskit.basic import PopScorer
 from lenskit.data.items import ItemList
@@ -29,7 +30,8 @@ class TestSoftmax(BasicComponentTests):
     component = StochasticTopNRanker
 
 
-@given(scored_lists(), st.sampled_from([None, "linear", "softmax"]))
+@mark.filterwarnings("error:divide by zero")
+@given(scored_lists(), st.sampled_from(["linear", "softmax"]))
 def test_unlimited_ranking(items: ItemList, transform):
     topn = StochasticTopNRanker(transform=transform)
     ranked = topn(items=items)

--- a/tests/stochastic/test_stochastic_ranker.py
+++ b/tests/stochastic/test_stochastic_ranker.py
@@ -174,4 +174,4 @@ def test_stochasticity(rng):
     pvals = np.array(pvals)
     _log.info("trial p-value statistics: mean=%.3f, median=%.3f", np.mean(pvals), np.median(pvals))
     # do 90% of trials pass the test?
-    assert np.sum(pvals < 0.05) >= 0.9
+    assert np.mean(pvals < 0.05) >= 0.9


### PR DESCRIPTION
This deprecates the broken `SoftmaxSampler` in favor of a `StochasticTopNSampler` with configurable transformation (defaulting to softmax).