### PR TITLE
Re-add progress bars and signal checking to Item KNN builder

### DIFF
--- a/src/accel/sparse/consumer.rs
+++ b/src/accel/sparse/consumer.rs
@@ -1,0 +1,160 @@
+use std::{
+    collections::LinkedList,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use arrow::{
+    array::{Float32Builder, Int32Builder, LargeListArray, StructArray},
+    buffer::OffsetBuffer,
+};
+use arrow_schema::{DataType, Field, Fields};
+use pyo3::{intern, prelude::*, types::PyDict};
+use rayon::iter::plumbing::{Consumer, Folder, Reducer};
+
+use super::SparseIndexType;
+
+pub type CSRItem = Vec<(i32, f32)>;
+pub type CSRResult = LinkedList<LargeListArray>;
+
+const UPDATE_FREQ: u64 = 100;
+
+/// Rayon consumer that collects sparse rows (as vectors) into a chunked sparse row array.
+///
+/// It handles checking for signals and updating progress.
+pub struct ArrowCSRConsumer {
+    state: Arc<CSRState>,
+    lengths: Vec<usize>,
+    col_bld: Int32Builder,
+    val_bld: Float32Builder,
+}
+
+struct CSRState {
+    dimension: usize,
+    counter: AtomicU64,
+    progress: Option<Py<PyAny>>,
+}
+
+impl CSRState {
+    fn new(dim: usize, progress: Option<Py<PyAny>>) -> Self {
+        CSRState {
+            dimension: dim,
+            counter: AtomicU64::new(0),
+            progress,
+        }
+    }
+}
+
+impl ArrowCSRConsumer {
+    fn from_state(state: CSRState) -> Self {
+        Self::from_state_ref(Arc::new(state))
+    }
+
+    fn from_state_ref(state: Arc<CSRState>) -> Self {
+        ArrowCSRConsumer {
+            state,
+            lengths: Vec::new(),
+            col_bld: Int32Builder::new(),
+            val_bld: Float32Builder::new(),
+        }
+    }
+    pub(crate) fn new(dim: usize) -> Self {
+        Self::from_state(CSRState::new(dim, None))
+    }
+
+    pub(crate) fn with_progress(dim: usize, progress: Py<PyAny>) -> Self {
+        Self::from_state(CSRState::new(dim, Some(progress)))
+    }
+
+    fn check_progress(&mut self) {
+        let n = self.state.counter.fetch_add(1, Ordering::Relaxed) + 1;
+        if n % UPDATE_FREQ == 0 {
+            Python::with_gil(|py| {
+                py.check_signals()?;
+                if let Some(pb) = &self.state.progress {
+                    let kwargs = PyDict::new(py);
+                    kwargs.set_item(intern!(py, "completed"), n)?;
+                    pb.call_method(py, intern!(py, "update"), (), Some(&kwargs))?;
+                }
+                Ok::<(), PyErr>(())
+            })
+            .expect("progress update failed");
+        }
+    }
+}
+
+impl Consumer<CSRItem> for ArrowCSRConsumer {
+    type Folder = Self;
+
+    type Reducer = Self;
+
+    type Result = CSRResult;
+
+    fn split_at(self, _index: usize) -> (Self, Self, Self::Reducer) {
+        let left = ArrowCSRConsumer::from_state_ref(self.state.clone());
+        let right = ArrowCSRConsumer::from_state_ref(self.state.clone());
+        (left, right, self)
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        self
+    }
+
+    fn full(&self) -> bool {
+        false
+    }
+}
+
+impl Folder<CSRItem> for ArrowCSRConsumer {
+    type Result = CSRResult;
+
+    fn consume(mut self, item: CSRItem) -> Self {
+        let len = item.len();
+        for (i, s) in item {
+            self.col_bld.append_value(i);
+            self.val_bld.append_value(s);
+        }
+        self.lengths.push(len);
+        self.check_progress();
+        self
+    }
+
+    fn complete(mut self) -> Self::Result {
+        let struct_fields = Fields::from(vec![
+            Field::new("index", DataType::Int32, false)
+                .with_extension_type(SparseIndexType::create(self.state.dimension)),
+            Field::new("value", DataType::Float32, false),
+        ]);
+        let list_field = Field::new("rows", DataType::Struct(struct_fields.clone()), false);
+        let sa = StructArray::new(
+            struct_fields,
+            vec![
+                Arc::new(self.col_bld.finish()),
+                Arc::new(self.val_bld.finish()),
+            ],
+            None,
+        );
+        let list = LargeListArray::new(
+            Arc::new(list_field),
+            OffsetBuffer::from_lengths(self.lengths),
+            Arc::new(sa),
+            None,
+        );
+        let mut result = LinkedList::new();
+        result.push_back(list);
+        result
+    }
+
+    fn full(&self) -> bool {
+        false
+    }
+}
+
+impl Reducer<CSRResult> for ArrowCSRConsumer {
+    fn reduce(self, mut left: CSRResult, mut right: CSRResult) -> CSRResult {
+        left.append(&mut right);
+        left
+    }
+}

--- a/src/accel/sparse/mod.rs
+++ b/src/accel/sparse/mod.rs
@@ -10,11 +10,13 @@ use arrow::{
 use pyo3::exceptions::PyTypeError;
 use pyo3::PyResult;
 
+mod consumer;
 mod index;
 mod index_list;
 mod matrix;
 mod row;
 
+pub use consumer::ArrowCSRConsumer;
 pub use index::SparseIndexType;
 pub use index_list::SparseIndexListType;
 pub use matrix::{CSRMatrix, CSRStructure};

--- a/tests/models/test_knn_item_item.py
+++ b/tests/models/test_knn_item_item.py
@@ -223,7 +223,7 @@ def test_ii_train_ml100k(tmp_path, ml_100k):
     with fn.open("rb") as modf:
         restored = pickle.load(modf)
 
-    r_mat = restored.sim_matrix.to_csr()
+    r_mat = restored.sim_matrix.to_scipy()
 
     assert all(r_mat.data > 0)
     assert all(r_mat.data == matrix.data)


### PR DESCRIPTION
This updates the KNN accelerator in a few ways:

- Implement a Rayon `Consumer` to accumulate results directly into Arrow.
- Check for signals after every 100 accumulated rows.
- Re-add item KNN progress bar.