### PR TITLE
Speed up weighted metrics

### DIFF
--- a/src/lenskit/data/items.py
+++ b/src/lenskit/data/items.py
@@ -608,15 +608,17 @@ class ItemList:
             nums = nums[nums >= 0]
             mask[nums] = True
             result = mask[self.numbers()]
-        elif self._ids_numpy is not None and pa.types.is_integer(self._ids.type):
-            result = np.isin(self._ids_numpy, other.ids())
         else:
-            try:
-                result = pc.is_in(self.ids(format="arrow"), other.ids(format="arrow")).to_numpy(
-                    zero_copy_only=False
-                )
-            except pa.ArrowTypeError:
-                result = np.zeros(len(self), dtype=np.bool_)
+            id_arr = self.ids(format="arrow")
+            if pa.types.is_integer(id_arr.type):
+                result = np.isin(id_arr.to_numpy(), other.ids())
+            else:
+                try:
+                    result = pc.is_in(self.ids(format="arrow"), other.ids(format="arrow")).to_numpy(
+                        zero_copy_only=False
+                    )
+                except pa.ArrowTypeError:
+                    result = np.zeros(len(self), dtype=np.bool_)
 
         self._mask_cache = (other, result)
         return result

--- a/src/lenskit/data/items.py
+++ b/src/lenskit/data/items.py
@@ -525,6 +525,8 @@ class ItemList:
     @overload
     def ranks(self, format: Literal["arrow"]) -> pa.Array[pa.Int32Scalar] | None: ...
     @overload
