### PR TITLE
Rewrite FunkSVD in Rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,55 +94,6 @@ jobs:
             coverage.db
             coverage.xml
 
-  nojit:
-    name: Non-JIT test coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: "🛒 Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: 🕶️ Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-
-      - name: 📦 Set up Python dependencies (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          uv sync --all-extras --no-default-groups --group test
-
-      - name: 🔍 Inspect environment
-        run: |
-          lenskit doctor
-
-      - name: 🏃🏻‍➡️ Test LKPY
-        run: |
-          python -m pytest --verbose --log-file=test.log --durations=25 -m 'not slow' --cov=src/lenskit tests
-        env:
-          NUMBA_DISABLE_JIT: 1
-          PYTORCH_JIT: 0
-
-      - name: 📐 Coverage results
-        if: ${{ !cancelled() }}
-        run: |
-          coverage xml
-          coverage report
-          cp .coverage coverage.db
-
-      - name: 📤 Upload test results
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: test-nojit
-          path: |
-            test*.log
-            coverage.db
-            coverage.xml
-
   mindep-all:
     name: Minimal dependency tests (all options)
     runs-on: ubuntu-latest
@@ -359,7 +310,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - vanilla
-      - nojit
       - mindep-all
       - mindep
       - eval-tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,7 @@
     "editor.formatOnSave": true
   },
   "[toml]": {
-    "editor.defaultFormatter": "tamasfe.even-better-toml",
+    "editor.defaultFormatter": "dprint.dprint",
     "editor.formatOnSave": true
   },
   "[jsonnet]": {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ arrow-schema = { version = "^55", features = ["serde"] }
 nalgebra = { version = "^0.33" }
 ndarray = { version = "^0.16", features = ["rayon"] }
 nshare = { version = "^0.10", default-features = false, features = ["ndarray", "nalgebra"] }
-# ndarray-linalg = { version = "^0.17", features = ["openblas-system"] }
 numpy = "^0.24"
 
 [profile.dev]
@@ -34,3 +33,4 @@ opt-level = 2
 
 [profile.release]
 lto = true
+debug = "line-tables-only"

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -83,26 +83,6 @@ outputs:
     requirements:
       run:
         - ${{ pin_subpackage('lenskit') }}
-        - numba >=0.56
-    tests:
-      - python:
-          imports:
-            - lenskit.funksvd
-      - script:
-          - pytest -m "not slow" tests/funksvd
-        files:
-          source:
-            - tests/
-            - conftest.py
-            - data/
-            - pyproject.toml
-        requirements:
-          run:
-            - pytest >=8.2,<9
-            - pytest-benchmark =4
-            - pytest-doctestplus >=1.2.1,<2
-            - hypothesis >=6.16
-            - pyyaml ~=6.0
 
   - package:
       name: lenskit-sklearn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ gpu = ["torch ~=2.4"]
 
 [project.optional-dependencies]
 sklearn = ["scikit-learn ~=1.2"]
-funksvd = ["numba >= 0.56"]
+funksvd = []
 hpf = ["hpfrec~=0.2.12"]
 implicit = ["implicit >=0.7.2"]
 notebook = ["ipywidgets ~=8.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ lenskit-recommend = "lenskit.cli.recommend:recommend"
 
 # configure build tools
 [tool.maturin]
+profile = "release"
 python-source = "src"
 module-name = "lenskit._accel"
 

--- a/src/accel/funksvd.rs
+++ b/src/accel/funksvd.rs
@@ -79,6 +79,9 @@ impl FunkSVDTrainer {
         assert_eq!(items.len(), n);
         assert_eq!(ratings.len(), n);
 
+        let lr = self.config.learning_rate;
+        let reg = self.config.regularization;
+
         let mut uf_col = uf_mat.column_mut(feature);
         let mut if_col = if_mat.column_mut(feature);
 
@@ -98,15 +101,15 @@ impl FunkSVDTrainer {
                 let error = rating - pred;
                 sse += error * error;
 
-                let ufd = error * ifv - self.config.regularization * ufv;
-                let ufd = ufd * self.config.learning_rate;
-                let ifd = error * ufv - self.config.regularization * ifv;
-                let ifd = ifd * self.config.learning_rate;
+                let ufd = error * ifv - reg * ufv;
+                let ufd = ufd * lr;
+                let ifd = error * ufv - reg * ifv;
+                let ifd = ifd * lr;
                 uf_col[user] += ufd as f32;
                 if_col[item] += ifd as f32;
             }
 
-            Ok((sse / self.data.n_samples() as f64).sqrt())
+            Ok((sse / n as f64).sqrt())
         })
     }
 }

