### PR TITLE
Parallelize item-item scoring

### DIFF
--- a/docs/guide/parallelism.rst
+++ b/docs/guide/parallelism.rst
@@ -10,10 +10,12 @@ variable controlling its:
 
 - :doc:`Batch operations <batch>` using :ref:`multi-process execution
   <parallel-model-ops>`.
-- Parallel model training.  For most models provided by LensKit, this is
-  implemented either using PyTorch JIT parallelism (:func:`torch.jit.fork`) or
-  using Rayon in the Rust extension module.
-- Parallel computation in the various backends (BLAS, MKL, Torch, etc.).
+- Parallel model training.  For most models provided by LensKit, such
+  parallelism uses Rayon in the Rust extension module or PyTorch JIT parallelism
+  (:func:`torch.jit.fork`) in Python code.
+- Parallel inference, using Rayon in the Rust extension module.
+- Parallel computation in the various backends (BLAS, MKL, Torch, etc.), for
+  both training and inference.
 
 .. _parallel-config:
 
@@ -36,12 +38,17 @@ The environment variables and their defaults are:
 
 .. envvar:: LK_NUM_THREADS
 
-    The number of threads to use for parallel model building.  Defaults to the
-    number of CPUs or 8, whichever is smaller.
+    The number of threads to use for LensKit's explicit parallelism (model
+    building and inference).  Defaults to the number of CPUs or 8, whichever is
+    smaller.
 
     This number is passed to :func:`torch.set_num_interop_threads` to set up the
     Torch JIT thread count, and is used to configure the Rayon thread pool used
     by the Rust acceleration module.
+
+    .. note::
+
+        Only the k-NN models currently use this at inference time.
 
 .. envvar:: LK_NUM_BACKEND_THREADS
 
@@ -108,6 +115,13 @@ PyTorch tensors, including those on CUDA devices, are shared.
 LensKit users will generally not need to directly use parallel op invokers, but
 if you are implementing new batch operations with parallelism they are useful.
 They may also be useful for other kinds of analysis.
+
+.. note::
+
+    Client code generally does not need to directly use this facility.  We are
+    also exploring deprecating the internal parallelism support in favor of Ray_.
+
+.. _Ray: https://docs.ray.io
 
 Debugging Parallelism and Performance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/accel/atomic.rs
+++ b/src/accel/atomic.rs
@@ -1,0 +1,106 @@
+// This file is part of LensKit.
+// Copyright (C) 2018-2023 Boise State University.
+// Copyright (C) 2023-2025 Drexel University.
+// Licensed under the MIT license, see LICENSE.md for details.
+// SPDX-License-Identifier: MIT
+
+//! Atomic utilities
+
+use std::{
+    hint::spin_loop,
+    mem, ptr,
+    sync::atomic::{AtomicPtr, Ordering},
+};
+
+/// A cell supporting atomic mutation with spin locks for waiters.
+///
+/// This uses spin loops on atomic pointers instead of full OS-level mutexes, so
+/// we can create a lot of these without incurring the overhead of going to
+/// pthreads.
+#[repr(transparent)]
+pub struct AtomicCell<T: Send + Sync> {
+    pointer: AtomicPtr<T>,
+}
+
+impl<T: Send + Sync> AtomicCell<T> {
+    /// Construct a new atomic cell.
+    pub fn new(value: T) -> Self {
+        let ptr = Box::leak(Box::new(value));
+        AtomicCell {
+            pointer: AtomicPtr::new(ptr),
+        }
+    }
+
+    /// Create a new vector of atomic cells.
+    pub fn new_vec<S: IntoIterator<Item = T>>(src: S) -> Vec<AtomicCell<T>> {
+        src.into_iter().map(AtomicCell::new).collect()
+    }
+
+    /// Mutate the cell.
+    pub fn update<R, F: FnMut(&mut T) -> R>(&self, mut func: F) -> R {
+        let ptr = self.acquire();
+        let tref = unsafe { &mut *ptr };
+        let res = func(tref);
+        self.assign(ptr);
+        res
+    }
+
+    /// Acquire the pointer.
+    fn acquire(&self) -> *mut T {
+        loop {
+            // load the pointer
+            let ptr = self.pointer.load(Ordering::Relaxed);
+            if !ptr.is_null() {
+                // the cell is live, try to take the lock (null the cell)
+                let null = ptr::null_mut::<T>();
+                if let Ok(_) = self.pointer.compare_exchange_weak(
+                    ptr,
+                    null,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    // we successfully took the lock, return the pointer
+                    return ptr;
+                }
+            }
+            // we failed to take the lock, loop and try again
+            spin_loop();
+        }
+    }
+
+    /// Set the pointer.
+    fn assign(&self, ptr: *mut T) {
+        // just make sure we aren't locked
+        let cur = self.pointer.load(Ordering::Relaxed);
+        assert!(cur.is_null());
+        if let Ok(_) = self
+            .pointer
+            .compare_exchange(cur, ptr, Ordering::Relaxed, Ordering::Relaxed)
+        {
+            return;
+        } else {
+            panic!("another thread wrote while we have the lock");
+        }
+    }
+}
+
+impl<T: Default + Send + Sync> AtomicCell<T> {
+    pub fn unwrap_vec<S: IntoIterator<Item = AtomicCell<T>>>(src: S) -> Vec<T> {
+        src.into_iter()
+            .map(|c| {
+                let ptr = c.acquire();
+                let obj = unsafe { &mut *ptr };
+                mem::take(obj)
+            })
+            .collect()
+    }
+}
+
+impl<T: Send + Sync> Drop for AtomicCell<T> {
+    fn drop(&mut self) {
+        let ptr = self.pointer.get_mut();
+        if !ptr.is_null() {
+            let _ = unsafe { Box::from_raw(ptr) };
+        }
+    }
+}

