### PR TITLE
added binarize_ratings function in DatasetBuilder

### DIFF
--- a/src/lenskit/data/builder.py
+++ b/src/lenskit/data/builder.py
@@ -587,6 +587,42 @@ class DatasetBuilder:
 
         self._tables[cls] = tbl
 
+        def binarize_ratings(
+            self,
+            cls: str = "rating",
+            min_rating: float = 1.0,
+            method: str = "remove",
+        ):
+            """
+            Binarize the ratings in a relationship class.
+
+            Args:
+                cls (str): The relationship class to binarize (default: "rating").
+                min_rating (float): Minimum rating to consider as positive.
+                method (str): 'zero' to set ratings to 0/1, 'remove' to drop rows below min_rating.
+            """
+            tbl = self._tables.get(cls, None)
+            if tbl is None:
+                raise ValueError(f"relationship class {cls} is empty")
+
+            if "rating" not in tbl.column_names:
+                raise ValueError(f"relationship class {cls} does not have a 'rating' column")
+
+            min_rating: pa.scalar = pa.scalar(min_rating, tbl.column("rating").type)
+            if method == "zero":
+                # Set rating to 1 if >= min_rating, else 0
+                mask = pc.greater_equal(tbl.column("rating"), min_rating)
+                binarized = pc.cast(mask, pa.int32())
+                tbl = tbl.set_column(tbl.schema.get_field_index("rating"), "rating", binarized)
+            elif method == "remove":
+                # Keep only rows where rating >= min_rating
+                mask = pc.greater_equal(tbl.column("rating"), min_rating)
+                tbl = tbl.filter(mask)
+            else:
+                raise ValueError("method must be 'zero' or 'remove'")
+
+            self._tables[cls] = tbl
+
     def clear_relationships(self, cls: str):
         """
         Remove all records for a specified relationship class.


### PR DESCRIPTION
This PR adds a binarize_ratings method to the DatasetBuilder class, enabling users to easily binarize the ratings in a relationship class (typically "rating"). This is useful for preparing implicit feedback datasets or filtering out low ratings.

Details

DatasetBuilder.binarize_ratings(cls="rating", min_rating=1.0, method="remove")

cls: The relationship class to binarize (default: "rating").
min_rating: Minimum value to consider as positive.
method:
- "zero": Set ratings to 1 if >= min_rating, else 0.
- "remove": Remove rows where rating < min_rating (default).