### PR TITLE
Add lenskit data subset command, improve ItemListCollection conversion, and support random seeds in the CLI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,7 +16,7 @@ from hypothesis import settings
 from pytest import fixture, skip
 
 from lenskit.parallel import ensure_parallel_init
-from lenskit.random import set_global_rng
+from lenskit.random import init_global_rng
 
 # bring common fixtures into scope
 from lenskit.testing import ml_100k, ml_ds, ml_ds_unchecked, ml_ratings  # noqa: F401
@@ -53,7 +53,7 @@ def rng() -> Generator:
 @fixture(autouse=True)
 def init_rng(request):
     if RNG_SEED is not None:
-        set_global_rng(RNG_SEED)
+        init_global_rng(RNG_SEED)
 
 
 @fixture(scope="module", params=["cpu", "cuda"])

--- a/src/lenskit/cli/__init__.py
+++ b/src/lenskit/cli/__init__.py
@@ -6,12 +6,14 @@
 
 import sys
 from importlib.metadata import entry_points
+from pathlib import Path
 
 import click
 import numpy as np
 
 from lenskit import __version__
 from lenskit.logging import LoggingConfig, console, get_logger
+from lenskit.random import init_global_rng, load_seed
 
 __all__ = ["lenskit", "main", "version"]
 _log = get_logger(__name__)
@@ -36,8 +38,11 @@ def main():
 
 
 @click.group("lenskit")
-@click.option("-v", "--verbose", "verbosity", count=True, help="enable verbose logging output")
-def lenskit(verbosity: int):
+@click.option("-v", "--verbose", "verbosity", count=True, help="Enable verbose logging output")
+@click.option(
+    "--seed-file", type=Path, metavar="FILE", help="Load random seed from FILE (key: random.seed)"
+)
+def lenskit(verbosity: int, seed_file: Path | None):
     """
     Data and pipeline operations with LensKit.
     """
@@ -47,6 +52,11 @@ def lenskit(verbosity: int):
     if verbosity:
         lc.set_verbose(verbosity)
     lc.apply()
+
+    if seed_file is not None:
+        _log.debug("loading RND seed from %s", seed_file)
+        seed = load_seed(seed_file)
+        init_global_rng(seed)
 
 
 @lenskit.command("version")

--- a/src/lenskit/cli/__init__.py
+++ b/src/lenskit/cli/__init__.py
@@ -40,7 +40,11 @@ def main():
 @click.group("lenskit")
 @click.option("-v", "--verbose", "verbosity", count=True, help="Enable verbose logging output")
 @click.option(
-    "--seed-file", type=Path, metavar="FILE", help="Load random seed from FILE (key: random.seed)"
+    "--seed-file",
+    type=Path,
+    metavar="FILE",
+    help="Load random seed from FILE (key: random.seed)",
+    envvar="LK_SEED_FILE",
 )
 def lenskit(verbosity: int, seed_file: Path | None):
     """
@@ -54,7 +58,7 @@ def lenskit(verbosity: int, seed_file: Path | None):
     lc.apply()
 
     if seed_file is not None:
-        _log.debug("loading RND seed from %s", seed_file)
+        _log.info("loading RND seed from %s", seed_file)
         seed = load_seed(seed_file)
         init_global_rng(seed)
 

--- a/src/lenskit/cli/data/__init__.py
+++ b/src/lenskit/cli/data/__init__.py
@@ -9,6 +9,7 @@ import click
 from .convert import convert
 from .describe import describe
 from .fetch import fetch
+from .subset import subset
 
 
 @click.group
@@ -22,3 +23,4 @@ def data():
 data.add_command(convert)
 data.add_command(describe)
 data.add_command(fetch)
+data.add_command(subset)

--- a/src/lenskit/cli/data/convert.py
+++ b/src/lenskit/cli/data/convert.py
@@ -22,8 +22,8 @@ _log = get_logger(__name__)
 @click.option(
     "--item-lists", is_flag=True, help="Convert to an ItemListCollection instead of Dataset."
 )
-@click.argument("src", nargs=-1, required=True, type=Path)
-@click.argument("dst", type=Path)
+@click.argument("src", type=Path, nargs=-1, required=True)
+@click.argument("dst", type=Path, required=True)
 def convert(format: str | None, src: list[Path], dst: Path, item_lists: bool = False):
     """
     Convert data into the LensKit native format.