+    def ranks(self, format: Literal["pandas"]) -> pd.Series[int] | None: ...
+    @overload
     def ranks(self, format: LiteralString = "numpy") -> ArrayLike | None: ...
     def ranks(self, format: LiteralString = "numpy") -> ArrayLike | None:
         """
@@ -544,7 +546,11 @@ class ItemList:
         if self._ranks is None:
             self._ranks = MTArray(np.arange(1, self._len + 1, dtype=np.int32))
 
-        return self._ranks.to(format)
+        if format == "pandas":
+            ranks = self._ranks.to("numpy")
+            return pd.Series(ranks, index=self.ids())
+        else:
+            return self._ranks.to(format)
 
     @overload
     def field(

--- a/src/lenskit/data/items.py
+++ b/src/lenskit/data/items.py
@@ -601,10 +601,10 @@ class ItemList:
         if self._mask_cache is not None and self._mask_cache[0] is other:
             return self._mask_cache[1]
 
-        # fast path — use a mask
-        if self.vocabulary is not None and self.vocabulary == other.vocabulary:
+        # fast path — try to just use a mask
+        if self.vocabulary is not None:
             mask = np.zeros(len(self.vocabulary), dtype=np.bool_)
-            mask[other.numbers()] = True
+            mask[other.numbers(vocabulary=self.vocabulary)] = True
             result = mask[self.numbers()]
         elif self._ids_numpy is not None and pa.types.is_integer(self._ids.type):
             result = np.isin(self._ids_numpy, other.ids())

--- a/src/lenskit/data/items.py
+++ b/src/lenskit/data/items.py
@@ -604,7 +604,9 @@ class ItemList:
         # fast path — try to just use a mask
         if self.vocabulary is not None:
             mask = np.zeros(len(self.vocabulary), dtype=np.bool_)
-            mask[other.numbers(vocabulary=self.vocabulary)] = True
+            nums = other.numbers(vocabulary=self.vocabulary, missing="negative")
+            nums = nums[nums >= 0]
+            mask[nums] = True
             result = mask[self.numbers()]
         elif self._ids_numpy is not None and pa.types.is_integer(self._ids.type):
             result = np.isin(self._ids_numpy, other.ids())

--- a/src/lenskit/flexmf/_base.py
+++ b/src/lenskit/flexmf/_base.py
@@ -144,7 +144,8 @@ class FlexMFScorerBase(UsesTrainer, Component):
             scores = self.score_items(u_tensor, i_tensor)
 
         # fill in scores for scorable items
-        full_scores[scorable_mask] = scores.cpu()
+        scores = scores.cpu()
+        full_scores[scorable_mask] = scores
 
         # return the result!
         return ItemList(items, scores=full_scores)

--- a/src/lenskit/metrics/ranking/_rbp.py
+++ b/src/lenskit/metrics/ranking/_rbp.py
@@ -104,8 +104,16 @@ class RBP(ListMetric, RankingMetricBase):
             return np.nan
 
         good = recs.isin(test)
-        weight = self.weight.weight(np.arange(1, k + 1))
-        rbp = np.sum(weight[good]).item()
+
+        ranks = recs.ranks()
+        assert ranks is not None
+
+        # we only need to sum good weights
+        good_ranks = ranks[good]
+        weight = self.weight.weight(good_ranks)
+        rbp = np.sum(weight).item()
+
+        # figure out normalization
         wmax = self.weight.series_sum()
         if self.normalize:
             # normalize by max achieveable RBP
@@ -116,4 +124,5 @@ class RBP(ListMetric, RankingMetricBase):
             return rbp / wmax
         else:
             # normalize by total weight
-            return rbp / np.sum(weight).item()
+            all_weight = self.weight.weight(ranks)
+            return rbp / np.sum(all_weight).item()

--- a/tests/eval/test_rank_dcg.py
+++ b/tests/eval/test_rank_dcg.py
@@ -15,6 +15,51 @@ from lenskit.metrics.ranking import DCG
 from lenskit.metrics.ranking._dcg import array_dcg, fixed_dcg
 
 
+@mark.parametrize("method", ["graded", "binary"])
+def test_array_dcg_empty(method):
+    "empty should be zero"
+    assert array_dcg(np.array([]), graded=method == "graded") == approx(0)
+
+
+@mark.parametrize("method", ["graded", "binary"])
+def test_array_dcg_zeros(method):
+    assert array_dcg(np.zeros(10), graded=method == "graded") == approx(0)
+
+
+@mark.parametrize("method", ["graded", "binary"])
+def test_array_dcg_single(method):
+    "a single element should be scored at the right place"
+    val = 0.5 if method == "graded" else 1.0
+    assert array_dcg(np.array([0.5]), graded=method == "graded") == approx(val)
+    assert array_dcg(np.array([0, 0.5]), graded=method == "graded") == approx(val)
+    assert array_dcg(np.array([0, 0, 0.5]), graded=method == "graded") == approx(val / np.log2(3))
+    assert array_dcg(np.array([0, 0, 0.5, 0]), graded=method == "graded") == approx(
+        val / np.log2(3)
+    )
+
+
+def test_array_dcg_mult():
+    "multiple elements should score correctly"
+    assert array_dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)
+    assert array_dcg(np.array([np.e, 0, 0, np.pi])) == approx(np.e + np.pi / np.log2(4))
+
+
+@mark.parametrize("method", ["graded", "binary"])
+def test_array_dcg_empty2(method):
+    "empty should be zero"
+    assert array_dcg(np.array([]), graded=method == "graded") == approx(0)
+
+
+@mark.parametrize("method", ["graded", "binary"])
+def test_array_dcg_zeros2(method):
+    assert array_dcg(np.zeros(10), graded=method == "graded") == approx(0)
+
+
+def test_array_dcg_nan():
+    "NANs should be 0"
+    assert array_dcg(np.array([np.nan, 0.5])) == approx(0.5)
+
+
 def test_dcg_empty():
     recs = ItemList(ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])

--- a/tests/eval/test_rank_dcg.py
+++ b/tests/eval/test_rank_dcg.py
@@ -16,82 +16,31 @@ from lenskit.metrics.ranking._dcg import array_dcg, fixed_dcg
 
 
 def test_dcg_empty():
-    "empty should be zero"
-    assert array_dcg(np.array([])) == approx(0)
-
-
-def test_dcg_zeros():
-    assert array_dcg(np.zeros(10)) == approx(0)
-
-
-def test_dcg_single():
-    "a single element should be scored at the right place"
-    assert array_dcg(np.array([0.5])) == approx(0.5)
-    assert array_dcg(np.array([0, 0.5])) == approx(0.5)
-    assert array_dcg(np.array([0, 0, 0.5])) == approx(0.5 / np.log2(3))
-    assert array_dcg(np.array([0, 0, 0.5, 0])) == approx(0.5 / np.log2(3))
-
-
-def test_dcg_mult():
-    "multiple elements should score correctly"
-    assert array_dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)
-    assert array_dcg(np.array([np.e, 0, 0, np.pi])) == approx(np.e + np.pi / np.log2(4))
-
-
-def test_dcg_empty2():
-    "empty should be zero"
-    assert array_dcg(np.array([])) == approx(0)
-
-
-def test_dcg_zeros2():
-    assert array_dcg(np.zeros(10)) == approx(0)
-
-
-def test_dcg_single2():
-    "a single element should be scored at the right place"
-    assert array_dcg(np.array([0.5])) == approx(0.5)
-    assert array_dcg(np.array([0, 0.5])) == approx(0.5)
-    assert array_dcg(np.array([0, 0, 0.5])) == approx(0.5 / np.log2(3))
-    assert array_dcg(np.array([0, 0, 0.5, 0])) == approx(0.5 / np.log2(3))
-
-
-def test_dcg_nan():
-    "NANs should be 0"
-    assert array_dcg(np.array([np.nan, 0.5])) == approx(0.5)
-
-
-def test_dcg_mult2():
-    "multiple elements should score correctly"
-    assert array_dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)
-    assert array_dcg(np.array([np.e, 0, 0, np.pi])) == approx((np.e + np.pi / np.log2(4)))
-
-
-def test_ndcg_empty():
     recs = ItemList(ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     assert call_metric(DCG, recs, truth) == approx(0.0)
 
 
-def test_ndcg_no_match():
+def test_dcg_no_match():
     recs = ItemList([4], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     assert call_metric(DCG, recs, truth) == approx(0.0)
 
 
-def test_ndcg_perfect():
+def test_dcg_perfect():
     recs = ItemList([2, 3, 1], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     assert call_metric(DCG, recs, truth) == approx(np.sum(np.reciprocal(np.log2([2, 2, 3]))))
 
 
-def test_ndcg_perfect_k_short():
+def test_dcg_perfect_k_short():
     recs = ItemList([2, 3, 1], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     assert call_metric(DCG, recs, truth, k=2) == approx(2.0)
     assert call_metric(DCG, recs[:2], truth, k=2) == approx(2.0)
 
 
-def test_ndcg_shorter_not_best():
+def test_dcg_shorter_not_best():
     recs = ItemList([1, 2], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     assert call_metric(DCG, recs, truth) == approx(fixed_dcg(2))
@@ -99,19 +48,19 @@ def test_ndcg_shorter_not_best():
     assert call_metric(DCG, recs, truth, gain="rating") == approx(array_dcg(np.array([3.0, 5.0])))
 
 
-def test_ndcg_perfect_k():
+def test_dcg_perfect_k():
     recs = ItemList([2, 3], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     assert call_metric(DCG, recs, truth, k=2) == approx(2.0)
 
 
-def test_ndcg_perfect_k_norate():
+def test_dcg_perfect_k_norate():
     recs = ItemList([1, 3], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     assert call_metric(DCG, recs, truth, k=2) == approx(2.0)
 
 
-def test_ndcg_almost_perfect_k_gain():
+def test_dcg_almost_perfect_k_gain():
     recs = ItemList([1, 3], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])
     assert call_metric(DCG, recs, truth, k=2, gain="rating") == approx(

--- a/tests/eval/test_rank_ndcg.py
+++ b/tests/eval/test_rank_ndcg.py
@@ -14,64 +14,8 @@ from pytest import approx, mark
 from lenskit.data import ItemList
 from lenskit.metrics import call_metric
 from lenskit.metrics.ranking import NDCG
-from lenskit.metrics.ranking._dcg import _binary_dcg, _graded_dcg, array_dcg, fixed_dcg
+from lenskit.metrics.ranking._dcg import array_dcg, fixed_dcg
 from lenskit.testing import integer_ids
-
-
-def compute_dcg(arr, graded=True):
-    ids = np.arange(1, len(arr) + 1)
-    recs = ItemList(item_ids=ids, ordered=True)
-
-    mask = arr > 0
-    test = ItemList(item_ids=ids[mask], rating=arr[mask])
-
-    if graded:
-        return _graded_dcg(recs, test, "rating")
-    else:
-        return _binary_dcg(recs, test)
-
-
-@mark.parametrize("method", ["graded", "binary"])
-def test_dcg_empty(method):
-    "empty should be zero"
-    assert compute_dcg(np.array([]), method == "graded") == approx(0)
-
-
-@mark.parametrize("method", ["graded", "binary"])
-def test_dcg_zeros(method):
-    assert compute_dcg(np.zeros(10), method == "graded") == approx(0)
-
-
-@mark.parametrize("method", ["graded", "binary"])
-def test_dcg_single(method):
-    "a single element should be scored at the right place"
-    val = 0.5 if method == "graded" else 1.0
-    assert compute_dcg(np.array([0.5]), method == "graded") == approx(val)
-    assert compute_dcg(np.array([0, 0.5]), method == "graded") == approx(val)
-    assert compute_dcg(np.array([0, 0, 0.5]), method == "graded") == approx(val / np.log2(3))
-    assert compute_dcg(np.array([0, 0, 0.5, 0]), method == "graded") == approx(val / np.log2(3))
-
-
-def test_dcg_mult():
-    "multiple elements should score correctly"
-    assert compute_dcg(np.array([np.e, np.pi])) == approx(np.e + np.pi)
-    assert compute_dcg(np.array([np.e, 0, 0, np.pi])) == approx(np.e + np.pi / np.log2(4))
-
-
-@mark.parametrize("method", ["graded", "binary"])
-def test_dcg_empty2(method):
-    "empty should be zero"
-    assert compute_dcg(np.array([]), method == "graded") == approx(0)
-
-
-@mark.parametrize("method", ["graded", "binary"])
-def test_dcg_zeros2(method):
-    assert compute_dcg(np.zeros(10), method == "graded") == approx(0)
-
-
-def test_dcg_nan():
-    "NANs should be 0"
-    assert compute_dcg(np.array([np.nan, 0.5])) == approx(0.5)
 
 
 def test_ndcg_empty():


### PR DESCRIPTION
This PR refactors weighted metrics to dramatically speed them up, by only computing weights for the items that need to be scored in many cases.