--- a/src/accel/knn/accum.rs
+++ b/src/accel/knn/accum.rs
@@ -20,6 +20,12 @@ pub(super) enum ScoreAccumulator<T> {
     Full(BinaryHeap<AccEntry<T>>),
 }
 
+impl<T> Default for ScoreAccumulator<T> {
+    fn default() -> Self {
+        Self::Disabled
+    }
+}
+
 impl ScoreAccumulator<()> {
     pub fn add_weight(&mut self, limit: usize, weight: f32) -> PyResult<()> {
         self.add_value(limit, weight, ())

--- a/src/accel/knn/item_score.rs
+++ b/src/accel/knn/item_score.rs
@@ -8,9 +8,11 @@ use arrow::{
     array::{make_array, Array, ArrayData, Float32Array, Int32Array},
     pyarrow::PyArrowType,
 };
-use pyo3::{exceptions::PyValueError, prelude::*};
+use pyo3::prelude::*;
+use rayon::prelude::*;
 
 use crate::{
+    atomic::AtomicCell,
     knn::accum::{collect_items_averaged, collect_items_summed},
     sparse::{CSRMatrix, CSR},
     types::checked_array_ref,
@@ -36,30 +38,33 @@ pub fn score_explicit<'py>(
         let tgt_items = make_array(tgt_items.0);
 
         let ref_is: &Int32Array = checked_array_ref("reference item", "Int32", &ref_items)?;
+        let ref_islice = ref_is.values();
         let ref_vs: &Float32Array = checked_array_ref("reference ratings", "Float32", &ref_rates)?;
+        let ref_vslice = ref_vs.values();
         let tgt_is: &Int32Array = checked_array_ref("target item", "Int32", &tgt_items)?;
 
-        let mut heaps = ScoreAccumulator::new_array(sims.n_cols, tgt_is);
+        let heaps = AtomicCell::new_vec(ScoreAccumulator::new_array(sims.n_cols, tgt_is));
 
         // we loop reference items, looking for targets.
         // in the common (slow) top-N case, reference items are shorter than targets.
-        for (ri, rv) in ref_is.iter().zip(ref_vs.iter()) {
-            if let Some(ri) = ri {
-                let rv = rv.ok_or_else(|| PyValueError::new_err("reference rating is null"))?;
+        let iter = ref_islice.into_par_iter().zip(ref_vslice.into_par_iter());
+        iter.try_for_each(|(ri, rv)| {
+            let ri = *ri as usize;
+            let rv = *rv;
+            let (sp, ep) = sims.extent(ri);
+            for i in sp..ep {
+                let i = i as usize;
+                let ti = sims.col_inds.value(i);
+                let sim = sims.values.value(i);
 
-                let (sp, ep) = sims.extent(ri as usize);
-                for i in sp..ep {
-                    let i = i as usize;
-                    let ti = sims.col_inds.value(i);
-                    let sim = sims.values.value(i);
-
-                    // get the heap, initializing if needed.
-                    let acc = &mut heaps[ti as usize];
-                    acc.add_value(max_nbrs, sim, rv)?;
-                }
+                // get the heap, initializing if needed.
+                let cell = &heaps[ti as usize];
+                cell.update(|acc| acc.add_value(max_nbrs, sim, rv))?;
             }
-        }
+            Ok::<_, PyErr>(())
+        })?;
 
+        let heaps = AtomicCell::unwrap_vec(heaps);
         let out = collect_items_averaged(&heaps, tgt_is, min_nbrs);
         assert_eq!(out.len(), tgt_is.len());
 
@@ -83,27 +88,29 @@ pub fn score_implicit<'py>(
         let tgt_items = make_array(tgt_items.0);
 
         let ref_is: &Int32Array = checked_array_ref("reference item", "Int32", &ref_items)?;
+        let ref_islice = ref_is.values();
         let tgt_is: &Int32Array = checked_array_ref("target item", "Int32", &tgt_items)?;
 
-        let mut heaps = ScoreAccumulator::new_array(sims.n_cols, tgt_is);
+        let heaps = AtomicCell::new_vec(ScoreAccumulator::new_array(sims.n_cols, tgt_is));
 
         // we loop reference items, looking for targets.
         // in the common (slow) top-N case, reference items are shorter than targets.
-        for ref_item in ref_is {
-            if let Some(ri) = ref_item {
-                let (sp, ep) = sims.extent(ri as usize);
-                for i in sp..ep {
-                    let i = i as usize;
-                    let ti = sims.col_inds.value(i);
-                    let sim = sims.values.value(i);
+        ref_islice.into_par_iter().try_for_each(|ri| {
+            let ri = *ri as usize;
+            let (sp, ep) = sims.extent(ri);
+            for i in sp..ep {
+                let i = i as usize;
+                let ti = sims.col_inds.value(i);
+                let sim = sims.values.value(i);
 
-                    // get the heap, initializing if needed.
-                    let acc = &mut heaps[ti as usize];
-                    acc.add_weight(max_nbrs, sim)?;
-                }
+                // get the heap, initializing if needed.
+                let cell = &heaps[ti as usize];
+                cell.update(|acc| acc.add_weight(max_nbrs, sim))?;
             }
-        }
+            Ok::<_, PyErr>(())
+        })?;
 
+        let heaps = AtomicCell::unwrap_vec(heaps);
         let out = collect_items_summed(&heaps, &tgt_is, min_nbrs);
         assert_eq!(out.len(), tgt_is.len());
 

--- a/src/accel/lib.rs
+++ b/src/accel/lib.rs
@@ -9,6 +9,7 @@ use pyo3::prelude::*;
 use rayon::ThreadPoolBuilder;
 
 mod als;
+mod atomic;
 mod data;
 mod funksvd;
 mod knn;

--- a/src/lenskit/knn/item.py
+++ b/src/lenskit/knn/item.py
@@ -218,6 +218,8 @@ class ItemKNNScorer(Component[ItemList], Trainable):
 
     @override
     def __call__(self, query: QueryInput, items: ItemList) -> ItemList:
+        ensure_parallel_init()
+
         query = RecQuery.create(query)
         log = _log.bind(user_id=query.user_id, n_items=len(items))
         trace(log, "beginning prediction")


### PR DESCRIPTION
This uses Rayon to parallelize item-item scoring, and updates some parallelism configuration and documentation to use it.