### PR TITLE
Add lenskit.state module and move the ParameterContainer interface

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -13,6 +13,7 @@ Core Abstractions
     lenskit.diagnostics
     lenskit.operations
     lenskit.training
+    lenskit.state
 
 .. toctree::
     :caption: Core
@@ -23,6 +24,7 @@ Core Abstractions
     operations
     diagnostics
     training
+    state
 
 Components and Models
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/api/state.rst
+++ b/docs/api/state.rst
@@ -1,0 +1,19 @@
+Model State
+===========
+
+.. py:module:: lenskit.state
+
+The :mod:`lenskit.state` module provides support code for managing the state of
+components built on machine learning models, such as extrating learned parameters
+and saving model checkpoints.
+
+These features are modeled after the PyTorch ``state_dict`` design: components
+with state should implement :class:`ParameterContainer` and expose their state
+as dictionaries.  This state can then be saved and loaded, including in
+pickle-safe formats such as ``zarr`` or ``safetensors``.
+
+.. autosummary::
+    :toctree: .
+    :nosignatures:
+
+    ~lenskit.state.ParameterContainer

--- a/src/lenskit/data/items.py
+++ b/src/lenskit/data/items.py
@@ -447,7 +447,7 @@ class ItemList:
             RuntimeError: if the item list was not created with numbers or a
             :class:`Vocabulary`.
         """
-        if vocabulary is not None and vocabulary is not self._vocab:
+        if vocabulary is not None and vocabulary != self._vocab:
             # we need to translate vocabulary
             ids = self.ids()
             mta = MTArray(vocabulary.numbers(ids, missing=missing))

--- a/src/lenskit/data/vocab.py
+++ b/src/lenskit/data/vocab.py
@@ -90,9 +90,11 @@ class Vocabulary:
 
         arrow = pa.array(keys.values)
         # since we just made this array, we can assume the buffer is fully used
-        buf = arrow.buffers()[2]
-        assert buf is not None
-        self._hash = md5(memoryview(buf)).hexdigest()
+        h = md5()
+        for buf in arrow.buffers():
+            if buf is not None:
+                h.update(memoryview(buf))
+        self._hash = h.hexdigest()
 
     @property
     def index(self) -> pd.Index:
@@ -178,9 +180,7 @@ class Vocabulary:
 
     def __ne__(self, other: Vocabulary) -> bool:
         return (
-            not isinstance(other, Vocabulary)
-            and self is not other
-            and self._hash is not other._hash
+            not isinstance(other, Vocabulary) or self is not other or self._hash is not other._hash
         )
 
     def __contains__(self, key: object) -> bool:

--- a/src/lenskit/pipeline/components.py
+++ b/src/lenskit/pipeline/components.py
@@ -67,44 +67,6 @@ class ComponentConstructor(Protocol, Generic[CFG, COut]):
     def validate_config(self, data: Any = None) -> CFG | None: ...
 
 
-@runtime_checkable
-class ParameterContainer(Protocol):  # pragma: nocover
-    """
-    Protocol for components with learned parameters to enable saving, reloading,
-    checkpointing, etc.
-
-    Components that learn parameters from training data should implement this
-    protocol, and also work when pickled or pickled.  Pickling is sometimes used
-    for convenience, but parameter / state dictionaries allow serializing wtih
-    tools like ``safetensors`` or ``zarr``.
-
-    Stability:
-        Experimental
-    """
-
-    def get_parameters(self) -> dict[str, object]:
-        """
-        Get the component's parameters.
-
-        Returns:
-            The model's parameters, as a dictionary from names to parameter data
-            (usually arrays, tensors, etc.).
-        """
-        raise NotImplementedError()
-
-    def load_parameters(self, params: dict[str, object]) -> None:
-        """
-        Reload model state from parameters saved via :meth:`get_parameters`.
-
-        Args:
-            params:
-                The model parameters, as a dictionary from names to parameter
-                data (arrays, tensors, etc.), as returned from
-                :meth:`get_parameters`.
-        """
-        raise NotImplementedError()
-
-
 class Component(ABC, Generic[COut, CArgs]):
     """
     Base class for pipeline component objects.  Any component that is not just a

--- a/src/lenskit/pipeline/components.py
+++ b/src/lenskit/pipeline/components.py
@@ -70,31 +70,21 @@ class ComponentConstructor(Protocol, Generic[CFG, COut]):
 @runtime_checkable
 class ParameterContainer(Protocol):  # pragma: nocover
     """
-    Future protocol for components with learned parameters.
+    Protocol for components with learned parameters to enable saving, reloading,
+    checkpointing, etc.
 
-    .. important::
-
-        This protocol is not yet used.
+    Components that learn parameters from training data should implement this
+    protocol, and also work when pickled or pickled.  Pickling is sometimes used
+    for convenience, but parameter / state dictionaries allow serializing wtih
+    tools like ``safetensors`` or ``zarr``.
 
     Stability:
         Experimental
     """
 