--- a/src/accel/funksvd.rs
+++ b/src/accel/funksvd.rs
@@ -1,0 +1,117 @@
+use arrow::{
+    array::{make_array, ArrayData, Float32Array, Int32Array},
+    pyarrow::PyArrowType,
+};
+use numpy::{PyArray1, PyArray2, PyArrayMethods};
+use pyo3::prelude::*;
+
+use crate::types::checked_array;
+
+#[derive(FromPyObject, Clone, Debug)]
+struct FunkSVDConfig {
+    learning_rate: f64,
+    regularization: f64,
+    rating_min: f64,
+    rating_max: f64,
+}
+
+#[derive(FromPyObject)]
+struct FunkSVDTrainingInput {
+    users: PyArrowType<ArrayData>,
+    items: PyArrowType<ArrayData>,
+    ratings: PyArrowType<ArrayData>,
+}
+
+struct FunkSVDTrainingData {
+    users: Int32Array,
+    items: Int32Array,
+    ratings: Float32Array,
+}
+
+#[pyclass]
+pub struct FunkSVDTrainer {
+    config: FunkSVDConfig,
+    data: FunkSVDTrainingData,
+    user_features: Py<PyArray2<f32>>,
+    item_features: Py<PyArray2<f32>>,
+}
+
+#[pymethods]
+impl FunkSVDTrainer {
+    /// Instantiate a new FunkSVD trainer.
+    #[new]
+    fn new<'py>(
+        config: Bound<'py, PyAny>,
+        data: FunkSVDTrainingInput,
+        user_features: Bound<'py, PyArray2<f32>>,
+        item_features: Bound<'py, PyArray2<f32>>,
+    ) -> PyResult<Self> {
+        let config = FunkSVDConfig::extract_bound(&config)?;
+
+        Ok(FunkSVDTrainer {
+            config,
+            data: data.try_into()?,
+            user_features: user_features.unbind(),
+            item_features: item_features.unbind(),
+        })
+    }
+
+    /// Train a FunkSVD feature for one epoch.
+    fn feature_epoch<'py>(
+        &self,
+        py: Python<'py>,
+        feature: usize,
+        estimates: Bound<'py, PyArray1<f32>>,
+        trail: f64,
+    ) -> PyResult<f64> {
+        let mut uf_ref = self.user_features.bind(py).readwrite();
+        let mut uf_mat = uf_ref.as_array_mut();
+        let mut if_ref = self.item_features.bind(py).readwrite();
+        let mut if_mat = if_ref.as_array_mut();
+        let est_ref = estimates.readonly();
+        let est_vec = est_ref.as_array();
+
+        let mut sse = 0.0;
+
+        for s in 0..self.data.n_samples() {
+            let user = self.data.users.value(s) as usize;
+            let item = self.data.items.value(s) as usize;
+            let rating = self.data.ratings.value(s) as f64;
+            let ufv = uf_mat[[user, feature]] as f64;
+            let ifv = if_mat[[item, feature]] as f64;
+
+            let pred = est_vec[s] as f64 + ufv * ifv + trail;
+            let pred = pred.clamp(self.config.rating_min, self.config.rating_max);
+
+            let error = rating - pred;
+            sse += error * error;
+
+            let ufd = error * ifv - self.config.regularization * ufv;
+            let ufd = ufd * self.config.learning_rate;
+            let ifd = error * ufv - self.config.regularization * ifv;
+            let ifd = ifd * self.config.learning_rate;
+            uf_mat[[user, feature]] += ufd as f32;
+            if_mat[[item, feature]] += ifd as f32;
+        }
+
+        Ok((sse / self.data.n_samples() as f64).sqrt())
+    }
+}
+
+impl FunkSVDTrainingData {
+    fn n_samples(&self) -> usize {
+        self.users.len()
+    }
+}
+
+impl TryInto<FunkSVDTrainingData> for FunkSVDTrainingInput {
+    type Error = PyErr;
+
+    fn try_into(self) -> PyResult<FunkSVDTrainingData> {
+        Ok(FunkSVDTrainingData {
+            users: checked_array("users", &make_array(self.users.0))?,
+            items: checked_array("items", &make_array(self.items.0))?,
+            ratings: checked_array("ratings", &make_array(self.ratings.0))?,
+        })
+    }
+}

--- a/src/accel/knn/item_score.rs
+++ b/src/accel/knn/item_score.rs
@@ -7,7 +7,7 @@ use pyo3::{exceptions::PyValueError, prelude::*};
 use crate::{
     knn::accum::{collect_items_averaged, collect_items_summed},
     sparse::{CSRMatrix, CSR},
-    types::checked_array_convert,
+    types::checked_array_ref,
 };
 
 use super::accum::ScoreAccumulator;
