### PR TITLE
Force Python UTF-8 mode for license hader update in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: license-headers
         name: add license headers
         language: python
-        entry: python utils/update-headers.py --error-on-change
+        entry: python -X utf8 utils/update-headers.py --error-on-change
         types_or:
           - python
           - rust


### PR DESCRIPTION
This explicitly puts Python in UTF-8 mode for checking license headers, fixing encoding problems on Windows.

Closes #743.