### PR TITLE
Use 64-bit row pointers in matrix relationship sets

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,5 +1,6 @@
 *.yml
 *.zip
+*.tar
 *.csv
 *.gz
 *.zst

--- a/src/accel/data/rc_set.rs
+++ b/src/accel/data/rc_set.rs
@@ -76,7 +76,7 @@ impl RowColumnSet {
     #[new]
     fn new(matrix: PyArrowType<ArrayData>) -> PyResult<Self> {
         let matrix = make_array(matrix.0);
-        let matrix: CSRStructure<i32> = CSRStructure::from_arrow(matrix)?;
+        let matrix: CSRStructure<i64> = CSRStructure::from_arrow(matrix)?;
 
         let mut sets = Vec::with_capacity(matrix.len());
 

--- a/src/lenskit/data/relationships.py
+++ b/src/lenskit/data/relationships.py
@@ -188,7 +188,7 @@ class MatrixRelationshipSet(RelationshipSet):
         a relationship set's :meth:`~RelationshipSet.matrix` method.
     """
 
-    _row_ptrs: np.ndarray[tuple[int], np.dtype[np.int32]]
+    _row_ptrs: np.ndarray[tuple[int], np.dtype[np.int64]]
     _structure: SparseRowArray
     row_type: str
     _row_nums: pa.Int32Array
@@ -234,13 +234,13 @@ class MatrixRelationshipSet(RelationshipSet):
         # compute the row pointers
         log.debug("computing CSR data")
         n_rows = len(self.row_vocabulary)
-        row_sizes = np.zeros(n_rows + 1, dtype=np.int32())
+        row_sizes = np.zeros(n_rows + 1, dtype=np.int64)
         self._row_nums = self._table.column(e_cols[0]).combine_chunks()  # type: ignore
         rsz_struct = pc.value_counts(self._row_nums)
         rsz_nums = rsz_struct.field("values")
         rsz_counts = rsz_struct.field("counts").cast(pa.int32())
         row_sizes[np.asarray(rsz_nums) + 1] = rsz_counts
-        self._row_ptrs = np.cumsum(row_sizes, dtype=np.int32)
+        self._row_ptrs = np.cumsum(row_sizes, dtype=np.int64)  # type: ignore
 
         self._col_nums = self._table.column(e_cols[1]).combine_chunks()  # type: ignore
         self._structure = SparseRowArray.from_arrays(

--- a/tests/data/test_dataset_matrix.py
+++ b/tests/data/test_dataset_matrix.py
@@ -181,8 +181,6 @@ def test_matrix_scipy_csr(ml_ratings: pd.DataFrame, generation):
     assert ncols >= ml_ratings["item_id"].nunique()
     assert ncols == ml_ds.item_count
 
-    assert log.indptr.dtype == np.int32
-    assert log.indices.dtype == np.int32
     _check_user_offset_counts(ml_ds, ml_ratings, log.indptr)
     _check_item_number_counts(ml_ds, ml_ratings, log.indices)
     _check_item_ids(ml_ds, ml_ratings, log.indices)
@@ -241,7 +239,7 @@ def test_matrix_torch_csr(ml_ratings: pd.DataFrame, ml_ds: Dataset):
     _check_item_ids(ml_ds, ml_ratings, log.col_indices())
     _check_ratings(ml_ds, ml_ratings, log.values().numpy())
 
-    assert log.crow_indices().dtype == torch.int32
+    assert log.crow_indices().dtype == torch.int64
     assert log.col_indices().dtype == torch.int32
 
 

--- a/tests/data/test_huge.py
+++ b/tests/data/test_huge.py
@@ -7,3 +7,46 @@
 """
 Test extremely large datasets.
 """
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from pytest import mark
+
+from lenskit.data import DatasetBuilder
+from lenskit.logging import get_logger
+
+_log = get_logger(__name__)
+huge_dir = Path("data/ml-20mx16x32")
+
+
+@mark.skipif(not huge_dir.exists(), reason="ML 1B not available")
+@mark.slow
+def test_basic_huge():
+    "Test building a 1B data set"
+
+    dsb = DatasetBuilder()
+    dsb.add_relationship_class(
+        "interaction", ["user", "item"], allow_repeats=False, interaction=True
+    )
+
+    n_users = 0
+    n_rows = 0
+    for file in huge_dir.glob("train*.npz"):
+        _log.info("loading segment", file=file.name)
+        npz = np.load(file)
+        array = next(iter(npz.values()))
+        n_users += len(np.unique(array[:, 0]))
+        n_rows += array.shape[0]
+        dsb.add_interactions(
+            "interaction",
+            pd.DataFrame(array, columns=["user_id", "item_id"]),
+            missing="insert",
+        )
+
+    _log.info("building dataset")
+    ds = dsb.build()
+    assert ds.interaction_count == n_rows
+    assert ds.user_count == n_users

--- a/tests/data/test_huge.py
+++ b/tests/data/test_huge.py
@@ -1,0 +1,9 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+"""
+Test extremely large datasets.
+"""

--- a/tests/data/test_huge.py
+++ b/tests/data/test_huge.py
@@ -8,6 +8,7 @@
 Test extremely large datasets.
 """
 
+import os
 from pathlib import Path
 
 import numpy as np
@@ -17,6 +18,8 @@ from pytest import mark
 
 from lenskit.data import DatasetBuilder
 from lenskit.logging import get_logger
+
+pytestmark = mark.skipif("LK_HUGE_TEST" not in os.environ, "huge tests disabled")
 
 _log = get_logger(__name__)
 huge_dir = Path("data/ml-20mx16x32")


### PR DESCRIPTION
This updates `MatrixRelationshipSet` to use 64-bit row pointers to support more than 2B interactions.