### PR TITLE
Test and fix crash on Linux ARM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.13"
         platform:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-latest
           - windows-latest
         exclude:

--- a/tasks.py
+++ b/tasks.py
@@ -224,7 +224,6 @@ def update_headers(
 
 @task
 def clean(c: Context):
-    print(c.config)
     for od in ["build", "dist", "output", "target"]:
         odp = root / od
         if odp.exists():
@@ -236,6 +235,13 @@ def clean(c: Context):
         print(f"🚮 removing {glob}")
         for file in root.glob(glob):
             _log.info("removing %s", file)
+            if not c.config.run.dry:
+                file.unlink()
+
+    pkg = root / "src" / "lenskit"
+    for file in pkg.glob("_accel*"):
+        if file.name != "_accel.pyi":
+            print(f"🚮 removing {file}")
             if not c.config.run.dry:
                 file.unlink()
 


### PR DESCRIPTION
This enables the test suite with vanilla Python on Linux ARM, and fixes a crash in the item k-NN accelerator due to incorrect atomic ordering.