### PR TITLE
Add train and recommend commands to the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ cov-reports/
 test-logs/
 htmlcov/
 perf.data*
+*.pkl
+*.zst
+*.gz
+*.bz2
 
 # caches and working directories
 __pycache__/

--- a/pixi.lock
+++ b/pixi.lock
@@ -17463,43 +17463,8 @@ packages:
   timestamp: 1740155620594
 - pypi: .
   name: lenskit
-  version: 2025.2.1.dev23+gf6b5c0cf
-  sha256: 294904cfbd005783fa3b99c6cc6357844d0e7f7a02587fc71a86679eddd2297c
-  requires_dist:
-  - click~=8.1
-  - humanize~=4.2
-  - more-itertools>=9.0
-  - numpy>=1.25
-  - pandas~=2.0
-  - prettytable~=3.14
-  - pyarrow>=15
-  - pydantic~=2.7
-  - pyzmq>=24
-  - rich~=13.5
-  - scipy>=1.11
-  - structlog>=23.2
-  - threadpoolctl>=3.0
-  - torch~=2.4
-  - typing-extensions~=4.12
-  - numba>=0.56 ; extra == 'funksvd'
-  - hpfrec~=0.2.12 ; extra == 'hpf'
-  - implicit>=0.7.2 ; extra == 'implicit'
-  - ipywidgets~=8.0 ; extra == 'notebook'
-  - ray~=2.42 ; extra == 'ray'
-  - scikit-learn~=1.2 ; extra == 'sklearn'
-  - hypothesis>=6.16 ; extra == 'test'
-  - pyprojroot==0.3.* ; extra == 'test'
-  - pytest-benchmark==4.* ; extra == 'test'
-  - pytest-cov>=2.12 ; extra == 'test'
-  - pytest-doctestplus>=1.2.1,<2 ; extra == 'test'
-  - pytest-repeat>=0.9 ; extra == 'test'
-  - pytest>=8.2,<9 ; extra == 'test'
-  requires_python: '>=3.11'
-  editable: true
-- pypi: .
-  name: lenskit
-  version: 2025.2.1.dev80+gf877fd35.d20250321
-  sha256: 294904cfbd005783fa3b99c6cc6357844d0e7f7a02587fc71a86679eddd2297c
+  version: 2025.2.1.dev100+g93d55eed.d20250324
+  sha256: dad7b9c8ae2d2d43577c0f9b8c64340014c3d4b94502256ecdef46fb13c83b0d
   requires_dist:
   - click~=8.1
   - humanize~=4.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -17463,8 +17463,8 @@ packages:
   timestamp: 1740155620594
 - pypi: .
   name: lenskit
-  version: 2025.2.1.dev102+g156c72f3.d20250324
-  sha256: 83f93b4d4418e1850835a91abd262f4a6d95b72fa510ecf5203e6731d29417db
+  version: 2025.2.1.dev106+g93ddb8b1.d20250325
+  sha256: 468680958b8edeb230ebba109be2f99317c0eb972a0b5fdae19951c1f4dc79d3
   requires_dist:
   - click~=8.1
   - humanize~=4.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -17463,8 +17463,8 @@ packages:
   timestamp: 1740155620594
 - pypi: .
   name: lenskit
-  version: 2025.2.1.dev100+g93d55eed.d20250324
-  sha256: dad7b9c8ae2d2d43577c0f9b8c64340014c3d4b94502256ecdef46fb13c83b0d
+  version: 2025.2.1.dev102+g156c72f3.d20250324
+  sha256: 83f93b4d4418e1850835a91abd262f4a6d95b72fa510ecf5203e6731d29417db
   requires_dist:
   - click~=8.1
   - humanize~=4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ lenskit = "lenskit.cli:lenskit"
 lenskit-data = "lenskit.cli.data:data"
 lenskit-doctor = "lenskit.cli.doctor:doctor"
 lenskit-train = "lenskit.cli.train:train"
+lenskit-recommend = "lenskit.cli.recommend:recommend"
 
 # configure build tools
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ lenskit = "lenskit.cli:lenskit"
 [project.entry-points."lenskit.cli.plugins"]
 lenskit-data = "lenskit.cli.data:data"
 lenskit-doctor = "lenskit.cli.doctor:doctor"
