### PR TITLE
Add component input hooks to the pipeline

### DIFF
--- a/docs/api/pipeline.rst
+++ b/docs/api/pipeline.rst
@@ -54,6 +54,7 @@ Serialized Configurations
     ~lenskit.pipeline.PipelineConfig
 
 Hook Interfaces
+---------------
 
 .. autosummary::
     :toctree: .

--- a/docs/api/pipeline.rst
+++ b/docs/api/pipeline.rst
@@ -52,3 +52,11 @@ Serialized Configurations
     :nosignatures:
 
     ~lenskit.pipeline.PipelineConfig
+
+Hook Interfaces
+
+.. autosummary::
+    :toctree: .
+    :nosignatures:
+
+    ~lenskit.pipeline.ComponentInputHook

--- a/docs/guide/pipeline.rst
+++ b/docs/guide/pipeline.rst
@@ -461,6 +461,57 @@ components.  To do this:
     :meth:`PipelineBuilder.replace_component`.
 3.  Build the modified pipeline with :meth:`PipelineBuilder.build`.
 
+.. _pipeline-hooks:
+
+Pipeline Hooks
+~~~~~~~~~~~~~~
+
+Pipelines support *hooks* to allow client code to inspect or modify their
+behavior. Hooks are also used internally to support things like runtime type
+checking.
+
+.. note::
+
+    As of :ref:`2025.3.0`, only a single hook is supported: ``component-input``
+    run hooks.  Future hooks will be added as there is demand.  If you want
+    a new hook, `file an issue`_ (or send a PR adding it).
+
+.. _file an issue: https://github.com/lenskit/lkpy/issues
+
+.. note::
+
+    Currently (:ref:`2025.3.0`), only functions can reliably be used as hooks.
+    Support for other callable objects is under consideration but has not yet
+    been implemented or tested.
+
+Installing a hook requires three pieces:
+
+-   The hook **name**, which identifies the point in the process to insert the hook.
+-   The hook **function**, which is called when the pipeline reaches that hook
+    point. Each hook point has an associated protocol defining the call
+    signature for that hook.
+-   The hook **priority**, which determines the order in which hooks are called.
+    Hooks are run in ascending priority order, and the priority 0 is reserved
+    for LensKit's internal hooks.
+
+.. _pipeline-run-hooks:
+
+Run Hooks
+---------
+
+Run hooks are called each time the pipeline is run.  They can be configured with
+:meth:`PipelineBuilder.add_run_hook`.
+
+``component-input``
+    A ``component-input`` hook (see
+    :class:`~lenskit.pipeline.ComponentInputHook`) will be called for each
+    *component input*: a data value being supplied to one of the input
+    parameters of a component.  It is called separately for each component
+    input, even if two components have their input wired to the same source
+    node.  This facilitates data inspection, type checking, and other checks or
+    analyses that need to run on each edge of the pipeline graph.
+
+
 POPROX and Other Integrators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/2025.rst
+++ b/docs/releases/2025.rst
@@ -31,6 +31,8 @@ information on how to upgrade your code.
 -   :ref:`parallelism` now supports comma-separated lists for configuring
     parallelism within worker processes, and :envvar:`LK_NUM_CHILD_THREADS` is
     now deprecated.
+-   The pipeline runner now supports :ref:`pipeline-hooks` to inspect or modify
+    pipeline operations.
 -   The pipeline runner type checking logic has been refactored and simplified.
     As a consequence, when ``None`` is provided to a component input that does
     not accept ``None``, the runner now raises :class:`TypeError` instead of

--- a/docs/releases/2025.rst
+++ b/docs/releases/2025.rst
@@ -31,6 +31,12 @@ information on how to upgrade your code.
 -   :ref:`parallelism` now supports comma-separated lists for configuring
     parallelism within worker processes, and :envvar:`LK_NUM_CHILD_THREADS` is
     now deprecated.
+-   The pipeline runner type checking logic has been refactored and simplified.
+    As a consequence, when ``None`` is provided to a component input that does
+    not accept ``None``, the runner now raises :class:`TypeError` instead of
+    :class:`PipelineError`, as this is a type error.  Details on a type error's
+    input wiring are now provided as a note on the exception, instead of in the
+    main exception message.
 
 Component Changes
 .................

--- a/src/lenskit/pipeline/__init__.py
+++ b/src/lenskit/pipeline/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from lenskit.diagnostics import PipelineError, PipelineWarning
 
+from ._hooks import ComponentInputHook
 from ._impl import CloneMethod, Pipeline
 from .builder import PipelineBuilder
 from .cache import PipelineCache
@@ -43,4 +44,5 @@ __all__ = [
     "RecPipelineBuilder",
     "topn_pipeline",
     "predict_pipeline",
+    "ComponentInputHook",
 ]

