### PR TITLE
Improve NumPy -> Torch conversions for read-only data

### DIFF
--- a/src/lenskit/als/_explicit.py
+++ b/src/lenskit/als/_explicit.py
@@ -15,6 +15,7 @@ from lenskit.data import Dataset, ItemList
 from lenskit.logging.progress import item_progress_handle, pbh_update
 from lenskit.math.solve import solve_cholesky
 from lenskit.parallel.chunking import WorkChunks
+from lenskit.torch import safe_tensor
 
 from ._common import ALSBase, ALSConfig, TrainContext, TrainingData
 
@@ -82,7 +83,7 @@ class BiasedMFScorer(ALSBase):
         assert ratings is not None
 
         biases, u_bias = self.bias_.compute_for_items(items, None, items)
-        biases = torch.from_numpy(biases)
+        biases = safe_tensor(biases)
         ratings = ratings - biases
 
         ri_val = ratings[mask].to(torch.float64)

--- a/src/lenskit/basic/bias.py
+++ b/src/lenskit/basic/bias.py
@@ -22,6 +22,7 @@ from typing_extensions import Self, TypeAlias, overload
 
 from lenskit.data import ID, Dataset, ItemList, QueryInput, RecQuery, Vocabulary
 from lenskit.pipeline.components import Component
+from lenskit.torch import safe_tensor
 from lenskit.training import Trainable, TrainingOptions
 
 _logger = logging.getLogger(__name__)
@@ -249,9 +250,9 @@ class BiasModel:
         inos = indices[1, :]
         values = matrix.values() - self.global_bias
         if self.item_biases is not None:
-            values.subtract_(torch.from_numpy(self.item_biases)[inos])
+            values.subtract_(safe_tensor(self.item_biases)[inos])
         if self.user_biases is not None:
-            values.subtract_(torch.from_numpy(self.user_biases)[unos])
+            values.subtract_(safe_tensor(self.user_biases)[unos])
         return torch.sparse_coo_tensor(indices, values, size=matrix.size())
 
 

--- a/src/lenskit/data/attributes.py
+++ b/src/lenskit/data/attributes.py
@@ -22,6 +22,8 @@ from numpy.typing import NDArray
 from scipy.sparse import csr_array
 from typing_extensions import Any
 
+from lenskit.torch import safe_tensor
+
 from .schema import AttrLayout, ColumnSpec
 from .types import IDArray
 from .vocab import Vocabulary
@@ -167,7 +169,7 @@ class AttributeSet:
         return self.numpy()
 
     def torch(self) -> torch.Tensor:
-        return torch.from_numpy(self.numpy())
+        return safe_tensor(self.numpy())
 
     def drop_null(self):
         """

--- a/src/lenskit/data/mtarray.py
+++ b/src/lenskit/data/mtarray.py
@@ -17,6 +17,8 @@ import torch
 from numpy.typing import ArrayLike, NDArray
 from typing_extensions import Generic, Literal, LiteralString, Sequence, TypeVar, overload
 
+from lenskit.torch import safe_tensor
+
 NPT = TypeVar("NPT", bound=np.generic)
 
 
@@ -95,10 +97,7 @@ class MTArray(Generic[NPT]):
             if torch.is_tensor(self._unknown):
                 self._torch = self._unknown
             else:
-                # Make sure we have a writeable array for Torch. Client code
-                # still shouldn't write to it.
-                arr = np.require(self.numpy(), requirements="W")
-                return torch.tensor(arr)
+                self._torch = safe_tensor(self._unknown)
 
         if device:
             return self._torch.to(device)

--- a/src/lenskit/data/relationships.py
+++ b/src/lenskit/data/relationships.py
@@ -364,7 +364,7 @@ class MatrixRelationshipSet(RelationshipSet):
         nnz = self._table.num_rows
 
         colinds = self._table.column(num_col_name(self.col_type)).to_numpy()
-        colinds = torch.tensor(colinds)
+        colinds = torch.tensor(np.require(colinds, requirements="W"))
         if attribute is None or (attribute == "count" and "count" not in self._table.column_names):
             values = torch.ones(nnz, dtype=torch.float32)
         elif pa.types.is_timestamp(self._table.field(attribute).type):

--- a/src/lenskit/flexmf/_base.py
+++ b/src/lenskit/flexmf/_base.py
@@ -18,6 +18,7 @@ from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
 from lenskit.logging import get_logger, item_progress
 from lenskit.parallel.config import ensure_parallel_init
 from lenskit.pipeline import Component
+from lenskit.torch import safe_tensor
 from lenskit.training import IterativeTraining, TrainingOptions
 
 from ._model import FlexMFModel
@@ -254,7 +255,7 @@ class FlexMFScorerBase(IterativeTraining, Component):
         # ones we know, and remember which item IDs those are
         scorable_mask = i_cols >= 0
         i_cols = i_cols[scorable_mask]
-        i_tensor = torch.from_numpy(i_cols)
+        i_tensor = safe_tensor(i_cols)
         i_tensor = i_tensor.to(device)
 
         # initialize output score array, fill with missing

--- a/src/lenskit/knn/user.py
+++ b/src/lenskit/knn/user.py
@@ -197,8 +197,9 @@ class UserKNNScorer(Component[ItemList], Trainable):
 
         assert not torch.any(torch.isnan(kn_sims))
 
-        iidxs = items.numbers(vocabulary=self.items_, missing="negative")
-        iidxs = torch.from_numpy(iidxs).to(torch.int64)
+        iidxs = items.numbers(format="torch", vocabulary=self.items_, missing="negative").to(
+            torch.int64
+        )
 
         ki_mask = iidxs >= 0
         usable_iidxs = iidxs[ki_mask]

--- a/src/lenskit/math/sparse.py
+++ b/src/lenskit/math/sparse.py
@@ -17,6 +17,8 @@ from typing import Literal, overload
 import scipy.sparse as sps
 import torch
 
+from lenskit.torch import safe_tensor
+
 _log = logging.getLogger(__name__)
 
 
@@ -79,10 +81,13 @@ def torch_sparse_from_scipy(
 ) -> torch.Tensor:
     """
     Convert a SciPy :class:`sps.coo_array` into a torch sparse tensor.