-    def get_params(self) -> dict[str, object]:
+    def get_parameters(self) -> dict[str, object]:
         """
-        Protocol for components with parameters that can be extracted, saved,
-        and re-loaded.
-
-        LensKit components that learn parameters from training data should both
-        implement this method and work when pickled and unpickled.  Pickling is
-        sometimes used for convenience, but parameter / state dictionaries allow
-        serializing wtih tools like ``safetensors``.
-
-        Args:
-            include_caches:
-                Whether the parameter dictionary should include ephemeral
-                caching structures only used for runtime performance
-                optimizations.
+        Get the component's parameters.
 
         Returns:
             The model's parameters, as a dictionary from names to parameter data
@@ -102,9 +92,15 @@ class ParameterContainer(Protocol):  # pragma: nocover
         """
         raise NotImplementedError()
 
-    def load_params(self, params: dict[str, object]) -> None:
+    def load_parameters(self, params: dict[str, object]) -> None:
         """
-        Reload model state from parameters saved via :meth:`get_params`.
+        Reload model state from parameters saved via :meth:`get_parameters`.
+
+        Args:
+            params:
+                The model parameters, as a dictionary from names to parameter
+                data (arrays, tensors, etc.), as returned from
+                :meth:`get_parameters`.
         """
         raise NotImplementedError()
 

--- a/src/lenskit/state/__init__.py
+++ b/src/lenskit/state/__init__.py
@@ -1,0 +1,13 @@
+"""
+Support code for managing model state.
+
+Many LensKit components are built on machine learning models of various forms.
+While :mod:`lenskit.training` provides support for training those models,
+this module provides support for managing their learned state and weights.
+"""
+
+from ._container import ParameterContainer
+
+__all__ = [
+    "ParameterContainer",
+]

--- a/src/lenskit/state/_container.py
+++ b/src/lenskit/state/_container.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ParameterContainer(Protocol):  # pragma: nocover
+    """
+    Protocol for components with learned parameters to enable saving, reloading,
+    checkpointing, etc.
+
+    Components that learn parameters from training data should implement this
+    protocol, and also work when pickled or pickled.  Pickling is sometimes used
+    for convenience, but parameter / state dictionaries allow serializing wtih
+    tools like ``safetensors`` or ``zarr``.
+
+    Initializing a component with the same configuration as a trained component,
+    and loading its parameters with :meth:`load_parameters`, should result in a
+    component that is functionally equivalent to the original trained component.
+
+    Stability:
+        Experimental
+    """
+
+    def get_parameters(self) -> Mapping[str, object]:
+        """
+        Get the component's parameters.
+
+        Returns:
+            The model's parameters, as a dictionary from names to parameter data
+            (usually arrays, tensors, etc.).
+        """
+        raise NotImplementedError()
+
+    def load_parameters(self, params: Mapping[str, object]) -> None:
+        """
+        Reload model state from parameters saved via :meth:`get_parameters`.
+
+        Args:
+            params:
+                The model parameters, as a dictionary from names to parameter
+                data (arrays, tensors, etc.), as returned from
+                :meth:`get_parameters`.
+        """
+        raise NotImplementedError()

--- a/src/lenskit/training.py
+++ b/src/lenskit/training.py
@@ -27,48 +27,6 @@ from lenskit.random import RNGInput, random_generator
 _log = get_logger(__name__)
 
 
-@runtime_checkable
-class ParameterContainer(Protocol):  # pragma: nocover
-    """
-    Protocol for components with learned parameters to enable saving, reloading,
-    checkpointing, etc.
-
-    Components that learn parameters from training data should implement this
-    protocol, and also work when pickled or pickled.  Pickling is sometimes used
-    for convenience, but parameter / state dictionaries allow serializing wtih
-    tools like ``safetensors`` or ``zarr``.
-
-    Initializing a component with the same configuration as a trained component,
-    and loading its parameters with :meth:`load_parameters`, should result in a
-    component that is functionally equivalent to the original trained component.
-
-    Stability:
-        Experimental
-    """
-
-    def get_parameters(self) -> dict[str, object]:
-        """
-        Get the component's parameters.
-
-        Returns:
-            The model's parameters, as a dictionary from names to parameter data
-            (usually arrays, tensors, etc.).
-        """
-        raise NotImplementedError()
-
-    def load_parameters(self, params: dict[str, object]) -> None:
-        """
-        Reload model state from parameters saved via :meth:`get_parameters`.
-
-        Args:
-            params:
-                The model parameters, as a dictionary from names to parameter
-                data (arrays, tensors, etc.), as returned from
-                :meth:`get_parameters`.
-        """
-        raise NotImplementedError()
-
-
 @dataclass(frozen=True)
 class TrainingOptions:
     """
@@ -142,12 +100,12 @@ class Trainable(Protocol):  # pragma: nocover
     trained.  This protocol only captures the concept of trainability; most
     trainable components should have other properties and behaviors as well:
 
-    -   They are usually components (:class:`~lenskit.pipeline.Component`),
-        with an appropriate ``__call__`` method.
+    -   They are usually components (:class:`~lenskit.pipeline.Component`), with
+        an appropriate ``__call__`` method.
     -   They should be pickleable.
-    -   They should also usually implement :class:`ParameterContainer`, to
-        allow the learned parameters to be serialized and deserialized
-        without pickling.
+    -   They should also usually implement
+        :class:`~lenskit.state.ParameterContainer`, to allow the learned
+        parameters to be serialized and deserialized without pickling.
 
     Stability:
         Full


### PR DESCRIPTION
This adds a new module, `lenskit.state`, and moves `ParameterContainer` into it as a location for holding various aspects of model state and, eventually, saving and loading that state.