### PR TITLE
Correctly detect no-genre movies in MovieLens

### DIFF
--- a/docs/releases/2025.rst
+++ b/docs/releases/2025.rst
@@ -27,6 +27,7 @@ information on how to upgrade your code.
     reliably handle CSR matrix data in Arrow (previously, we had to carry the
     matrix width or row dimension in side information; it is now embedded into
     the Arrow metadata).
+-   Fix MovieLens import to detect movies without genres (:issue:`727`, :pr:`738`).
 
 Component Changes
 .................

--- a/src/lenskit/data/movielens.py
+++ b/src/lenskit/data/movielens.py
@@ -196,7 +196,9 @@ class MLMLoader(MLData):
 
         dsb.add_entities("item", movies["item_id"])
         dsb.add_scalar_attribute("item", "title", movies["item_id"], movies["title"])
+        genre_strings = movies["genres"]
         genres = movies["genres"].str.split("|", regex=False)
+        genres[genre_strings == "(no genres listed)"] = []
         dsb.add_list_attribute("item", "genres", movies["item_id"], genres, dictionary=True)
 
         ratings = self.ratings_df()

--- a/src/lenskit/data/movielens.py
+++ b/src/lenskit/data/movielens.py
@@ -198,7 +198,7 @@ class MLMLoader(MLData):
         dsb.add_scalar_attribute("item", "title", movies["item_id"], movies["title"])
         genre_strings = movies["genres"]
         genres = movies["genres"].str.split("|", regex=False)
-        genres[genre_strings == "(no genres listed)"] = []
+        genres[genre_strings == "(no genres listed)"] = None
         dsb.add_list_attribute("item", "genres", movies["item_id"], genres, dictionary=True)
 
         ratings = self.ratings_df()
@@ -334,7 +334,7 @@ class MLModernLoader(MLData):
         dsb.add_scalar_attribute("item", "title", movies["item_id"], movies["title"])
         genre_strings = movies["genres"]
         genres = movies["genres"].str.split("|", regex=False)
-        genres[genre_strings == "(no genres listed)"] = []
+        genres[genre_strings == "(no genres listed)"] = None
         dsb.add_list_attribute("item", "genres", movies["item_id"], genres)
 
         ratings = self.ratings_df()

--- a/src/lenskit/data/movielens.py
+++ b/src/lenskit/data/movielens.py
@@ -330,7 +330,9 @@ class MLModernLoader(MLData):
 
         dsb.add_entities("item", movies["item_id"])
         dsb.add_scalar_attribute("item", "title", movies["item_id"], movies["title"])
+        genre_strings = movies["genres"]
         genres = movies["genres"].str.split("|", regex=False)
+        genres[genre_strings == "(no genres listed)"] = []
         dsb.add_list_attribute("item", "genres", movies["item_id"], genres)
 
         ratings = self.ratings_df()

--- a/tests/data/test_load_movielens.py
+++ b/tests/data/test_load_movielens.py
@@ -40,6 +40,9 @@ def test_latest_small_dir():
     # Cry, The Beloved Country is drama
     assert genres.loc[40] == ["Drama"]
 
+    # Victoria has no genres
+    assert genres.loc[128620] == []
+
     assert "tag_counts" in ds.entities("item").attributes
     tags = ds.entities("item").attribute("tag_counts")
     assert tags.is_sparse


### PR DESCRIPTION
This updates MovieLens to detect no-genre movies and record them with empty genre lists.

Closes #727.