@@ -29,10 +29,9 @@ pub fn score_explicit<'py>(
         let ref_rates = make_array(ref_rates.0);
         let tgt_items = make_array(tgt_items.0);
 
-        let ref_is: &Int32Array = checked_array_convert("reference item", "Int32", &ref_items)?;
-        let ref_vs: &Float32Array =
-            checked_array_convert("reference ratings", "Float32", &ref_rates)?;
-        let tgt_is: &Int32Array = checked_array_convert("target item", "Int32", &tgt_items)?;
+        let ref_is: &Int32Array = checked_array_ref("reference item", "Int32", &ref_items)?;
+        let ref_vs: &Float32Array = checked_array_ref("reference ratings", "Float32", &ref_rates)?;
+        let tgt_is: &Int32Array = checked_array_ref("target item", "Int32", &tgt_items)?;
 
         let mut heaps = ScoreAccumulator::new_array(sims.n_cols, tgt_is);
 
@@ -77,8 +76,8 @@ pub fn score_implicit<'py>(
         let ref_items = make_array(ref_items.0);
         let tgt_items = make_array(tgt_items.0);
 
-        let ref_is: &Int32Array = checked_array_convert("reference item", "Int32", &ref_items)?;
-        let tgt_is: &Int32Array = checked_array_convert("target item", "Int32", &tgt_items)?;
+        let ref_is: &Int32Array = checked_array_ref("reference item", "Int32", &ref_items)?;
+        let tgt_is: &Int32Array = checked_array_ref("target item", "Int32", &tgt_items)?;
 
         let mut heaps = ScoreAccumulator::new_array(sims.n_cols, tgt_is);
 

