### PR TITLE
Work around Ray extension type serialization errors

### DIFF
--- a/src/lenskit/data/dataset.py
+++ b/src/lenskit/data/dataset.py
@@ -23,7 +23,7 @@ import scipy.sparse as sps
 import torch
 from humanize import metric
 from numpy.typing import NDArray
-from typing_extensions import Any, Literal, TypeAlias, TypeVar, overload
+from typing_extensions import Any, Literal, TypeAlias, TypedDict, TypeVar, overload
 
 from lenskit.diagnostics import DataError
 from lenskit.logging import get_logger
@@ -55,6 +55,12 @@ def _uses_data(func):
         return func(self, *args, **kwargs)
 
     return wrapper
+
+
+class DatasetState(TypedDict):
+    data: DataContainer
+    entities: dict[str, EntitySet]
+    relationships: dict[str, RelationshipSet]
 
 
 class Dataset:
@@ -508,6 +514,19 @@ class Dataset:
         if iset.row_type != "user":
             raise RuntimeError("default interactions do not have user columns")
         return iset.row_stats()
+
+    def __getstate__(self) -> DatasetState:
+        self._ensure_loaded()
+        return {
+            "data": self._data,
+            "entities": self._entities,
+            "relationships": self._relationships,
+        }
+
+    def __setstate__(self, state: DatasetState):
+        self._data = state["data"]
+        self._entities = state["entities"]
+        self._relationships = state["relationships"]
 
     def __str__(self) -> str:
         s = "<Dataset"

--- a/src/lenskit/data/dataset.py
+++ b/src/lenskit/data/dataset.py
@@ -59,8 +59,6 @@ def _uses_data(func):
 
 class DatasetState(TypedDict):
     data: DataContainer
-    entities: dict[str, EntitySet]
-    relationships: dict[str, RelationshipSet]
 
 
 class Dataset:
@@ -520,14 +518,11 @@ class Dataset:
         self._ensure_loaded()
         return {
             "data": self._data,
-            "entities": self._entities,
-            "relationships": self._relationships,
         }
 
     def __setstate__(self, state: DatasetState):
         self._data = state["data"]
-        self._entities = state["entities"]
-        self._relationships = state["relationships"]
+        self._init_caches()
 
     def __str__(self) -> str:
         s = "<Dataset"

--- a/src/lenskit/data/dataset.py
+++ b/src/lenskit/data/dataset.py
@@ -149,6 +149,7 @@ class Dataset:
     def _init_caches(self):
         "Initialize internal caches for this dataset."
         log = _log.bind(dataset=self.name)
+        self._data.normalize()
 
         self._entities = {}
         self._relationships = {}

--- a/tests/data/test_pickle.py
+++ b/tests/data/test_pickle.py
@@ -1,0 +1,20 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import pickle
+
+from lenskit.data import Dataset
+
+
+def test_dataset_pickle(ml_ds: Dataset):
+    data = pickle.dumps(ml_ds)
+
+    ds = pickle.loads(data)
+    assert isinstance(ds, Dataset)
+
+    assert ds.item_count == ml_ds.item_count
+    assert ds.user_count == ml_ds.user_count
+    assert ds.interaction_count == ml_ds.interaction_count

--- a/tests/data/test_ray.py
+++ b/tests/data/test_ray.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from pytest import importorskip, mark, skip
 
 from lenskit.data import Dataset, load_movielens
+from lenskit.parallel.ray import ensure_cluster
 
 ray = importorskip("ray")
 
@@ -17,6 +18,7 @@ data_dir = Path("data")
 
 @mark.parametrize("name", ["ml-latest-small", "ml-100k.zip", "ml-20m.zip"])
 def test_ray_roundtrip(name):
+    ensure_cluster()
     ds_path = data_dir / name
     if not ds_path.exists():
         skip(f"dataset {name} not available")

--- a/tests/data/test_ray.py
+++ b/tests/data/test_ray.py
@@ -1,0 +1,32 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+from pytest import importorskip, mark, skip
+
+from lenskit.data import Dataset, load_movielens
+
+ray = importorskip("ray")
+
+data_dir = Path("data")
+
+
+@mark.parametrize("name", ["ml-latest-small", "ml-100k.zip", "ml-20m.zip"])
+def test_ray_roundtrip(name):
+    ds_path = data_dir / name
+    if not ds_path.exists():
+        skip(f"dataset {name} not available")
+
+    ds = load_movielens(ds_path)
+
+    ref = ray.put(ds)
+    ds2 = ray.get(ref)
+
+    assert isinstance(ds2, Dataset)
+    assert ds2 is not ds
+
+    assert ds2.item_count == ds.item_count


### PR DESCRIPTION
This adds pickling tests, makes dataset pickling more explicit, and adds a workaround for Ray's inability to deserialize extension types (ray-project/ray#51959).