+
+    Stability:
+        Internal
     """
-    ris = torch.from_numpy(M.row)
-    cis = torch.from_numpy(M.col)
-    vs = torch.from_numpy(M.data)
+    ris = safe_tensor(M.row)
+    cis = safe_tensor(M.col)
+    vs = safe_tensor(M.data)
     indices = torch.stack([ris, cis])
     assert indices.shape == (2, M.nnz)
     T = torch.sparse_coo_tensor(indices, vs, size=M.shape)

--- a/src/lenskit/torch.py
+++ b/src/lenskit/torch.py
@@ -10,6 +10,7 @@ PyTorch utility functions.
 
 import functools
 
+import numpy as np
 import torch
 
 
@@ -43,3 +44,16 @@ def sparse_row(mat: torch.Tensor, row: int) -> torch.Tensor:
     return torch.sparse_coo_tensor(
         indices=cs[sp:ep].reshape(1, -1), values=vs[sp:ep], size=mat.shape[1:]
     )
+
+
+def safe_tensor(array) -> torch.Tensor:
+    """
+    Safely convert an array into a NumPy tensor.  This includes copying it to
+    writable memory if necessary.
+    """
+    if torch.is_tensor(array):
+        return array
+
+    arr = np.asarray(array)
+    arr = np.require(arr, requirements="W")
+    return torch.from_numpy(arr)

--- a/tests/utils/test_matrix_rows.py
+++ b/tests/utils/test_matrix_rows.py
@@ -34,8 +34,9 @@ def test_sparse_mean_center(tensor: torch.Tensor):
 
     np.add.at(counts, rows, 1)
     np.add.at(sums, rows, coo.values().numpy())
-    tgt_means = sums / counts
-    tgt_means = np.nan_to_num(tgt_means, nan=0)
+
+    tgt_means = np.zeros(len(sums))
+    np.divide(sums, counts, out=tgt_means, where=counts > 0)
 
     nt, means = normalize_sparse_rows(tensor, "center")
     assert means.shape == torch.Size([nr])

--- a/tests/utils/test_torch_util.py
+++ b/tests/utils/test_torch_util.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pyarrow as pa
+import scipy.sparse as sps
+import torch
+
+import hypothesis.extra.numpy as nph
+import hypothesis.strategies as st
+from hypothesis import HealthCheck, given, note, settings
+from pytest import approx, mark, skip
+
+from lenskit.torch import safe_tensor
+
+
+@given(
+    nph.arrays(
+        st.one_of(nph.floating_dtypes(endianness="="), nph.integer_dtypes(endianness="=")),
+        nph.array_shapes(max_dims=3),
+    )
+)
+def test_safe_tensor_from_numpy(arr):
+    t = safe_tensor(arr)
+    assert torch.is_tensor(t)
+
+    assert t.shape == arr.shape
+
+
+@given(
+    nph.arrays(
+        st.one_of(nph.floating_dtypes(endianness="="), nph.integer_dtypes(endianness="=")),
+        nph.array_shapes(max_dims=1),
+    )
+)
+def test_safe_tensor_from_arrow(arr):
+    arrow = pa.array(arr)
+    t = safe_tensor(arrow)
+    assert torch.is_tensor(t)
+
+    assert t.shape == arr.shape


### PR DESCRIPTION
Torch does not support read-only tensors, which can arise in some cases when converting from Arrow or deserializing in Ray.

This PR introduces the `safe_tensor` function to convert an array to a tensor, and uses it throughout in order to reduce risk of errors from non-modifiable tensors.