--- a/src/accel/knn/user_score.rs
+++ b/src/accel/knn/user_score.rs
@@ -7,7 +7,7 @@ use arrow::{
 
 use crate::{
     sparse::{CSRMatrix, CSRStructure, CSR},
-    types::checked_array_convert,
+    types::checked_array_ref,
 };
 
 use super::accum::{collect_items_averaged, collect_items_summed, ScoreAccumulator};
@@ -25,12 +25,12 @@ pub fn user_score_items_explicit<'py>(
     let rmat = CSRMatrix::<i32>::from_arrow(ratings)?;
 
     let tgt_items_ref = make_array(tgt_items.0);
-    let tgt_is: &Int32Array = checked_array_convert("target item", "int32", &tgt_items_ref)?;
+    let tgt_is: &Int32Array = checked_array_ref("target item", "int32", &tgt_items_ref)?;
 
     let nbr_rows_ref = make_array(nbr_rows.0);
-    let nbr_is: &Int32Array = checked_array_convert("neighbor index", "int32", &nbr_rows_ref)?;
+    let nbr_is: &Int32Array = checked_array_ref("neighbor index", "int32", &nbr_rows_ref)?;
     let nbr_sims_ref = make_array(nbr_sims.0);
-    let nbr_sims: &Float32Array = checked_array_convert("neighbor sims", "float32", &nbr_sims_ref)?;
+    let nbr_sims: &Float32Array = checked_array_ref("neighbor sims", "float32", &nbr_sims_ref)?;
 
     let mut heaps = ScoreAccumulator::new_array(rmat.n_cols, tgt_is);
     let iter = nbr_is.iter().zip(nbr_sims.iter()).flat_map(|ns| match ns {
@@ -66,12 +66,12 @@ pub fn user_score_items_implicit<'py>(
     let rmat = CSRStructure::<i32>::from_arrow(ratings)?;
 
     let tgt_items_ref = make_array(tgt_items.0);
-    let tgt_is: &Int32Array = checked_array_convert("target item", "int32", &tgt_items_ref)?;
+    let tgt_is: &Int32Array = checked_array_ref("target item", "int32", &tgt_items_ref)?;
 
     let nbr_rows_ref = make_array(nbr_rows.0);
-    let nbr_is: &Int32Array = checked_array_convert("neighbor index", "int32", &nbr_rows_ref)?;
+    let nbr_is: &Int32Array = checked_array_ref("neighbor index", "int32", &nbr_rows_ref)?;
     let nbr_sims_ref = make_array(nbr_sims.0);
-    let nbr_sims: &Float32Array = checked_array_convert("neighbor sims", "float32", &nbr_sims_ref)?;
+    let nbr_sims: &Float32Array = checked_array_ref("neighbor sims", "float32", &nbr_sims_ref)?;
 
     let mut heaps = ScoreAccumulator::new_array(rmat.n_cols, tgt_is);
     let iter = nbr_is.iter().zip(nbr_sims.iter()).flat_map(|ns| match ns {

--- a/src/accel/lib.rs
+++ b/src/accel/lib.rs
@@ -4,6 +4,7 @@ use rayon::ThreadPoolBuilder;
 
 mod als;
 mod data;
+mod funksvd;
 mod knn;
 mod progress;
 mod sampling;
@@ -17,6 +18,7 @@ fn _accel(m: &Bound<'_, PyModule>) -> PyResult<()> {
     knn::register_knn(m)?;
     als::register_als(m)?;
 
+    m.add_class::<funksvd::FunkSVDTrainer>()?;
     m.add_class::<sampling::NegativeSampler>()?;
     m.add_class::<data::RowColumnSet>()?;
     m.add_function(wrap_pyfunction!(init_accel_pool, m)?)?;

--- a/src/lenskit/_accel.pyi
+++ b/src/lenskit/_accel.pyi
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Protocol, TypedDict
+from typing import Protocol
 
 import numpy as np
 import pyarrow as pa
 
 from lenskit.data.matrix import SparseRowArray
 from lenskit.data.types import NPMatrix, NPVector
+from lenskit.funksvd import FunkSVDTrainingData, FunkSVDTrainingParams
 from lenskit.logging import Progress
 
 class _ALSAccelerator(Protocol):
@@ -29,22 +30,11 @@ class _ALSAccelerator(Protocol):
 
 als: _ALSAccelerator
 
-class _FunkSVDConfig(TypedDict):
-    learning_rate: float
-    regularization: float
-    rating_min: float
-    rating_max: float
-
-class _FunkSVDTrainingData(TypedDict):
-    users: pa.Int32Array
-    items: pa.Int32Array
-    ratings: pa.FloatArray
-
 class FunkSVDTrainer:
     def __init__(
         self,
-        config: _FunkSVDConfig,
-        data: _FunkSVDTrainingData,
+        config: FunkSVDTrainingParams,
+        data: FunkSVDTrainingData,
         user_features: NPMatrix,
         item_features: NPMatrix,
     ): ...

--- a/src/lenskit/_accel.pyi
+++ b/src/lenskit/_accel.pyi
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, TypedDict
 
 import numpy as np
 import pyarrow as pa
 
 from lenskit.data.matrix import SparseRowArray
-from lenskit.data.types import NPMatrix
+from lenskit.data.types import NPMatrix, NPVector
 from lenskit.logging import Progress
 
 class _ALSAccelerator(Protocol):
@@ -28,6 +28,27 @@ class _ALSAccelerator(Protocol):
     ) -> float: ...
 
 als: _ALSAccelerator
+
+class _FunkSVDConfig(TypedDict):
+    learning_rate: float
+    regularization: float
+    rating_min: float
+    rating_max: float
+
+class _FunkSVDTrainingData(TypedDict):
+    users: pa.Int32Array
+    items: pa.Int32Array
+    ratings: pa.FloatArray
+
+class FunkSVDTrainer:
+    def __init__(
+        self,
+        config: _FunkSVDConfig,
+        data: _FunkSVDTrainingData,
+        user_features: NPMatrix,
+        item_features: NPMatrix,
+    ): ...
+    def feature_epoch(self, feature: int, estimates: NPVector, trail: float) -> float: ...
 
 class RowColumnSet:
     def __init__(self, matrix: SparseRowArray): ...

--- a/src/lenskit/funksvd.py
+++ b/src/lenskit/funksvd.py
@@ -145,8 +145,8 @@ class FunkSVDScorer(Trainable, Component[ItemList]):
 
         log.debug("[%s] initializing embeddings")
         esize = self.config.embedding_size
-        uemb = np.full([n_users, esize], INITIAL_VALUE, dtype=np.float32)
-        iemb = np.full([n_items, esize], INITIAL_VALUE, dtype=np.float32)
+        uemb = np.full([n_users, esize], INITIAL_VALUE, dtype=np.float32, order="F")
+        iemb = np.full([n_items, esize], INITIAL_VALUE, dtype=np.float32, order="F")
 
         if self.config.range is not None:
             rmin, rmax = self.config.range

--- a/tests/funksvd/test_funksvd.py
+++ b/tests/funksvd/test_funksvd.py
@@ -36,33 +36,33 @@ class TestFunkSVD(BasicComponentTests, ScorerTests):
 def test_fsvd_basic_build():
     algo = funk.FunkSVDScorer(features=20, epochs=20)
     assert algo.config is not None
-    assert algo.config.features == 20
+    assert algo.config.embedding_size == 20
     algo.train(simple_ds)
 
-    assert algo.bias_ is not None
-    assert algo.bias_.global_bias == approx(simple_df.rating.mean())
-    assert algo.item_features_.shape == (3, 20)
-    assert algo.user_features_.shape == (3, 20)
+    assert algo.bias is not None
+    assert algo.bias.global_bias == approx(simple_df.rating.mean())
+    assert algo.item_embeddings.shape == (3, 20)
+    assert algo.user_embeddings.shape == (3, 20)
 
 
 def test_fsvd_clamp_build():
     algo = funk.FunkSVDScorer(features=20, epochs=20, range=(1, 5))
     algo.train(simple_ds)
 
-    assert algo.bias_ is not None
-    assert algo.bias_.global_bias == approx(simple_df.rating.mean())
-    assert algo.item_features_.shape == (3, 20)
-    assert algo.user_features_.shape == (3, 20)
+    assert algo.bias is not None
+    assert algo.bias.global_bias == approx(simple_df.rating.mean())
+    assert algo.item_embeddings.shape == (3, 20)
+    assert algo.user_embeddings.shape == (3, 20)
 
 
 def test_fsvd_predict_basic():
     algo = funk.FunkSVDScorer(features=20, epochs=20)
     algo.train(simple_ds)
 
-    assert algo.bias_ is not None
-    assert algo.bias_.global_bias == approx(simple_df.rating.mean())
-    assert algo.item_features_.shape == (3, 20)
-    assert algo.user_features_.shape == (3, 20)
+    assert algo.bias is not None
+    assert algo.bias.global_bias == approx(simple_df.rating.mean())
+    assert algo.item_embeddings.shape == (3, 20)
+    assert algo.user_embeddings.shape == (3, 20)
 
     preds = algo(query=10, items=ItemList([3]))
     assert len(preds) == 1
@@ -77,10 +77,10 @@ def test_fsvd_predict_clamp():
     algo = funk.FunkSVDScorer(features=20, epochs=20, range=(1, 5))
     algo.train(simple_ds)
 
-    assert algo.bias_ is not None
-    assert algo.bias_.global_bias == approx(simple_df.rating.mean())
-    assert algo.item_features_.shape == (3, 20)
-    assert algo.user_features_.shape == (3, 20)
+    assert algo.bias is not None
+    assert algo.bias.global_bias == approx(simple_df.rating.mean())
+    assert algo.item_embeddings.shape == (3, 20)
+    assert algo.user_embeddings.shape == (3, 20)
 
     preds = algo(query=10, items=ItemList([3]))
     assert len(preds) == 1
@@ -95,10 +95,10 @@ def test_fsvd_predict_bad_item():
     algo = funk.FunkSVDScorer(features=20, epochs=20)
     algo.train(simple_ds)
 
-    assert algo.bias_ is not None
-    assert algo.bias_.global_bias == approx(simple_df.rating.mean())
-    assert algo.item_features_.shape == (3, 20)
-    assert algo.user_features_.shape == (3, 20)
+    assert algo.bias is not None
+    assert algo.bias.global_bias == approx(simple_df.rating.mean())
+    assert algo.item_embeddings.shape == (3, 20)
+    assert algo.user_embeddings.shape == (3, 20)
 
     preds = algo(10, ItemList([4]))
     assert len(preds) == 1
@@ -112,10 +112,10 @@ def test_fsvd_predict_bad_item_clamp():
     algo = funk.FunkSVDScorer(features=20, epochs=20, range=(1, 5))
     algo.train(simple_ds)
 
-    assert algo.bias_ is not None
-    assert algo.bias_.global_bias == approx(simple_df.rating.mean())
-    assert algo.item_features_.shape == (3, 20)
-    assert algo.user_features_.shape == (3, 20)
+    assert algo.bias is not None
+    assert algo.bias.global_bias == approx(simple_df.rating.mean())
+    assert algo.item_embeddings.shape == (3, 20)
+    assert algo.user_embeddings.shape == (3, 20)
 
     preds = algo(10, ItemList([4]))
     assert len(preds) == 1
@@ -129,10 +129,10 @@ def test_fsvd_predict_bad_user():
     algo = funk.FunkSVDScorer(features=20, epochs=20)
     algo.train(simple_ds)
 
-    assert algo.bias_ is not None
-    assert algo.bias_.global_bias == approx(simple_df.rating.mean())
-    assert algo.item_features_.shape == (3, 20)
-    assert algo.user_features_.shape == (3, 20)
+    assert algo.bias is not None
+    assert algo.bias.global_bias == approx(simple_df.rating.mean())
+    assert algo.item_embeddings.shape == (3, 20)
+    assert algo.user_embeddings.shape == (3, 20)
 
     preds = algo(query=50, items=ItemList([3]))
     assert len(preds) == 1
@@ -148,24 +148,24 @@ def test_fsvd_save_load(ml_ds: Dataset):
     original = funk.FunkSVDScorer(features=20, epochs=20)
     original.train(ml_ds)
 
-    assert original.bias_ is not None
-    assert original.bias_.global_bias == approx(
+    assert original.bias is not None
+    assert original.bias.global_bias == approx(
         ml_ds.interaction_matrix(format="scipy", field="rating").data.mean()
     )
-    assert original.item_features_.shape == (ml_ds.item_count, 20)
-    assert original.user_features_.shape == (ml_ds.user_count, 20)
+    assert original.item_embeddings.shape == (ml_ds.item_count, 20)
+    assert original.user_embeddings.shape == (ml_ds.user_count, 20)
 
     mod = pickle.dumps(original)
     _log.info("serialized to %d bytes", len(mod))
     algo = pickle.loads(mod)
 
-    assert algo.bias_.global_bias == original.bias_.global_bias
-    assert np.all(algo.bias_.user_biases == original.bias_.user_biases)
-    assert np.all(algo.bias_.item_biases == original.bias_.item_biases)
-    assert np.all(algo.user_features_ == original.user_features_)
-    assert np.all(algo.item_features_ == original.item_features_)
-    assert np.all(algo.items_.index == original.items_.index)
-    assert np.all(algo.users_.index == original.users_.index)
+    assert algo.bias.global_bias == original.bias.global_bias
+    assert np.all(algo.bias.user_biases == original.bias.user_biases)
+    assert np.all(algo.bias.item_biases == original.bias.item_biases)
+    assert np.all(algo.user_embeddings == original.user_embeddings)
+    assert np.all(algo.item_embeddings == original.item_embeddings)
+    assert np.all(algo.items.index == original.items.index)
+    assert np.all(algo.users.index == original.users.index)
 
 
 @wantjit

--- a/uv.lock
+++ b/uv.lock
@@ -1376,9 +1376,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-funksvd = [
-    { name = "numba" },
-]
 hpf = [
     { name = "hpfrec" },
 ]
@@ -1487,7 +1484,6 @@ requires-dist = [
     { name = "implicit", marker = "extra == 'implicit'", specifier = ">=0.7.2" },
     { name = "ipywidgets", marker = "extra == 'notebook'", specifier = "~=8.0" },
     { name = "more-itertools", specifier = ">=9.0" },
-    { name = "numba", marker = "extra == 'funksvd'", specifier = ">=0.56" },
     { name = "numpy", specifier = ">=1.25" },
     { name = "pandas", specifier = "~=2.0" },
     { name = "prettytable", specifier = "~=3.14" },
@@ -1611,29 +1607,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/36/ecc106dd448a112455a8585db0994886b0439bbf808215249a89302dd626/line_profiler-4.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6767d8b922a7368b6917a47c164c3d96d48b82109ad961ef518e78800947cef4", size = 718497 },
     { url = "https://files.pythonhosted.org/packages/8a/61/6293341fbcc6c5b4469f49bd94f37fea5d2efc8cce441809012346a5b7d0/line_profiler-4.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3137672a769717be4da3a6e006c3bd7b66ad4a341ba89ee749ef96c158a15b22", size = 1701191 },
     { url = "https://files.pythonhosted.org/packages/23/9c/ab8a94c30c082caca87bc0db78efe91372e45d35a700ef07ffe78ed10cda/line_profiler-4.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:727e970d358616a1a33d51d696efec932a5ef7730785df62658bd7e74aa58951", size = 128232 },
-]
-
-[[package]]
-name = "llvmlite"
-version = "0.44.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/6a/95a3d3610d5c75293d5dbbb2a76480d5d4eeba641557b69fe90af6c5b84e/llvmlite-0.44.0.tar.gz", hash = "sha256:07667d66a5d150abed9157ab6c0b9393c9356f229784a4385c02f99e94fc94d4", size = 171880 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/e2/86b245397052386595ad726f9742e5223d7aea999b18c518a50e96c3aca4/llvmlite-0.44.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:eed7d5f29136bda63b6d7804c279e2b72e08c952b7c5df61f45db408e0ee52f3", size = 28132305 },
-    { url = "https://files.pythonhosted.org/packages/ff/ec/506902dc6870249fbe2466d9cf66d531265d0f3a1157213c8f986250c033/llvmlite-0.44.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ace564d9fa44bb91eb6e6d8e7754977783c68e90a471ea7ce913bff30bd62427", size = 26201090 },
-    { url = "https://files.pythonhosted.org/packages/99/fe/d030f1849ebb1f394bb3f7adad5e729b634fb100515594aca25c354ffc62/llvmlite-0.44.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5d22c3bfc842668168a786af4205ec8e3ad29fb1bc03fd11fd48460d0df64c1", size = 42361858 },
-    { url = "https://files.pythonhosted.org/packages/d7/7a/ce6174664b9077fc673d172e4c888cb0b128e707e306bc33fff8c2035f0d/llvmlite-0.44.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f01a394e9c9b7b1d4e63c327b096d10f6f0ed149ef53d38a09b3749dcf8c9610", size = 41184200 },
-    { url = "https://files.pythonhosted.org/packages/5f/c6/258801143975a6d09a373f2641237992496e15567b907a4d401839d671b8/llvmlite-0.44.0-cp311-cp311-win_amd64.whl", hash = "sha256:d8489634d43c20cd0ad71330dde1d5bc7b9966937a263ff1ec1cebb90dc50955", size = 30331193 },
-    { url = "https://files.pythonhosted.org/packages/15/86/e3c3195b92e6e492458f16d233e58a1a812aa2bfbef9bdd0fbafcec85c60/llvmlite-0.44.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:1d671a56acf725bf1b531d5ef76b86660a5ab8ef19bb6a46064a705c6ca80aad", size = 28132297 },
-    { url = "https://files.pythonhosted.org/packages/d6/53/373b6b8be67b9221d12b24125fd0ec56b1078b660eeae266ec388a6ac9a0/llvmlite-0.44.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f79a728e0435493611c9f405168682bb75ffd1fbe6fc360733b850c80a026db", size = 26201105 },
-    { url = "https://files.pythonhosted.org/packages/cb/da/8341fd3056419441286c8e26bf436923021005ece0bff5f41906476ae514/llvmlite-0.44.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0143a5ef336da14deaa8ec26c5449ad5b6a2b564df82fcef4be040b9cacfea9", size = 42361901 },
-    { url = "https://files.pythonhosted.org/packages/53/ad/d79349dc07b8a395a99153d7ce8b01d6fcdc9f8231355a5df55ded649b61/llvmlite-0.44.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d752f89e31b66db6f8da06df8b39f9b91e78c5feea1bf9e8c1fba1d1c24c065d", size = 41184247 },
-    { url = "https://files.pythonhosted.org/packages/e2/3b/a9a17366af80127bd09decbe2a54d8974b6d8b274b39bf47fbaedeec6307/llvmlite-0.44.0-cp312-cp312-win_amd64.whl", hash = "sha256:eae7e2d4ca8f88f89d315b48c6b741dcb925d6a1042da694aa16ab3dd4cbd3a1", size = 30332380 },
-    { url = "https://files.pythonhosted.org/packages/89/24/4c0ca705a717514c2092b18476e7a12c74d34d875e05e4d742618ebbf449/llvmlite-0.44.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:319bddd44e5f71ae2689859b7203080716448a3cd1128fb144fe5c055219d516", size = 28132306 },
-    { url = "https://files.pythonhosted.org/packages/01/cf/1dd5a60ba6aee7122ab9243fd614abcf22f36b0437cbbe1ccf1e3391461c/llvmlite-0.44.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9c58867118bad04a0bb22a2e0068c693719658105e40009ffe95c7000fcde88e", size = 26201090 },
-    { url = "https://files.pythonhosted.org/packages/d2/1b/656f5a357de7135a3777bd735cc7c9b8f23b4d37465505bd0eaf4be9befe/llvmlite-0.44.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46224058b13c96af1365290bdfebe9a6264ae62fb79b2b55693deed11657a8bf", size = 42361904 },
-    { url = "https://files.pythonhosted.org/packages/d8/e1/12c5f20cb9168fb3464a34310411d5ad86e4163c8ff2d14a2b57e5cc6bac/llvmlite-0.44.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0097052c32bf721a4efc03bd109d335dfa57d9bffb3d4c24cc680711b8b4fc", size = 41184245 },
-    { url = "https://files.pythonhosted.org/packages/d0/81/e66fc86539293282fd9cb7c9417438e897f369e79ffb62e1ae5e5154d4dd/llvmlite-0.44.0-cp313-cp313-win_amd64.whl", hash = "sha256:2fb7c4f2fb86cbae6dca3db9ab203eeea0e22d73b99bc2341cdf9de93612e930", size = 30331193 },
 ]
 
 [[package]]
@@ -2022,33 +1995,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307 },
-]
-
-[[package]]
-name = "numba"
-version = "0.61.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llvmlite" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/88/c13a935f200fda51384411e49840a8e7f70c9cb1ee8d809dd0f2477cf7ef/numba-0.61.0.tar.gz", hash = "sha256:888d2e89b8160899e19591467e8fdd4970e07606e1fbc248f239c89818d5f925", size = 2816484 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/8f/f983a7c859ccad73d3cc3f86fbba94f16e137cd1ee464631d61b624363b2/numba-0.61.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:bf64c2d0f3d161af603de3825172fb83c2600bcb1d53ae8ea568d4c53ba6ac08", size = 2768960 },
-    { url = "https://files.pythonhosted.org/packages/be/1b/c33dc847d475d5b647b4ad5aefc38df7a72283763f4cda47745050375a81/numba-0.61.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:de5aa7904741425f28e1028b85850b31f0a245e9eb4f7c38507fb893283a066c", size = 2771862 },
-    { url = "https://files.pythonhosted.org/packages/14/91/18b9f64b34ff318a14d072251480547f89ebfb864b2b7168e5dc5f64f502/numba-0.61.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21c2fe25019267a608e2710a6a947f557486b4b0478b02e45a81cf606a05a7d4", size = 3825411 },
-    { url = "https://files.pythonhosted.org/packages/f2/97/1a38030c2a331e273ace1de2b61988e33d80878fda8a5eedee0cd78399d3/numba-0.61.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:74250b26ed6a1428763e774dc5b2d4e70d93f73795635b5412b8346a4d054574", size = 3519604 },
-    { url = "https://files.pythonhosted.org/packages/df/a7/56f547de8fc197963f238fd62beb5f1d2cace047602d0577956bf6840970/numba-0.61.0-cp311-cp311-win_amd64.whl", hash = "sha256:b72bbc8708e98b3741ad0c63f9929c47b623cc4ee86e17030a4f3e301e8401ac", size = 2827642 },
-    { url = "https://files.pythonhosted.org/packages/63/c9/c61881e7f2e253e745209f078bbd428ce23b6cf901f7d93afe166720ff95/numba-0.61.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:152146ecdbb8d8176f294e9f755411e6f270103a11c3ff50cecc413f794e52c8", size = 2769758 },
-    { url = "https://files.pythonhosted.org/packages/e1/28/ddec0147a4933f86ceaca580aa9bb767d5632ecdb1ece6cfb3eab4ac78e5/numba-0.61.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5cafa6095716fcb081618c28a8d27bf7c001e09696f595b41836dec114be2905", size = 2772445 },
-    { url = "https://files.pythonhosted.org/packages/18/74/6a9f0e6c76c088f8a6aa702eab31734068061dca5cc0f34e8bc1eb447de1/numba-0.61.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ffe9fe373ed30638d6e20a0269f817b2c75d447141f55a675bfcf2d1fe2e87fb", size = 3882115 },
-    { url = "https://files.pythonhosted.org/packages/53/68/d7c31e53f08e6b4669c9b5a3cd7c5fb9097220c5ef388bc099ca8ab9749f/numba-0.61.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9f25f7fef0206d55c1cfb796ad833cbbc044e2884751e56e798351280038484c", size = 3573296 },
-    { url = "https://files.pythonhosted.org/packages/94/4f/8357a99a14f331b865a42cb4756ae37da85599b9c95e01277ea10361e91a/numba-0.61.0-cp312-cp312-win_amd64.whl", hash = "sha256:550d389573bc3b895e1ccb18289feea11d937011de4d278b09dc7ed585d1cdcb", size = 2828077 },
-    { url = "https://files.pythonhosted.org/packages/3b/54/71fba18e4af5619f1ea8175ee92e82dd8e220bd6feb8c0153c6b814c8a60/numba-0.61.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:b96fafbdcf6f69b69855273e988696aae4974115a815f6818fef4af7afa1f6b8", size = 2768024 },
-    { url = "https://files.pythonhosted.org/packages/39/76/2448b43d08e904aad1b1b9cd12835b19411e84a81aa9192f83642a5e0afd/numba-0.61.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f6c452dca1de8e60e593f7066df052dd8da09b243566ecd26d2b796e5d3087d", size = 2769541 },
-    { url = "https://files.pythonhosted.org/packages/32/8f/4bb2374247ab988c9eac587b304b2947a36d605b9bb9ba4bf06e955c17d3/numba-0.61.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44240e694d4aa321430c97b21453e46014fe6c7b8b7d932afa7f6a88cc5d7e5e", size = 3890102 },
-    { url = "https://files.pythonhosted.org/packages/ab/bc/dc2d03555289ae5263f65c01d45eb186ce347585c191daf0e60021d5ed39/numba-0.61.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:764f0e47004f126f58c3b28e0a02374c420a9d15157b90806d68590f5c20cc89", size = 3580239 },
-    { url = "https://files.pythonhosted.org/packages/61/08/71247ce560d2c222d9ca705c7d3547fc4069b96fc85d71aabeb890befe9f/numba-0.61.0-cp313-cp313-win_amd64.whl", hash = "sha256:074cd38c5b1f9c65a4319d1f3928165f48975ef0537ad43385b2bd908e6e2e35", size = 2828035 },
 ]
 
 [[package]]


### PR DESCRIPTION
This rewrites FunkSVD in Rust instead of Numba, and removes our Numba dependency.

Closes #719.