+lenskit-train = "lenskit.cli.train:train"
 
 # configure build tools
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ documentation = "https://lkpy.lenskit.org"
 source = "https://github.com/lenskit/lkpy"
 
 [project.scripts]
-lenskit = "lenskit.cli:lenskit"
+lenskit = "lenskit.cli:main"
 
 [project.entry-points."lenskit.cli.plugins"]
 lenskit-data = "lenskit.cli.data:data"

--- a/src/lenskit/batch/_runner.py
+++ b/src/lenskit/batch/_runner.py
@@ -170,8 +170,8 @@ class BatchPipelineRunner:
                 progress.update()
             timer.stop()
 
-            rate = timer.elapsed() / n_users
-            log.info("finished running in %s (%.1fms/user)", timer, rate)
+            rate = timer.elapsed() / n_users * 1000
+            log.info("finished running in %s (%.1fms/request)", timer, rate)
 
         return results
 

--- a/src/lenskit/batch/_runner.py
+++ b/src/lenskit/batch/_runner.py
@@ -170,8 +170,8 @@ class BatchPipelineRunner:
                 progress.update()
             timer.stop()
 
-            rate = timer.elapsed() / n_users * 1000
-            log.info("finished running in %s (%.1fms/request)", timer, rate)
+            rate_ms = timer.elapsed() / n_users * 1000
+            log.info("finished running in %s", timer, time_per_query="{:.1f}ms".format(rate_ms))
 
         return results
 

--- a/src/lenskit/cli/recommend.py
+++ b/src/lenskit/cli/recommend.py
@@ -12,7 +12,7 @@ import click
 
 import lenskit.operations as ops
 from lenskit.data import Dataset
-from lenskit.logging import get_logger
+from lenskit.logging import Stopwatch, get_logger
 from lenskit.random import random_generator
 
 _log = get_logger(__name__)
