### PR TITLE
Fix coordinate table breakage when adding interactions after filtering or removing

### DIFF
--- a/src/lenskit/data/builder.py
+++ b/src/lenskit/data/builder.py
@@ -104,7 +104,9 @@ class DatasetBuilder:
             }
             # reuse _rel_coords if we have them
             if name._rel_coords is not None:
-                self._rel_coords = {n: coo.copy() for n, coo in name._rel_coords.items()}
+                self._rel_coords = {
+                    n: coo.copy() for n, coo in name._rel_coords.items() if coo is not None
+                }
         else:
             self.schema = DataSchema(name=name, entities={"item": EntitySchema()})
             self._tables = {"item": None}

--- a/src/lenskit/data/container.py
+++ b/src/lenskit/data/container.py
@@ -34,7 +34,7 @@ class DataContainer:
     schema: DataSchema
     tables: dict[str, pa.Table]
     _sorted: bool = False
-    _rel_coords: dict[str, _data_accel.CoordinateTable] | None = None
+    _rel_coords: dict[str, _data_accel.CoordinateTable | None] | None = None
 
     def normalize(self):
         """


### PR DESCRIPTION
This fixes a bug in the accelerated duplicate-checking logic in which the dataset build was failing when you clear or filter interactions, create another dataset builder from the resulting data set, and then add more new interactions.

For simplicity, the interaction-filtering logic clears out the coordinate table, but constructing a builder from a dataset with cleared coordinate tables did not properly check for `None`, and therefore fails. This adds a test, updates the `DataContainer` types, and properly filters `None`.

Closes #818.