--- a/src/lenskit/cli/data/subset.py
+++ b/src/lenskit/cli/data/subset.py
@@ -50,7 +50,7 @@ def subset(
     subsetting operation are entire rows of the interaction matrix, typically
     users.
     """
-    log = _log.bind(src=str(str))
+    log = _log.bind(src=str(src))
 
     dataset: Dataset | None = None
     lists: ItemListCollection
@@ -58,7 +58,7 @@ def subset(
         log.info("loading ItemListCollection")
         lists = ItemListCollection.load_parquet(src)
     else:
-        log.info("loading Dataset")
+        log.debug("loading Dataset")
         dataset = Dataset.load(src)
         log.info("extracting default interactions")
         if len(dataset.schema.relationships) > 1:

--- a/src/lenskit/cli/data/subset.py
+++ b/src/lenskit/cli/data/subset.py
@@ -1,0 +1,102 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+from typing import Literal
+
+import click
+
+from lenskit.data import ItemListCollection
+from lenskit.data.dataset import Dataset
+from lenskit.logging import get_logger
+from lenskit.random import random_generator
+
+_log = get_logger(__name__)
+
+
+@click.command("subset")
+@click.option(
+    "--item-lists", is_flag=True, help="Write an ItemListCollection instead of a Dataset."
+)
+@click.option(
+    "--layout",
+    type=click.Choice(["native", "flat"]),
+    default="native",
+    help="Specify layout for item list output.",
+)
+@click.option(
+    "--sample-rows",
+    type=int,
+    metavar="N",
+    help="Subset to at most N rows of the interaction data",
+)
+@click.argument("src", required=True, type=Path)
+@click.argument("dst", required=True, type=Path)
+def subset(
+    src: Path,
+    dst: Path,
+    sample_rows: int | None,
+    item_lists: bool,
+    layout: Literal["native", "flat"],
+):
+    """
+    Subset a LensKit dataset.
+
+    The input SRC can be either a LensKit native dataset or a Parquet file
+    containing an item list colleciton in native format.  The "rows" in this
+    subsetting operation are entire rows of the interaction matrix, typically
+    users.
+    """
+    log = _log.bind(src=str(str))
+
+    dataset: Dataset | None = None
+    lists: ItemListCollection
+    if src.is_file():
+        log.info("loading ItemListCollection")
+        lists = ItemListCollection.load_parquet(src)
+    else:
+        log.info("loading Dataset")
+        dataset = Dataset.load(src)
+        log.info("extracting default interactions")
+        if len(dataset.schema.relationships) > 1:
+            log.warn("Dataset has multiple relationships, only default interactions are subset")
+
+        # TODO: support non-default interactions / multiple interaction sets
+        lists = dataset.interactions().matrix().to_ilc()
+
+    if sample_rows is not None:
+        lists = _subset_lists(lists, sample_rows)
+
+    log = _log.bind(dst=str(dst))
+    if item_lists:
+        log.info("saving ItemListCollection Parquet in %s layout", layout)
+        lists.save_parquet(dst, layout=layout)
+    else:
+        log.info("saving full dataset")
+        lists.to_dataset().save(dst)
+
+
+def _subset_lists(lists: ItemListCollection, n: int) -> ItemListCollection:
+    """
+    Subset the user lists.
+    """
+    log = _log.bind(n_input=len(lists), n_output=n)
+    if len(lists) <= n:
+        log.warn("input count exceeds target count, keeping all")
+        return lists
+
+    rng = random_generator()
+
+    log.info("subsetting lists")
+    log.debug("picking row indices")
+    rows = rng.choice(len(lists), n, replace=True)
+
+    log.debug("converting to arrow table")
+    table = lists.to_arrow()
+    log.debug("subsetting arrow table")
+    table = table.take(rows)
+    log.debug("converting back to item list collection")
+    return ItemListCollection.from_arrow(table)

--- a/src/lenskit/data/collection/_list.py
+++ b/src/lenskit/data/collection/_list.py
@@ -141,6 +141,22 @@ class ListILC(MutableItemListCollection[K], Generic[K]):
 
         return ilc
 
+    @staticmethod
+    def from_arrow(table: pa.Table) -> MutableItemListCollection[Any]:
+        """
+        Convert an Arrow table into an item list collection.
+        """
+        from ._list import ListILC
+
+        keys = table.drop("items")
+        lists = table.column("items")
+        ilc = ListILC(keys.schema.names)
+        for i, k in enumerate(keys.to_pylist()):
+            il_data = lists[i].values
+            ilc.add(ItemList.from_arrow(il_data), **k)
+
+        return ilc
+
     def add(self, list: ItemList, *fields: ID, **kwfields: ID):
         """
         Add a single item list to this list.

--- a/src/lenskit/data/items.py
+++ b/src/lenskit/data/items.py
@@ -945,7 +945,7 @@ class ItemList:
             # on large arrays, actually faster to do the final filter in NumPy.
             vs = vs.cpu().numpy()
             picked = picked.cpu().numpy()
-            invalid = np.isnan(picked)
+            invalid = np.isnan(vs)
             picked = picked[~invalid]
         else:
             if not isinstance(scores, MTArray):

--- a/src/lenskit/data/relationships.py
+++ b/src/lenskit/data/relationships.py
@@ -35,6 +35,7 @@ from .types import ID, LAYOUT, MAT_AGG
 from .vocab import Vocabulary
 
 if TYPE_CHECKING:
+    from .collection import ItemListCollection
     from .dataset import Dataset
 
 _log = get_logger(__name__)
@@ -558,6 +559,21 @@ class MatrixRelationshipSet(RelationshipSet):
             return None
 
         return ItemList.from_arrow(tbl, vocabulary=self.col_vocabulary)
+
+    def to_ilc(self) -> ItemListCollection:
+        """
+        Get the rows as an item list collection.
+        """
+        from .collection import ListILC
+
+        if self.col_type != "item":
+            raise RuntimeError("row_items() only valid for item-column matrices")
+
+        # FIXME: make this a lot faster with Arrow
+        ilc = ListILC([f"{self.row_type}_id"])
+        for i in range(self.n_rows):
+            ilc.add(self.row_items(number=i), self.row_vocabulary.id(i))
+        return ilc
 
     def row_stats(self):
         if self._row_stats is None:

--- a/tests/cli/test_data_subset.py
+++ b/tests/cli/test_data_subset.py
@@ -1,0 +1,33 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import json
+from os import fspath
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from lenskit.cli import lenskit
+from lenskit.data import Dataset, ItemListCollection
+
+
+def test_data_subset(tmpdir: Path, ml_ds: Dataset):
+    ds_path = tmpdir / "ml-data"
+    ml_ds.save(ds_path)
+
+    out_path = tmpdir / "ml.subset.parquet"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        lenskit,
+        ["data", "subset", "--sample-rows=100", "--item-lists", fspath(ds_path), fspath(out_path)],
+    )
+
+    assert result.exit_code == 0
+    assert out_path.exists()
+
+    items = ItemListCollection.load_parquet(out_path)
+    assert len(items) == 100

