### PR TITLE
Add additional tests to verify training item filtering

### DIFF
--- a/tests/basic/test_candidates.py
+++ b/tests/basic/test_candidates.py
@@ -34,3 +34,18 @@ def test_unrated_selector(ml_ds: Dataset):
 
     assert len(cands) <= ml_ds.item_count
     assert len(cands) == len(set(ml_ds.items.ids()) - set(row.ids()))
+
+
+def test_unrated_selector_many(rng: np.random.Generator, ml_ds: Dataset):
+    sel = UnratedTrainingItemsCandidateSelector()
+    sel.train(ml_ds)
+
+    for u in rng.choice(ml_ds.users.ids(), 200):
+        row = ml_ds.user_row(100)
+        assert row is not None
+        cands = sel(query=row)
+
+        assert len(cands) <= ml_ds.item_count
+        assert len(cands) == len(set(ml_ds.items.ids()) - set(row.ids()))
+        assert not np.any(np.isin(cands.ids(), row.ids()))
+        assert not np.any(np.isin(cands.numbers(), row.numbers()))

--- a/tests/integration/test_pipeline_basics.py
+++ b/tests/integration/test_pipeline_basics.py
@@ -10,7 +10,7 @@ Whole-pipeline integration tests to check for composite bugs.
 
 import numpy as np
 
-from lenskit import batch
+from lenskit import batch, recommend
 from lenskit.basic import (
     RandomSelector,
     UnratedTrainingItemsCandidateSelector,
@@ -20,7 +20,30 @@ from lenskit.data import Dataset, QueryInput
 from lenskit.pipeline import PipelineBuilder
 
 
-def test_training_items_removed(rng: np.random.Generator, ml_ds: Dataset):
+def test_training_items_removed_solo(rng: np.random.Generator, ml_ds: Dataset):
+    pb = PipelineBuilder()
+    query = pb.create_input("query", QueryInput)
+    query = pb.add_component("lookup", UserTrainingHistoryLookup, query=query)
+    candidates = pb.add_component("candidate-selector", UnratedTrainingItemsCandidateSelector)
+    pb.add_component("recommender", RandomSelector, {"n": 100}, items=candidates)
+
+    pipe = pb.build()
+    pipe.train(ml_ds)
+
+    users = rng.choice(ml_ds.users.ids(), 200)
+
+    for uid in users:
+        items = recommend(pipe, uid)
+
+        train_items = ml_ds.user_row(uid)
+        assert train_items is not None
+
+        assert len(items) == 100
+        assert not np.any(np.isin(items.ids(), train_items.ids()))
+        assert not np.any(np.isin(items.numbers(), train_items.numbers()))
+
+
+def test_training_items_removed_batch(rng: np.random.Generator, ml_ds: Dataset):
     pb = PipelineBuilder()
     query = pb.create_input("query", QueryInput)
     query = pb.add_component("lookup", UserTrainingHistoryLookup, query=query)

--- a/tests/integration/test_pipeline_basics.py
+++ b/tests/integration/test_pipeline_basics.py
@@ -1,0 +1,44 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+"""
+Whole-pipeline integration tests to check for composite bugs.
+"""
+
+import numpy as np
+
+from lenskit import batch
+from lenskit.basic import (
+    RandomSelector,
+    UnratedTrainingItemsCandidateSelector,
+    UserTrainingHistoryLookup,
+)
+from lenskit.data import Dataset, QueryInput
+from lenskit.pipeline import PipelineBuilder
+
+
+def test_training_items_removed(rng: np.random.Generator, ml_ds: Dataset):
+    pb = PipelineBuilder()
+    query = pb.create_input("query", QueryInput)
+    query = pb.add_component("lookup", UserTrainingHistoryLookup, query=query)
+    candidates = pb.add_component("candidate-selector", UnratedTrainingItemsCandidateSelector)
+    pb.add_component("recommender", RandomSelector, {"n": 100}, items=candidates)
+
+    pipe = pb.build()
+    pipe.train(ml_ds)
+
+    users = rng.choice(ml_ds.users.ids(), 200)
+    recs = batch.recommend(pipe, users)
+
+    for key, items in recs.items():
+        uid = key.user_id
+        assert uid in users
+        train_items = ml_ds.user_row(uid)
+        assert train_items is not None
+
+        assert len(items) == 100
+        assert not np.any(np.isin(items.ids(), train_items.ids()))
+        assert not np.any(np.isin(items.numbers(), train_items.numbers()))

--- a/tests/integration/test_pipeline_basics.py
+++ b/tests/integration/test_pipeline_basics.py
@@ -27,9 +27,9 @@ from lenskit.pipeline import Pipeline, PipelineBuilder, topn_pipeline
 def random_pipe(ml_ds: Dataset):
     pb = PipelineBuilder()
     query = pb.create_input("query", QueryInput)
-    query = pb.add_component("history-lookup", UserTrainingHistoryLookup, query=query)
+    history = pb.add_component("history-lookup", UserTrainingHistoryLookup, query=query)
     candidates = pb.add_component(
-        "candidate-selector", UnratedTrainingItemsCandidateSelector, query=query
+        "candidate-selector", UnratedTrainingItemsCandidateSelector, query=history
     )
     pb.add_component("recommender", RandomSelector, {"n": 100}, items=candidates)
 


### PR DESCRIPTION
This adds a few more integration tests to verify that training items are correctly excluded from recommendations in common recommender designs.

This did not find any new bugs in the components, but increases our confidence in their correctness both independently and in combination.