### PR TITLE
Reduce base structure memory consumption

### DIFF
--- a/src/lenskit/basic/bias.py
+++ b/src/lenskit/basic/bias.py
@@ -71,12 +71,12 @@ class BiasModel:
 
     items: Vocabulary | None = None
     "Vocabulary of items."
-    item_biases: np.ndarray[int, np.dtype[np.float32]] | None = None
+    item_biases: np.ndarray[tuple[int], np.dtype[np.float32]] | None = None
     "The item offsets (:math:`b_i` values)."
 
     users: Vocabulary | None = None
     "Vocabulary of users."
-    user_biases: np.ndarray[int, np.dtype[np.float32]] | None = None
+    user_biases: np.ndarray[tuple[int], np.dtype[np.float32]] | None = None
     "The user offsets (:math:`b_u` values)."
 
     @classmethod

--- a/src/lenskit/data/container.py
+++ b/src/lenskit/data/container.py
@@ -75,11 +75,11 @@ class DataContainer:
         tables = {}
         for name in schema.entities:
             log.debug("reading entity table %s", name, table=name, time=timer.elapsed())
-            tables[name] = read_table(path / f"{name}.parquet")
+            tables[name] = read_table(path / f"{name}.parquet").combine_chunks()
 
         for name in schema.relationships:
             log.debug("reading relationship table %s", name, table=name, time=timer.elapsed())
-            tables[name] = read_table(path / f"{name}.parquet")
+            tables[name] = read_table(path / f"{name}.parquet").combine_chunks()
 
         log.debug("finished loading data set in %s", timer, time=timer.elapsed())
         return cls(schema, tables)

--- a/src/lenskit/data/matrix.py
+++ b/src/lenskit/data/matrix.py
@@ -448,6 +448,22 @@ class SparseRowArray(pa.ExtensionArray):
         else:
             return None
 
+    def row_extent(self, row: int) -> tuple[int, int]:
+        """
+        Get the start and end of a row.
+        """
+        start = self.storage.offsets[row].as_py()
+        end = self.storage.offsets[row + 1].as_py()
+        return start, end
+
+    def row_indices(self, row: int) -> pa.Int32Array:
+        """
+        Get the index array for a compressed sparse row.
+        """
+        sp, ep = self.row_extent(row)
+        indices = self.indices
+        return indices.slice(sp, ep - sp)
+
 
 def _check_index_type(index_type: pa.DataType, dimension: int | None) -> int:
     if isinstance(index_type, SparseIndexType):


### PR DESCRIPTION
This has some memory and disk usage improvements:

- Reduce disk usage of serialized matrix relationship sets
- Combine chunks when loading data sets to improve shareability