--- a/tests/data/test_collection.py
+++ b/tests/data/test_collection.py
@@ -255,6 +255,20 @@ def test_to_arrow():
     assert names == ["item_id", "score"]
 
 
+def test_to_arrow_flat():
+    ilc = ItemListCollection.from_dict(
+        {72: ItemList(["a"], scores=[1]), 82: ItemList(["a", "b", "c"], scores=[3, 4, 10])},
+        key="user_id",
+    )
+    tbl = ilc.to_arrow(layout="flat")
+    print(tbl)
+    assert tbl.num_columns == 3
+    assert tbl.num_rows == 4
+    assert np.all(tbl.column("user_id").to_numpy() == [72, 82, 82, 82])
+    assert np.all(tbl.column("item_id").to_numpy() == ["a", "a", "b", "c"])
+    assert np.all(tbl.column("score").to_numpy() == [1, 3, 4, 10])
+
+
 @mark.parametrize("layout", ["native", "flat"])
 def test_save_parquet(ml_ds: Dataset, tmpdir: Path, layout):
     ilc = ItemListCollection.empty(["user_id"])


### PR DESCRIPTION
This adds the new `lenskit data subset` command. To do that, it also incorporates a couple of other changes:

- Add `lenskit data subset`, with initial support for sampling rows of the interaction matrix.
- Add methods to improve round-trip conversion between item list collections and datasets.
- Add global random seed file support for the LensKit CLI.

Closes #772.