### PR TITLE
Update ALS solve to zero rows for no-info users/items

### DIFF
--- a/src/accel/als/explicit.rs
+++ b/src/accel/als/explicit.rs
@@ -98,7 +98,7 @@ fn train_row_solve(
     let soln = if let Some(cholesky) = mtm.view((0, 0), (nd, nd)).cholesky() {
         cholesky.solve(&v)
     } else {
-        mtm.lu().solve(&v).expect("matrix is singular")
+        mtm.lu().solve(&v).expect("matrix is non-invertible")
     };
 
     let soln = soln.into_ndarray1();

--- a/src/accel/als/explicit.rs
+++ b/src/accel/als/explicit.rs
@@ -70,7 +70,7 @@ fn train_row_solve(
     let cols = matrix.row_cols(row_num);
     let vals = matrix.row_vals(row_num);
 
-    if cols.len() == 0 {
+    if cols.len() == 0 || vals.iter().all(|v| v.abs() < 1.0e-12) {
         row_data.fill(0.0);
         return 0.0;
     }
@@ -94,7 +94,10 @@ fn train_row_solve(
 
     let mtm = mtm.into_nalgebra();
     let v = v.into_nalgebra();
-    let cholesky = mtm.cholesky().expect("matrix is not positive definite");
+    let cholesky = mtm.cholesky().expect(&format!(
+        "matrix is not positive definite ({} cols)",
+        cols.len()
+    ));
 
     let soln = cholesky.solve(&v);
     let soln = soln.into_ndarray1();

--- a/src/accel/als/explicit.rs
+++ b/src/accel/als/explicit.rs
@@ -71,6 +71,7 @@ fn train_row_solve(
     let vals = matrix.row_vals(row_num);
 
     if cols.len() == 0 {
+        row_data.fill(0.0);
         return 0.0;
     }
 

--- a/src/accel/als/implicit.rs
+++ b/src/accel/als/implicit.rs
@@ -73,6 +73,7 @@ fn train_row_solve(
     let vals = matrix.row_vals(row_num);
 
     if cols.len() == 0 {
+        row_data.fill(0.0);
         return 0.0;
     }
 


### PR DESCRIPTION
Two improvements:

- Zero out rows on solve when the row's data is empty. This was done in the old code, but got lost in Rust upgrade.
- Fall back to LU decomposition when Cholesky decomposition fails in BiasedMF; in some cases, the matrices were not positive definite.