@@ -65,11 +65,17 @@ def recommend(
         log.info("selecting random users", count=random_users)
         users = rng.choice(data.users.ids(), random_users)  # type: ignore
 
+    timer = Stopwatch(start=False)
     for user in users:
         ulog = log.bind(user=user)
         ulog.debug("generating single-user recommendations")
-        recs = ops.recommend(pipe, user, list_length)
-        ulog.info("recommended for user", length=len(recs))
+        with timer.measure(accumulate=True):
+            recs = ops.recommend(pipe, user, list_length)
+        ulog.info(
+            "recommended for user",
+            length=len(recs),
+            time="{:.1f}ms".format(timer.elapsed(accumulated=False) * 1000),
+        )
 
         titles = None
         if data is not None:
@@ -82,3 +88,10 @@ def recommend(
                 print("item {}: {}".format(item, titles.loc[item]))
             else:
                 print("item {}".format(item))
+
+    log.info(
+        "finished recommending for %d users in %s (%.1fms/u)",
+        len(users),
+        timer,
+        timer.elapsed() * 1000 / len(users),
+    )

--- a/src/lenskit/cli/recommend.py
+++ b/src/lenskit/cli/recommend.py
@@ -1,0 +1,70 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2025 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import pickle
+from pathlib import Path
+
+import click
+
+import lenskit.operations as ops
+from lenskit.data import Dataset
+from lenskit.logging import get_logger
+
+_log = get_logger(__name__)
+
+
+@click.command("recommend")
+@click.option(
+    "-o",
+    "--output",
+    "out_file",
+    metavar="FILE",
+    help="Output file for recommendations.",
+)
+@click.option("-n", "--list-length", type=int, help="Recommendation list length.")
+@click.option("-d", "--dataset", metavar="DATA", type=Path, help="Use dataset DATA.")
+@click.argument("PIPE_FILE", type=Path)
+@click.argument("USERS", nargs=-1)
+def recommend(
+    out_file: Path,
+    list_length: int | None,
+    dataset: Path | None,
+    pipe_file: Path,
+    users: list,
+):
+    """
+    Generate recommendations from a serialized recommendation pipeline.
+    """
+    _log.warning("the recommend CLI is experimental and may change without notice")
+
+    _log.info("loading pipeline", file=str(pipe_file))
+    with open(pipe_file, "rb") as pf:
+        pipe = pickle.load(pf)
+    log = _log.bind(name=pipe.name)
+
+    if dataset is not None:
+        data = Dataset.load(dataset)
+        log = log.bind(data=data.name)
+    else:
+        data = None
+
+    for user in users:
+        ulog = log.bind(user=user)
+        ulog.debug("generating single-user recommendations")
+        recs = ops.recommend(pipe, user, list_length)
+        ulog.info("recommended for user", length=len(recs))
+
+        titles = None
+        if data is not None:
+            items = data.entities("item")
+            if "title" in items.attributes:
+                titles = items.select(ids=recs.ids()).attribute("title").pandas()
+
+        for item in recs.ids():
+            if titles is not None:
+                print("item {}: {}".format(item, titles.loc[item]))
+            else:
+                print("item {}".format(item))

--- a/src/lenskit/cli/recommend.py
+++ b/src/lenskit/cli/recommend.py
@@ -26,10 +26,12 @@ _log = get_logger(__name__)
 )
 @click.option("-n", "--list-length", type=int, help="Recommendation list length.")
 @click.option("-d", "--dataset", metavar="DATA", type=Path, help="Use dataset DATA.")
+@click.option("-u", "--users-file", type=Path, metavar="FILE", help="Load list of users from FILE.")
 @click.argument("PIPE_FILE", type=Path)
 @click.argument("USERS", nargs=-1)
 def recommend(
     out_file: Path,
+    users_file: Path,
     list_length: int | None,
     dataset: Path | None,
     pipe_file: Path,

--- a/src/lenskit/cli/train.py
+++ b/src/lenskit/cli/train.py
@@ -27,13 +27,13 @@ _log = get_logger(__name__)
     default="model.pkl",
     help="Output file for trained model.",
 )
-@click.option("-n", "--name", help="Name of the recommendation pipeline.")
+@click.option("--name", help="Name of the recommendation pipeline.")
 @click.option(
     "--rating-predictor",
     is_flag=True,
     help="Include rating prediction in the pipeline capabilities.",
 )
-@click.option("-N", "--list-length", type=int, help="Default list length for pipeline ranker.")
+@click.option("-n", "--list-length", type=int, help="Default list length for pipeline ranker.")
 @click.argument("dataset", metavar="DATA", type=Path)
 def train(
     scorer_class: str | None,
@@ -43,6 +43,9 @@ def train(
     rating_predictor: bool,
     dataset: Path,
 ):
+    """
+    Train a recommendation pipeline and serialize it to disk.
+    """
     _log.warning("the training CLI is experimental and may change without notice")
 
     if scorer_class is not None:

--- a/src/lenskit/cli/train.py
+++ b/src/lenskit/cli/train.py
@@ -1,0 +1,66 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University
+# Copyright (C) 2023-2025 Drexel University
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import pickle
+from pathlib import Path
+
+import click
+
+from lenskit.data import Dataset
+from lenskit.logging import get_logger
+from lenskit.pipeline import Component, topn_pipeline
+from lenskit.pipeline.types import parse_type_string
+
+_log = get_logger(__name__)
+
+
+@click.command("train")
+@click.option("-C", "--scorer-class", metavar="CLS", help="Train a model with scorer CLS.")
+@click.option(
+    "-o",
+    "--output",
+    "out_file",
+    metavar="FILE",
+    default="model.pkl",
+    help="Output file for trained model.",
+)
+@click.option("-n", "--name", help="Name of the recommendation pipeline.")
+@click.option(
+    "--rating-predictor",
+    is_flag=True,
+    help="Include rating prediction in the pipeline capabilities.",
+)
+@click.option("-N", "--list-length", type=int, help="Default list length for pipeline ranker.")
+@click.argument("dataset", metavar="DATA", type=Path)
+def train(
+    scorer_class: str | None,
+    out_file: Path,
+    name: str | None,
+    list_length: int | None,
+    rating_predictor: bool,
+    dataset: Path,
+):
+    _log.warning("the training CLI is experimental and may change without notice")
+
+    if scorer_class is not None:
+        scorer = parse_type_string(scorer_class)
+        if name is None:
+            name = scorer.__name__
+        assert issubclass(scorer, Component)
+        pipe = topn_pipeline(scorer, predicts_ratings=rating_predictor, n=list_length, name=name)
+    else:
+        _log.error("no scorer specified")
+        raise SystemExit(5)
+
+    data = Dataset.load(dataset)
+    log = _log.bind(data=data.name, name=name)
+
+    log.info("training model")
+    pipe.train(data)
+
+    _log.info("saving trained model", file=out_file)
+    with open(out_file, "wb") as pf:
+        pickle.dump(pipe, pf)

--- a/src/lenskit/data/entities.py
+++ b/src/lenskit/data/entities.py
@@ -69,7 +69,7 @@ class EntitySet:
     @property
     def attributes(self) -> list[str]:
         """
-        Get the attribute names for this enrtity class.
+        Get the attribute names for this entity class.
         """
         return list(self.schema.attributes.keys())
 

--- a/src/lenskit/data/items.py
+++ b/src/lenskit/data/items.py
@@ -735,11 +735,11 @@ class ItemList:
         print(f"<ItemList of {self._len} items with {nf} fields", "{", file=out)
 
         if self._numbers is not None:
-            print("  numbers:", self._numbers.numpy(), file=out)
+            print("  numbers:", np.array2string(self._numbers.numpy(), threshold=10), file=out)
         if self._ids is not None:
-            print("  ids:", self._ids, file=out)
+            print("  ids:", np.array2string(self._ids, threshold=10), file=out)
         for name, f in self._fields.items():
-            print(f"  {name}:", f.numpy(), file=out)
+            print(f"  {name}:", np.array2string(f.numpy(), threshold=10), file=out)
         print("}>", end="", file=out)
 
         return out.getvalue()

--- a/src/lenskit/logging/config.py
+++ b/src/lenskit/logging/config.py
@@ -21,7 +21,7 @@ from typing import Literal, TypeAlias
 import structlog
 
 from ._console import ConsoleHandler, console, setup_console
-from .processors import format_timestamp, log_warning, remove_internal
+from .processors import format_timestamp, log_warning, record_logged_error, remove_internal
 from .progress import set_progress_impl
 from .tracing import lenskit_filtering_logger
 
@@ -187,6 +187,7 @@ class LoggingConfig:  # pragma: nocover
         )
         formatter = structlog.stdlib.ProcessorFormatter(
             processors=[
+                record_logged_error,
                 remove_internal,
                 format_timestamp,
                 proc_fmt,

--- a/src/lenskit/logging/stopwatch.py
+++ b/src/lenskit/logging/stopwatch.py
@@ -8,7 +8,10 @@
 Timing support
 """
 
+from __future__ import annotations
+
 import time
+from contextlib import contextmanager
 
 
 class Stopwatch:
@@ -16,8 +19,9 @@ class Stopwatch:
     Timer class for recording elapsed wall time in operations.
     """
 
-    start_time = None
-    stop_time = None
+    acc_time: float | None = None
+    start_time: float | None = None
+    stop_time: float | None = None
 
     def __init__(self, start=True):
         if start:
@@ -28,12 +32,38 @@ class Stopwatch:
 
     def stop(self):
         self.stop_time = time.perf_counter()
+        if self.start_time is not None and self.acc_time is not None:
+            self.acc_time += self.stop_time - self.start_time
 
-    def elapsed(self) -> float:
+    def elapsed(self, *, accumulated=True) -> float:
+        """
+        Get the elapsed time.
+        """
         assert self.start_time is not None
         stop = self.stop_time or time.perf_counter()
 
-        return stop - self.start_time
+        t = stop - self.start_time
+        if accumulated and self.acc_time is not None:
+            t += self.acc_time
+
+        return t
+
+    @contextmanager
+    def measure(self, accumulate: bool = False):
+        """
+        Context manager to measure an item, optionally accumulating its time.
+        """
+        if accumulate:
+            if self.acc_time is None:
+                self.acc_time = 0.0
+        else:
+            self.acc_time = None
+
+        self.start()
+        try:
+            yield self
+        finally:
+            self.stop()
 
     def __str__(self):
         elapsed = self.elapsed()


### PR DESCRIPTION
This adds new `train` and `recommend` commands to the LensKit CLI, to enable saving pipelines and recommending from them.