### PR TITLE
Automatically search up for lenskit.toml in CLI

### DIFF
--- a/src/lenskit/cli/__init__.py
+++ b/src/lenskit/cli/__init__.py
@@ -12,6 +12,7 @@ import click
 import numpy as np
 
 from lenskit import __version__, configure
+from lenskit.config import locate_configuration_root
 from lenskit.logging import LoggingConfig, console, get_logger
 
 __all__ = ["lenskit", "main", "version"]
@@ -55,6 +56,9 @@ def lenskit(verbosity: int, project_root: Path | None):
     if verbosity:
         lc.set_verbose(verbosity)
     lc.apply()
+
+    if project_root is None:
+        project_root = locate_configuration_root()
 
     configure(cfg_dir=project_root)
 


### PR DESCRIPTION
This updates the CLI to automatically search parent directories to find `lenskit.toml` by default, and to respect an `LK_CONFIG_ROOT` environment variable.