--- a/src/lenskit/pipeline/_hooks/__init__.py
+++ b/src/lenskit/pipeline/_hooks/__init__.py
@@ -22,9 +22,9 @@ from typing_extensions import (
     TypeVar,
 )
 
-from .components import Component, PipelineFunction
-from .nodes import ComponentInstanceNode
-from .types import TypeExpr
+from ..components import Component, PipelineFunction
+from ..nodes import ComponentInstanceNode
+from ..types import TypeExpr
 
 ComponentObject: TypeAlias = Component | PipelineFunction
 
@@ -82,3 +82,9 @@ class ComponentInputHook(Protocol):
 RunHooks = TypedDict(
     "RunHooks", {"component-input": list[HookEntry[ComponentInputHook]]}, total=False
 )
+
+
+def default_run_hooks() -> RunHooks:
+    from .typecheck import typecheck_input_data
+
+    return {"component-input": [HookEntry(typecheck_input_data, 0)]}

--- a/src/lenskit/pipeline/_hooks/__init__.py
+++ b/src/lenskit/pipeline/_hooks/__init__.py
@@ -28,7 +28,7 @@ from ..types import TypeExpr
 
 ComponentObject: TypeAlias = Component | PipelineFunction
 
-Hook = TypeVar("Hook", bound=Callable[..., Any])
+Hook = TypeVar("Hook", bound=Callable[..., Any], covariant=True)
 
 
 class HookEntry(NamedTuple, Generic[Hook]):
@@ -54,6 +54,7 @@ class ComponentInputHook(Protocol):
         input_name: str,
         input_type: TypeExpr | None,
         value: object,
+        **context: Any,
     ) -> Any:
         """
         Inspect or process the component input data.
@@ -70,6 +71,8 @@ class ComponentInputHook(Protocol):
                 The data value to be supplied.  This is declared
                 :class:`object`, because its type is not known or guaranteed in
                 the genral case.
+            context:
+                Additional context variables, mostly for the use of internal hooks.
 
         Returns:
             The value to pass to the component.  For inspection-only hooks, this

--- a/src/lenskit/pipeline/_hooks/__init__.py
+++ b/src/lenskit/pipeline/_hooks/__init__.py
@@ -44,8 +44,10 @@ class ComponentInputHook(Protocol):
     """
     Inspect or process data as it passes to a component's input.
 
