### PR TITLE
Fix locate_configuration_root and Conda tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           uv run --only-group=scripting just build-conda
         shell: bash -el {0}
+        env:
+          UV_LOCKED: 1
 
       - name: Save package
         uses: actions/upload-artifact@v4

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -66,7 +66,7 @@ outputs:
             - lenskit.als
             - lenskit.knn
       - script:
-          - python -m lenskit doctor --full
+          - python -m lenskit --verbose doctor --full
       - script:
           - pytest -m "not slow" tests
         files:

--- a/justfile
+++ b/justfile
@@ -50,7 +50,7 @@ build-accel profile="dev": init-dirs
 # build Conda packages
 build-conda: build-sdist
     #!/bin/bash
-    set -euo pipefail
+    set -eo pipefail
     export LK_PACKAGE_VERSION="$(python utils/version-tool.py -q)"
     # python path will confuse conda-build, yeet
     export PYTHONPATH=

--- a/src/lenskit/config/__init__.py
+++ b/src/lenskit/config/__init__.py
@@ -251,6 +251,7 @@ def locate_configuration_root(
         cwd = Path()
     elif not isinstance(cwd, Path):
         cwd = Path(cwd)
+    cwd = cwd.resolve()
 
     log = _log.bind(cwd=str(cwd))
     log.debug("searching for lenskit.toml")
@@ -265,4 +266,7 @@ def locate_configuration_root(
         if abort_at_gitroot and (cwd / ".git").exists():
             break
 
-        cwd = cwd.parent
+        if cwd.parent == cwd:
+            break
+        else:
+            cwd = cwd.parent

--- a/tests/config/test_locate.py
+++ b/tests/config/test_locate.py
@@ -1,0 +1,67 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import os
+from pathlib import Path
+
+from pytest import mark, skip
+
+from lenskit.config import locate_configuration_root
+
+LK_ROOT = Path(__file__).parent.parent.parent
+
+
+def test_locate_lktoml_cwd(tmp_path: Path):
+    lkt = tmp_path / "lenskit.toml"
+    lkt.touch()
+
+    path = locate_configuration_root(cwd=tmp_path)
+    assert path == tmp_path
+
+
+def test_locate_lktoml_parent(tmp_path: Path):
+    lkt = tmp_path / "lenskit.toml"
+    lkt.touch()
+
+    child = tmp_path / "foo" / "bar"
+    child.mkdir(parents=True, exist_ok=True)
+
+    path = locate_configuration_root(cwd=child)
+    assert path == tmp_path
+
+
+def test_stop_git(tmp_path: Path):
+    lkt = tmp_path / "lenskit.toml"
+    lkt.touch()
+
+    (tmp_path / "foo" / ".git").mkdir(parents=True)
+
+    child = tmp_path / "foo" / "bar"
+    child.mkdir(parents=True)
+
+    path = locate_configuration_root(cwd=child)
+    assert path is None
+
+
+def test_stop_pyproject(tmp_path: Path):
+    lkt = tmp_path / "lenskit.toml"
+    lkt.touch()
+
+    child = tmp_path / "foo" / "bar"
+    child.mkdir(parents=True)
+
+    (tmp_path / "foo" / "pyproject.toml").touch()
+
+    path = locate_configuration_root(cwd=child)
+    assert path is None
+
+
+def test_locate_none(tmp_path: Path):
+    child = tmp_path / "foo" / "bar"
+    child.mkdir(parents=True, exist_ok=True)
+
+    path = locate_configuration_root(cwd=child)
+    assert path is None


### PR DESCRIPTION
The `locate_configuration_root` function had no tests, and was very broken, and was responsible for hanging the Conda tests.