### PR TITLE
Build with setuptools instead of hatch

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
-prune envs
-prune .github
-prune .vscode
-exclude .*.yml
-exclude .*.yaml
+graft src
+graft tests
+graft data/ml-latest-small
+prune .*
+exclude .*
+global-exclude *.py[cod]

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -26,8 +26,8 @@ outputs:
       host:
         - python =${{ python_min }}
         - pip
-        - hatchling =1
-        - hatch-vcs =0.4
+        - setuptools >=70
+        - setuptools-scm >=8
       run:
         - python >=${{ python_min }}
         - typing-extensions >=4.12,<5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling ~=1.0", "hatch-vcs ~=0.4.0"]
-build-backend = "hatchling.build"
+requires = ["setuptools >=70", "setuptools-scm >=8"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "lenskit"
@@ -67,8 +67,8 @@ demo = [
 ]
 reporting = ["coverage >=5"]
 dev = [
-  "hatchling ~=1.24",
-  "hatch-vcs ~=0.4.0",
+  "setuptools >=70",
+  "setuptools-scm >=8",
   "build ~=1.0",
   "unbeheader ~=1.3",
   "ruff >=0.2",
@@ -112,21 +112,8 @@ lenskit-train = "lenskit.cli.train:train"
 lenskit-recommend = "lenskit.cli.recommend:recommend"
 
 # configure build tools
-[tool.hatch.metadata]
-allow-direct-references = true
-
-[tool.hatch.build.targets.sdist]
-include = ["src/lenskit", "LICENSE.md", "README.md"]
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/lenskit"]
-
-[tool.hatch.version]
-source = "vcs"
-raw-options = { version_scheme = "guess-next-dev" }
-
-[tool.hatch.build.hooks.vcs]
-version-file = "src/lenskit/_version.py"
+[tool.setuptools_scm]
+version_file = "src/lenskit/_version.py"
 
 # configure UV sources
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -716,34 +716,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hatch-vcs"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hatchling" },
-    { name = "setuptools-scm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/c9/54bb4fa27b4e4a014ef3bb17710cdf692b3aa2cbc7953da885f1bf7e06ea/hatch_vcs-0.4.0.tar.gz", hash = "sha256:093810748fe01db0d451fabcf2c1ac2688caefd232d4ede967090b1c1b07d9f7", size = 10917 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/0f/6cbd9976160bc334add63bc2e7a58b1433a31b34b7cda6c5de6dd983d9a7/hatch_vcs-0.4.0-py3-none-any.whl", hash = "sha256:b8a2b6bee54cf6f9fc93762db73890017ae59c9081d1038a41f16235ceaf8b2c", size = 8412 },
-]
-
-[[package]]
-name = "hatchling"
-version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pluggy" },
-    { name = "trove-classifiers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794 },
-]
-
-[[package]]
 name = "hpfrec"
 version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
@@ -1396,8 +1368,6 @@ demo = [
 dev = [
     { name = "build" },
     { name = "coverage" },
-    { name = "hatch-vcs" },
-    { name = "hatchling" },
     { name = "hypothesis" },
     { name = "ipython" },
     { name = "line-profiler" },
@@ -1420,6 +1390,8 @@ dev = [
     { name = "ruff" },
     { name = "scipy-stubs" },
     { name = "seaborn" },
+    { name = "setuptools" },
+    { name = "setuptools-scm" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-togglebutton" },
@@ -1478,7 +1450,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = "~=4.12" },
     { name = "xopen", specifier = "~=2.0" },
 ]
-provides-extras = ["funksvd", "hpf", "implicit", "notebook", "ray", "sklearn"]
+provides-extras = ["sklearn", "funksvd", "hpf", "implicit", "notebook", "ray"]
 
 [package.metadata.requires-dev]
 cpu = [{ name = "torch", specifier = "~=2.4", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "lenskit", group = "cpu" } }]
@@ -1493,8 +1465,6 @@ demo = [
 dev = [
     { name = "build", specifier = "~=1.0" },
     { name = "coverage", specifier = ">=5" },
-    { name = "hatch-vcs", specifier = "~=0.4.0" },
-    { name = "hatchling", specifier = "~=1.24" },
     { name = "hypothesis", specifier = ">=6.16" },
     { name = "ipython", specifier = ">=7" },
     { name = "line-profiler" },
@@ -1518,6 +1488,8 @@ dev = [
     { name = "ruff", specifier = ">=0.2" },
     { name = "scipy-stubs", specifier = ">=1.14.1.6,<2" },
     { name = "seaborn", specifier = ">=0.13.2,<0.14" },
+    { name = "setuptools", specifier = ">=70" },
+    { name = "setuptools-scm", specifier = ">=8" },
     { name = "sphinx", specifier = ">=4.2" },
     { name = "sphinx-autobuild", specifier = ">=2021" },
     { name = "sphinx-togglebutton", specifier = ">=0.3.2,<0.4" },
@@ -2285,15 +2257,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
 ]
 
 [[package]]
@@ -3796,15 +3759,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/2e/757d2280d4fefe7d33af7615124e7e298ae7b8e3bc4446cdb8e88b0f9bab/triton-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8009a1fb093ee8546495e96731336a33fb8856a38e45bb4ab6affd6dbc3ba220", size = 253157636 },
     { url = "https://files.pythonhosted.org/packages/06/00/59500052cb1cf8cf5316be93598946bc451f14072c6ff256904428eaf03c/triton-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d9b215efc1c26fa7eefb9a157915c92d52e000d2bf83e5f69704047e63f125c", size = 253159365 },
     { url = "https://files.pythonhosted.org/packages/c7/30/37a3384d1e2e9320331baca41e835e90a3767303642c7a80d4510152cbcf/triton-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5dfa23ba84541d7c0a531dfce76d8bcd19159d50a4a8b14ad01e91734a5c1b0", size = 253154278 },
-]
-
-[[package]]
-name = "trove-classifiers"
-version = "2025.3.19.19"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/c6/1bc495f33ab4cd16c1044bde55d5ac76646c6c759df751218c7c2aeb3bba/trove_classifiers-2025.3.19.19.tar.gz", hash = "sha256:98e9d396fe908d5f43b7454fa4c43d17cd0fdadf046f45fb38a5e3af8d959ecd", size = 16280 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/f8/9c6d334002e7b4ff34a875d2f6fe76c6c1544bd7fde3e39cb7cd2593488f/trove_classifiers-2025.3.19.19-py3-none-any.whl", hash = "sha256:5fc02770ecd81588a605ac98b9d85d50a5a3f9daa30af2a6b1361a1999d75d07", size = 13678 },
 ]
 
 [[package]]


### PR DESCRIPTION
This replaces `hatchling` with `setuptools`, since we weren't actually using any Hatch capabilities.