### PR TITLE
Fix syntax in testsetup for item-list docs

### DIFF
--- a/docs/guide/data/item-lists.rst
+++ b/docs/guide/data/item-lists.rst
@@ -51,7 +51,7 @@ Keys, Schemas, and Lookup
 
 .. testsetup::
 
-    >>> from lenskit.data import ItemListCollection, ItemList
+    from lenskit.data import ItemListCollection, ItemList
 
 Item list collections use **keys** following a schema that is set when the item
 list collection is created.  A key schema or key type defines one or more *key


### PR DESCRIPTION
This fixes a syntax error in `item-lists.rst` that was causing test failures.