-    As with all :ref:`hooks`, an input hook is a callable that is run at the
-    appropriate stage of the input.
+    As with all :ref:`pipeline-hooks`, an input hook is a callable that is run
+    at the appropriate stage of the input.
+
+    Component input hooks are installed under the name ``component-input``.
     """
 
     def __call__(

--- a/src/lenskit/pipeline/_hooks/typecheck.py
+++ b/src/lenskit/pipeline/_hooks/typecheck.py
@@ -17,11 +17,20 @@ from ..types import TypeExpr, is_compatible_data
 
 
 def typecheck_input_data(
-    node: ComponentInstanceNode[Any], input_name: str, input_type: TypeExpr | None, value: Any
+    node: ComponentInstanceNode[Any],
+    input_name: str,
+    input_type: TypeExpr | None,
+    value: Any,
+    *,
+    required: bool = True,
+    **context,
 ) -> Any:
     """
     Hook to check that input data matches the component's declared input type.
     """
+    if value is None and not required:
+        return None
+
     if input_type and not is_compatible_data(value, input_type):
         if value is None:
             raise PipelineError(

--- a/src/lenskit/pipeline/_hooks/typecheck.py
+++ b/src/lenskit/pipeline/_hooks/typecheck.py
@@ -13,7 +13,7 @@ from typing import Any
 from lenskit.diagnostics import PipelineError
 
 from ..nodes import ComponentInstanceNode
-from ..types import TypeExpr, is_compatible_data
+from ..types import SkipComponent, TypeExpr, is_compatible_data
 
 
 def typecheck_input_data(
@@ -28,16 +28,16 @@ def typecheck_input_data(
     """
     Hook to check that input data matches the component's declared input type.
     """
-    if value is None and not required:
-        return None
-
     if input_type and not is_compatible_data(value, input_type):
         if value is None:
-            raise PipelineError(
-                f"no data available for required input ❬{input_name}❭ on component ❬{node.name}❭"
+            msg = f"no data available for required input ❬{input_name}❭ on component ❬{node.name}❭"
+            if required:
+                raise PipelineError(msg)
+            else:
+                raise SkipComponent(msg)
+        else:
+            raise TypeError(
+                f"input ❬{input_name}❭ on component ❬{node.name}❭ has invalid type {type(value)} (expected {input_type})"  # noqa: E501
             )
-        raise TypeError(
-            f"input ❬{input_name}❭ on component ❬{node.name}❭ has invalid type {type(value)} (expected {input_type})"  # noqa: E501
-        )
 
     return value

--- a/src/lenskit/pipeline/_hooks/typecheck.py
+++ b/src/lenskit/pipeline/_hooks/typecheck.py
@@ -1,0 +1,34 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+"""
+Input type checking hook.
+"""
+
+from typing import Any
+
+from lenskit.diagnostics import PipelineError
+
+from ..nodes import ComponentInstanceNode
+from ..types import TypeExpr, is_compatible_data
+
+
+def typecheck_input_data(
+    node: ComponentInstanceNode[Any], input_name: str, input_type: TypeExpr | None, value: Any
+) -> Any:
+    """
+    Hook to check that input data matches the component's declared input type.
+    """
+    if input_type and not is_compatible_data(value, input_type):
+        if value is None:
+            raise PipelineError(
+                f"no data available for required input ❬{input_name}❭ on component ❬{node.name}❭"
+            )
+        raise TypeError(
+            f"input ❬{input_name}❭ on component ❬{node.name}❭ has invalid type {type(value)} (expected {input_type})"  # noqa: E501
+        )
+
+    return value

--- a/src/lenskit/pipeline/_impl.py
+++ b/src/lenskit/pipeline/_impl.py
@@ -28,13 +28,13 @@ from lenskit.logging import get_logger
 
 from . import config
 from .config import PipelineConfig
+from .hooks import RunHooks
 from .nodes import (
     ComponentConstructorNode,
     ComponentInstanceNode,
     Node,
 )
 from .state import PipelineState
-from .types import HookEntry
 
 if TYPE_CHECKING:
     from lenskit.training import TrainingOptions
@@ -82,14 +82,14 @@ class Pipeline:
     _aliases: dict[str, Node[Any]]
     _default: Node[Any] | None = None
     _hash: str | None = None
-    _run_hooks: dict[str, list[HookEntry]]
+    _run_hooks: RunHooks
 
     def __init__(
         self,
         config: config.PipelineConfig,
         nodes: Iterable[Node[Any]],
         *,
-        run_hooks: dict[str, list[HookEntry]],
+        run_hooks: RunHooks,
     ):
         self._nodes = {}
         for node in nodes:
@@ -107,7 +107,7 @@ class Pipeline:
 
         self._run_hooks = {}
         for name, hooks in run_hooks.items():
-            self._run_hooks.setdefault(name, [])
+            self._run_hooks.setdefault(name, [])  # type: ignore
             self._run_hooks[name] += hooks
 
     @property

--- a/src/lenskit/pipeline/_impl.py
+++ b/src/lenskit/pipeline/_impl.py
@@ -27,8 +27,8 @@ from lenskit.diagnostics import PipelineError
 from lenskit.logging import get_logger
 
 from . import config
+from ._hooks import RunHooks, default_run_hooks
 from .config import PipelineConfig
-from .hooks import RunHooks
 from .nodes import (
     ComponentConstructorNode,
     ComponentInstanceNode,
@@ -105,10 +105,11 @@ class Pipeline:
         if config.default:
             self._default = self.node(config.default)
 
-        self._run_hooks = {}
+        self._run_hooks = default_run_hooks()
         for name, hooks in run_hooks.items():
-            self._run_hooks.setdefault(name, [])  # type: ignore
-            self._run_hooks[name] += hooks
+            my_hooks = self._run_hooks.setdefault(name, [])  # type: ignore
+            my_hooks.extend(hooks)  # type: ignore
+            my_hooks.sort(key=lambda h: h.priority)
 
     @property
     def config(self) -> PipelineConfig:

--- a/src/lenskit/pipeline/builder.py
+++ b/src/lenskit/pipeline/builder.py
@@ -458,7 +458,7 @@ class PipelineBuilder:
         self, name: Literal["component-input"], hook: ComponentInputHook, *, priority: int = 1
     ) -> None:
         """
-        Add a hook to be called when the pipeline is run.
+        Add a hook to be called when the pipeline is run (see :ref:`pipeline-hooks`).
 
         Args:
             name:

--- a/src/lenskit/pipeline/builder.py
+++ b/src/lenskit/pipeline/builder.py
@@ -24,6 +24,7 @@ from lenskit.diagnostics import PipelineError, PipelineWarning
 from lenskit.logging import get_logger
 
 from . import config
