### PR TITLE
Add tests to avoid overflow in softmax stochastic sampling

### DIFF
--- a/src/lenskit/stats.py
+++ b/src/lenskit/stats.py
@@ -15,6 +15,7 @@ import warnings
 import numpy as np
 from numpy.typing import ArrayLike
 
+from lenskit.data.types import NPVector
 from lenskit.diagnostics import DataWarning
 
 
@@ -61,7 +62,7 @@ def gini(xs: ArrayLike) -> float:
     return max(num / denom, 0)
 
 
-def argtopn(xs: ArrayLike, n: int) -> np.ndarray[int, np.dtype[np.int64]]:
+def argtopn(xs: ArrayLike, n: int) -> NPVector[np.int64]:
     """
     Compute the ordered positions of the top *n* elements.  Similar to
     :func:`torch.topk`, but works with NumPy arrays and only returns the

--- a/tests/stochastic/test_stochastic_ranker.py
+++ b/tests/stochastic/test_stochastic_ranker.py
@@ -136,6 +136,9 @@ def test_overflow(items: ItemList, scale: float):
     assert scores is not None
     assert np.all(np.isfinite(scores))
 
+    k2 = topn._compute_keys(scores, topn._rng_factory(None))
+    assert np.all(np.isfinite(k2))
+
     try:
         assert isinstance(ranked, ItemList)
         assert len(ranked) == len(items)
@@ -144,9 +147,6 @@ def test_overflow(items: ItemList, scale: float):
         weights = ranked.field("weight")
         assert weights is not None
         assert np.all(np.isfinite(weights))
-
-        k2 = topn._compute_keys(scores, topn._rng_factory(None))
-        assert np.all(np.isfinite(k2))
 
         # the scores match
         rank_s = ranked.scores("pandas", index="ids")

--- a/tests/stochastic/test_stochastic_ranker.py
+++ b/tests/stochastic/test_stochastic_ranker.py
@@ -233,7 +233,7 @@ def test_scale_affects_ranking(rng, ml_ds: Dataset):
     recs = batch.recommend(pipe, split.test, n_jobs=1)
 
     topn = TopNRanker()
-    samp_frac = StochasticTopNRanker(scale=0.1)
+    samp_frac = StochasticTopNRanker(scale=0.01)
     samp_one = StochasticTopNRanker(scale=1)
     samp_hundred = StochasticTopNRanker(scale=100)
 

--- a/tests/stochastic/test_stochastic_ranker.py
+++ b/tests/stochastic/test_stochastic_ranker.py
@@ -134,7 +134,12 @@ def test_runtime_truncation(n, items: ItemList):
     assert np.all(rank_s == src_s)
 
 
-@given(scored_lists(n=st.integers(100, 5000), scores=st.floats(0, 15)), st.floats(0.1, 10000))
+@given(
+    scored_lists(
+        n=st.integers(100, 5000), scores=st.floats(-5, 15, width=32, allow_infinity=False)
+    ),
+    st.floats(0.1, 10000),
+)
 def test_overflow(items: ItemList, scale: float):
     topn = StochasticTopNRanker(transform="softmax", scale=scale)
     ranked = topn(items=items, include_weights=True)


### PR DESCRIPTION
This adds tests for floating-point overflow in the softmax scaling for stochastic sampling.