+from ._hooks import ComponentInputHook, HookEntry, RunHooks
 from ._impl import Pipeline
 from .cache import PipelineCache
 from .components import (
@@ -34,7 +35,6 @@ from .components import (
     instantiate_component,
 )
 from .config import PipelineConfig, PipelineHook
-from .hooks import ComponentInputHook, HookEntry, RunHooks
 from .nodes import (
     ND,
     ComponentConstructorNode,

--- a/src/lenskit/pipeline/config.py
+++ b/src/lenskit/pipeline/config.py
@@ -19,7 +19,7 @@ from types import FunctionType
 from typing import Literal, Mapping
 
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
-from typing_extensions import Any, Optional, Self
+from typing_extensions import Any, Self
 
 from .components import Component
 from .nodes import ComponentConstructorNode, ComponentInstanceNode, ComponentNode, InputNode
@@ -38,15 +38,15 @@ class PipelineConfig(BaseModel):
 
     meta: PipelineMeta
     "Pipeline metadata."
-    inputs: list[PipelineInput] = Field(default_factory=list)
+    inputs: list[PipelineInput] = []
     "Pipeline inputs."
     components: OrderedDict[str, PipelineComponent] = Field(default_factory=OrderedDict)
     "Pipeline components, with their configurations and wiring."
-    aliases: dict[str, str] = Field(default_factory=dict)
+    aliases: dict[str, str] = {}
     "Pipeline node aliases."
     default: str | None = None
     "The default node for running this pipeline."
-    literals: dict[str, PipelineLiteral] = Field(default_factory=dict)
+    literals: dict[str, PipelineLiteral] = {}
     "Literals"
 
 
@@ -79,7 +79,7 @@ class PipelineInput(BaseModel):
 
     name: str
     "The name for this input."
-    types: Optional[set[str]]
+    types: set[str] | None
     "The list of types for this input."
 
     @classmethod
@@ -103,13 +103,13 @@ class PipelineComponent(BaseModel):
     This is a Python qualified path of the form ``module:name``.
     """
 
-    config: Mapping[str, JsonValue] | None = Field(default=None)
+    config: Mapping[str, JsonValue] | None = None
     """
     The component configuration.  If not provided, the component will be created
     with its default constructor parameters.
     """
 
-    inputs: dict[str, str] = Field(default_factory=dict)
+    inputs: dict[str, str] = {}
     """
     The component's input wirings, mapping input names to node names.  For
     certain meta-nodes, it is specified as a list instead of a dict.

--- a/src/lenskit/pipeline/config.py
+++ b/src/lenskit/pipeline/config.py
@@ -23,8 +23,8 @@ from annotated_types import Predicate
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
 from typing_extensions import Any, Self
 
+from ._hooks import HookEntry
 from .components import Component
-from .hooks import HookEntry
 from .nodes import ComponentConstructorNode, ComponentInstanceNode, ComponentNode, InputNode
 from .types import type_string
 

--- a/src/lenskit/pipeline/config.py
+++ b/src/lenskit/pipeline/config.py
@@ -24,8 +24,9 @@ from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
 from typing_extensions import Any, Self
 
 from .components import Component
+from .hooks import HookEntry
 from .nodes import ComponentConstructorNode, ComponentInstanceNode, ComponentNode, InputNode
-from .types import HookEntry, type_string
+from .types import type_string
 
 
 class PipelineHook(BaseModel):
@@ -37,7 +38,7 @@ class PipelineHook(BaseModel):
     priority: Annotated[int, Predicate(lambda x: x != 0)] = 1
 
     @classmethod
-    def from_entry(cls, hook: HookEntry):
+    def from_entry(cls, hook: HookEntry[Any]):
         if not isinstance(hook, FunctionType):  # type: ignore
             warnings.warn(f"hook {hook.function} is not a function")
         function = f"{hook.function.__module__}:{hook.function.__qualname__}"

--- a/src/lenskit/pipeline/hooks.py
+++ b/src/lenskit/pipeline/hooks.py
@@ -8,13 +8,36 @@
 Definition of pipeline hook protocols.
 """
 
-from typing_extensions import Any, Protocol, TypeAlias
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from typing_extensions import (
+    Any,
+    Generic,
+    NamedTuple,
+    Protocol,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+)
 
 from .components import Component, PipelineFunction
 from .nodes import ComponentInstanceNode
 from .types import TypeExpr
 
 ComponentObject: TypeAlias = Component | PipelineFunction
+
+Hook = TypeVar("Hook", bound=Callable[..., Any])
+
+
+class HookEntry(NamedTuple, Generic[Hook]):
+    """
+    An entry in a pipeline hook list.
+    """
+
+    function: Hook
+    priority: int = 1
 
 
 class ComponentInputHook(Protocol):
@@ -54,3 +77,8 @@ class ComponentInputHook(Protocol):
             values depending on application needs.
         """
         pass
+
+
+RunHooks = TypedDict(
+    "RunHooks", {"component-input": list[HookEntry[ComponentInputHook]]}, total=False
+)

--- a/src/lenskit/pipeline/hooks.py
+++ b/src/lenskit/pipeline/hooks.py
@@ -1,0 +1,56 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+"""
+Definition of pipeline hook protocols.
+"""
+
+from typing_extensions import Any, Protocol, TypeAlias
+
+from .components import Component, PipelineFunction
+from .nodes import ComponentInstanceNode
+from .types import TypeExpr
+
+ComponentObject: TypeAlias = Component | PipelineFunction
+
+
+class ComponentInputHook(Protocol):
+    """
+    Inspect or process data as it passes to a component's input.
+
+    As with all :ref:`hooks`, an input hook is a callable that is run at the
+    appropriate stage of the input.
+    """
+
+    def __call__(
+        self,
+        node: ComponentInstanceNode[Any],
+        input_name: str,
+        input_type: TypeExpr | None,
+        value: object,
+    ) -> Any:
+        """
+        Inspect or process the component input data.
+
+        Args:
+            node:
+                The component node being invoked.
+            input_name:
+                The name of the component's input that will receive the data.
+            input_type:
+                The type of data the component expects for this input, if one
+                was specified in the component definition.
+            value:
+                The data value to be supplied.  This is declared
+                :class:`object`, because its type is not known or guaranteed in
+                the genral case.
+
+        Returns:
+            The value to pass to the component.  For inspection-only hooks, this
+            will just be ``value``; hooks can also substitute alternative
+            values depending on application needs.
+        """
+        pass

--- a/src/lenskit/pipeline/runner.py
+++ b/src/lenskit/pipeline/runner.py
@@ -147,8 +147,7 @@ class PipelineRunner:
             if not lazy:
                 try:
                     ival = self._run_input_hooks(node, iname, itype, ival, required=ireq)
-                except SkipComponent as e:
-                    trace(ilog, "hook asked to skip component", exc_info=e)
+                except SkipComponent:
                     return None
 
             in_data[iname] = ival

--- a/src/lenskit/pipeline/runner.py
+++ b/src/lenskit/pipeline/runner.py
@@ -159,16 +159,6 @@ class PipelineRunner:
                 for hook in self.pipe._run_hooks.get("component-input", []):
                     ival = hook.function(node, iname, itype, ival)
 
-            # check the data type before passing
-            if itype and not lazy and not is_compatible_data(ival, itype):
-                if ival is None:
-                    raise PipelineError(
-                        f"no data available for required input ❬{iname}❭ on component ❬{node.name}❭"
-                    )
-                raise TypeError(
-                    f"input ❬{iname}❭ on component ❬{node.name}❭ has invalid type {type(ival)} (expected {itype})"  # noqa: E501
-                )
-
             in_data[iname] = ival
 
         trace(log, "running component", component=node.component)

--- a/src/lenskit/pipeline/types.py
+++ b/src/lenskit/pipeline/types.py
@@ -11,12 +11,13 @@ import re
 import warnings
 from importlib import import_module
 from types import GenericAlias, NoneType, UnionType
-from typing import (  # type: ignore
+from typing import (
     Generic,
     Protocol,
+    TypeAlias,
     TypeVar,
     Union,
-    _GenericAlias,
+    _GenericAlias,  # type: ignore
     get_args,
     get_origin,
 )
@@ -24,6 +25,24 @@ from typing import (  # type: ignore
 import numpy as np
 
 T = TypeVar("T", covariant=True)
+"""
+General type variable for generic container types or inputs.
+"""
+
+TypeExpr: TypeAlias = type | UnionType
+"""
+Type for (resolved) type expressions.
+
+This type is intended to encapsulate any fully-resolved type expression.
+
+:class:`type` encapsulates many other types, including:
+
+- :class:`~types.GenericAlias`
+- :class:`~types.NoneType`
+- :class:`~types.FunctionType`
+- :class:`~types.MethodType`
+- :class:`~typing.TypeVar`
+"""
 
 
 class TypecheckWarning(UserWarning):
@@ -57,7 +76,7 @@ class Lazy(Protocol, Generic[T]):
         ...
 
 
-def is_compatible_type(typ: type, *targets: type) -> bool:
+def is_compatible_type(typ: type, *targets: TypeExpr) -> bool:
     """
     Make a best-effort check whether a type is compatible with at least one
     target type. This function is limited by limitations of the Python type
@@ -101,13 +120,13 @@ def is_compatible_type(typ: type, *targets: type) -> bool:
                     return True
         elif typ == int and isinstance(target, type) and issubclass(target, (float, complex)):  # noqa: E721
             return True
-        elif typ == float and issubclass(target, complex):  # noqa: E721
+        elif typ == float and isinstance(target, type) and issubclass(target, complex):  # noqa: E721
             return True
 
     return False
 
 
-def is_compatible_data(obj: object, *targets: type | TypeVar) -> bool:
+def is_compatible_data(obj: object, *targets: TypeExpr) -> bool:
     """
     Make a best-effort check whether a type is compatible with at least one
     target type. This function is limited by limitations of the Python type
@@ -163,7 +182,7 @@ def is_compatible_data(obj: object, *targets: type | TypeVar) -> bool:
             and issubclass(target, (float, complex))
         ):  # noqa: E721
             return True
-        elif isinstance(obj, float) and issubclass(target, complex):  # noqa: E721
+        elif isinstance(obj, float) and isinstance(target, type) and issubclass(target, complex):  # noqa: E721
             return True
 
     return False

--- a/src/lenskit/pipeline/types.py
+++ b/src/lenskit/pipeline/types.py
@@ -51,6 +51,12 @@ class TypecheckWarning(UserWarning):
     pass
 
 
+class SkipComponent(Exception):
+    "Internal exception used to skip an optional component."
+
+    pass
+
+
 class Lazy(Protocol, Generic[T]):
     """
     Type for accepting lazy inputs from the pipeline runner.  If your function

--- a/src/lenskit/pipeline/types.py
+++ b/src/lenskit/pipeline/types.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 import re
 import warnings
+from collections.abc import Callable
 from importlib import import_module
 from types import GenericAlias, NoneType, UnionType
 from typing import (
+    Any,
     Generic,
+    NamedTuple,
     Protocol,
     TypeAlias,
     TypeVar,
@@ -49,6 +52,15 @@ class TypecheckWarning(UserWarning):
     "Warnings about type-checking logic."
 
     pass
+
+
+class HookEntry(NamedTuple):
+    """
+    An entry in a pipeline hook list.
+    """
+
+    function: Callable[..., Any]
+    priority: int = 1
 
 
 class Lazy(Protocol, Generic[T]):

--- a/src/lenskit/pipeline/types.py
+++ b/src/lenskit/pipeline/types.py
@@ -78,6 +78,22 @@ class Lazy(Protocol, Generic[T]):
     def get(self) -> T:
         """
         Get the value behind this lazy instance.
+
+        .. note::
+
+            As this method invokes upstream components if they have not yet been
+            run, it may fail if one of the required components fails or pipeline
+            data checks fail.
+
+        Raises:
+            Exception:
+                Any exception raised by the component(s) needed to supply the
+                lazy value may be raised when this method is called.
+            SkipComponent:
+                Internal exception raised to indicate that no value is available
+                and the calling component should be skipped.  Components
+                generally do not need to handle this directly, as it is used to
+                signal the pipeline runner.
         """
         ...
 

--- a/src/lenskit/pipeline/types.py
+++ b/src/lenskit/pipeline/types.py
@@ -9,13 +9,10 @@ from __future__ import annotations
 
 import re
 import warnings
-from collections.abc import Callable
 from importlib import import_module
 from types import GenericAlias, NoneType, UnionType
 from typing import (
-    Any,
     Generic,
-    NamedTuple,
     Protocol,
     TypeAlias,
     TypeVar,
@@ -52,15 +49,6 @@ class TypecheckWarning(UserWarning):
     "Warnings about type-checking logic."
 
     pass
-
-
-class HookEntry(NamedTuple):
-    """
-    An entry in a pipeline hook list.
-    """
-
-    function: Callable[..., Any]
-    priority: int = 1
 
 
 class Lazy(Protocol, Generic[T]):

--- a/tests/pipeline/test_component_input_hook.py
+++ b/tests/pipeline/test_component_input_hook.py
@@ -47,9 +47,8 @@ def test_component_input_called():
     pipe = build.build()
 
     assert len(pipe.config.hooks.run["component-input"]) == 1
-    assert (
-        pipe.config.hooks.run["component-input"][0].function
-        == "tests.pipeline.test_component_input_hook:_input_hook"
+    assert pipe.config.hooks.run["component-input"][0].function.endswith(
+        "tests.pipeline.test_component_input_hook:_input_hook"
     )
     assert pipe.config.hooks.run["component-input"][0].priority == 1
 

--- a/tests/pipeline/test_component_input_hook.py
+++ b/tests/pipeline/test_component_input_hook.py
@@ -1,0 +1,116 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+from contextvars import ContextVar
+from typing import Any
+
+from lenskit.logging import get_logger
+from lenskit.pipeline import PipelineBuilder
+from lenskit.pipeline.nodes import ComponentInstanceNode
+from lenskit.pipeline.types import T
+
+_log = get_logger(__name__)
+hook_calls = ContextVar(f"lk-{__name__}-hook-calls", default=0)
+
+
+def proc_hello(msg: str) -> str:
+    return f"Hello, {msg}"
+
+
+def proc_prefix(msg: str, prefix: str) -> str:
+    return prefix + msg
+
+
+def _input_hook(
+    node: ComponentInstanceNode[Any], input_name: str, input_type: Any, value: Any
+) -> Any:
+    n = hook_calls.get()
+    _log.debug("input hook called", n=n, msg=value)
+    hook_calls.set(n + 1)
+    return value
+
+
+def test_component_input_called():
+    build = PipelineBuilder()
+    msg = build.create_input("message", str)
+    hello = build.add_component("hello", proc_hello, msg=msg)
+
+    build.add_run_hook("component-input", _input_hook)
+
+    pipe = build.build()
+
+    assert len(pipe.config.hooks.run["component-input"]) == 1
+    assert (
+        pipe.config.hooks.run["component-input"][0].function
+        == "tests.pipeline.test_component_input_hook:_input_hook"
+    )
+    assert pipe.config.hooks.run["component-input"][0].priority == 1
+
+    hook_calls.set(0)
+    out = pipe.run(hello, message="world")
+    assert out == "Hello, world"
+
+    assert hook_calls.get() == 1
+
+
+def test_hook_passed_to_clone():
+    build = PipelineBuilder()
+    msg = build.create_input("message", str)
+    _hello = build.add_component("hello", proc_hello, msg=msg)
+
+    build.add_run_hook("component-input", _input_hook)
+
+    pipe = build.build()
+
+    b2 = PipelineBuilder.from_pipeline(pipe)
+    cfg2 = b2.build_config()
+
+    assert len(cfg2.hooks.run["component-input"]) == 1
+    assert (
+        cfg2.hooks.run["component-input"][0].function
+        == "tests.pipeline.test_component_input_hook:_input_hook"
+    )
+    assert cfg2.hooks.run["component-input"][0].priority == 1
+
+
+def test_hook_loaded_from_config():
+    build = PipelineBuilder()
+    msg = build.create_input("message", str)
+    _hello = build.add_component("hello", proc_hello, msg=msg)
+
+    build.add_run_hook("component-input", _input_hook)
+
+    cfg = build.build_config()
+    print(cfg.model_dump_json(indent=2))
+
+    b2 = PipelineBuilder.from_config(cfg)
+    cfg2 = b2.build_config()
+    print(cfg2.model_dump_json(indent=2))
+
+    assert len(cfg2.hooks.run["component-input"]) == 1
+    assert (
+        cfg2.hooks.run["component-input"][0].function
+        == "tests.pipeline.test_component_input_hook:_input_hook"
+    )
+    assert cfg2.hooks.run["component-input"][0].priority == 1
+
+
+def test_component_input_called_multi():
+    build = PipelineBuilder()
+    msg = build.create_input("message", str)
+    pfx = build.add_component("prefix", proc_prefix, msg=msg, prefix="good ")
+    hello = build.add_component("hello", proc_hello, msg=pfx)
+
+    build.add_run_hook("component-input", _input_hook)
+
+    pipe = build.build()
+
+    hook_calls.set(0)
+    out = pipe.run(hello, message="friend")
+    assert out == "Hello, good friend"
+
+    # we have 3 input edges: 2 to proc_prefix, 1 to proc_hello
+    assert hook_calls.get() == 3

--- a/tests/pipeline/test_component_input_hook.py
+++ b/tests/pipeline/test_component_input_hook.py
@@ -29,7 +29,7 @@ def lazy_prefix(msg: Lazy[str], prefix: str, extra: Lazy[str]) -> str:
 
 
 def _input_hook(
-    node: ComponentInstanceNode[Any], input_name: str, input_type: Any, value: Any
+    node: ComponentInstanceNode[Any], input_name: str, input_type: Any, value: Any, **context
 ) -> Any:
     cs = hook_calls.get()
     _log.debug("input hook called", n=len(cs), msg=value)

--- a/tests/pipeline/test_component_input_hook.py
+++ b/tests/pipeline/test_component_input_hook.py
@@ -24,7 +24,7 @@ def proc_prefix(msg: str, prefix: str) -> str:
     return prefix + msg
 
 
-def lazy_prefix(msg: Lazy[str], prefix, extra: Lazy[str]) -> str:
+def lazy_prefix(msg: Lazy[str], prefix: str, extra: Lazy[str]) -> str:
     return prefix + msg.get()
 
 
@@ -138,4 +138,7 @@ def test_component_lazy_hook():
     # we should be called twice: once for msg, once for prefix. extra is not called.
     cs = hook_calls.get()
     assert len(hook_calls.get()) == 2
-    assert cs == [("prefix", "msg"), ("prefix", "prefix")]
+    assert cs == [
+        ("prefix", "prefix"),
+        ("prefix", "msg"),
+    ]

--- a/tests/pipeline/test_component_input_hook.py
+++ b/tests/pipeline/test_component_input_hook.py
@@ -72,9 +72,8 @@ def test_hook_passed_to_clone():
     cfg2 = b2.build_config()
 
     assert len(cfg2.hooks.run["component-input"]) == 1
-    assert (
-        cfg2.hooks.run["component-input"][0].function
-        == "tests.pipeline.test_component_input_hook:_input_hook"
+    assert cfg2.hooks.run["component-input"][0].function.endswith(
+        "tests.pipeline.test_component_input_hook:_input_hook"
     )
     assert cfg2.hooks.run["component-input"][0].priority == 1
 
@@ -94,9 +93,8 @@ def test_hook_loaded_from_config():
     print(cfg2.model_dump_json(indent=2))
 
     assert len(cfg2.hooks.run["component-input"]) == 1
-    assert (
-        cfg2.hooks.run["component-input"][0].function
-        == "tests.pipeline.test_component_input_hook:_input_hook"
+    assert cfg2.hooks.run["component-input"][0].function.endswith(
+        "tests.pipeline.test_component_input_hook:_input_hook"
     )
     assert cfg2.hooks.run["component-input"][0].priority == 1
 

--- a/tests/pipeline/test_fallback.py
+++ b/tests/pipeline/test_fallback.py
@@ -77,7 +77,7 @@ def test_fallback_fail_with_missing_options():
     na = pipe.add_component("add", add, x=nd, y=fb)
 
     pipe = pipe.build()
-    with raises(PipelineError, match="no data available"):
+    with raises(TypeError, match="found None, expected"):
         pipe.run(na, a=3)
 
 

--- a/tests/pipeline/test_modify_pipeline.py
+++ b/tests/pipeline/test_modify_pipeline.py
@@ -115,5 +115,5 @@ def test_modify_pipeline_clear_input():
     assert isinstance(n2.component, Prefixer)
     assert n2.component is not comp
 
-    with raises(PipelineError):
+    with raises(TypeError):
         p2.run(msg="HACKEM MUCHE")

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -10,7 +10,7 @@ from uuid import UUID
 import numpy as np
 from typing_extensions import assert_type
 
-from pytest import mark, raises, warns
+from pytest import raises, warns
 
 from lenskit.pipeline import PipelineBuilder, PipelineError
 from lenskit.pipeline.nodes import InputNode, Node

--- a/tests/pipeline/test_pipeline_runtime_typecheck.py
+++ b/tests/pipeline/test_pipeline_runtime_typecheck.py
@@ -48,7 +48,7 @@ def test_raise_invalid_wired_input():
 
     pipe = build.build()
 
-    with raises(TypeError, match="has invalid type"):
+    with raises(TypeError, match="found.*, expected"):
         pipe.run(excl, x=5)
 
 
@@ -60,5 +60,5 @@ def test_raise_lazy_input():
 
     pipe = build.build()
 
-    with raises(TypeError, match="has invalid type"):
+    with raises(TypeError, match="found.*, expected"):
         pipe.run(excl, x=5)

--- a/tests/pipeline/test_pipeline_runtime_typecheck.py
+++ b/tests/pipeline/test_pipeline_runtime_typecheck.py
@@ -1,0 +1,47 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+from pytest import raises
+
+from lenskit.pipeline import PipelineBuilder
+
+
+def proc_hello(msg: str) -> str:
+    return f"Hello, {msg}"
+
+
+def proc_incr(x: int) -> int:
+    return x + 1
+
+
+def proc_exclaim(msg: str) -> str:
+    return msg + "!"
+
+
+def test_raise_invalid_input():
+    build = PipelineBuilder()
+    msg = build.create_input("message", str)
+    hello = build.add_component("hello", proc_hello, msg=msg)
+
+    pipe = build.build()
+
+    out = pipe.run(hello, message="world")
+    assert out == "Hello, world"
+
+    with raises(TypeError, match="invalid data for input"):
+        pipe.run(hello, message=5)
+
+
+def test_raise_invalid_wired_input():
+    build = PipelineBuilder()
+    x = build.create_input("x", int)
+    incr = build.add_component("incr", proc_incr, x=x)
+    excl = build.add_component("exclaim", proc_exclaim, msg=incr)
+
+    pipe = build.build()
+
+    with raises(TypeError, match="has invalid type"):
+        pipe.run(excl, x=5)


### PR DESCRIPTION
This PR adds component input hooks to the pipeline, to support client code inspecting or manipulating data as it winds through the pipeline.

- [x] Add the concept of “run hooks” that are run when the pipeline is run.
- [x] Add a single type of run hook, a `component-input` hook.
- [x] Support run hooks in the builder, pipeline, and schema
- [x] Support and invoke run hooks in the pipeline runner
- [x] Implement runtime type checking as a component input hook, to simplify code and more thorough exercise the hook mechanism during ordinary LensKit runs
- [x] Convert `None` detection to a `TypeError`, simplifying type checking logic
- [x] Document pipeline hook facility

Closes #775.