### PR TITLE
Make list metric DF have a standard Index when there is one key field

### DIFF
--- a/src/lenskit/metrics/bulk.py
+++ b/src/lenskit/metrics/bulk.py
@@ -240,8 +240,12 @@ class RunAnalysis:
         Measure a set of outputs against a set of test data.
         """
         self._validate_setup()
-        index = pd.MultiIndex.from_tuples(outputs.keys())
-        index.names = list(outputs.key_fields)
+        if len(outputs.key_fields) > 1:
+            index = pd.MultiIndex.from_tuples(outputs.keys())
+            index.names = list(outputs.key_fields)
+        else:
+            index = pd.Index([k[0] for k in outputs.keys()])
+            index.name = outputs.key_fields[0]
 
         lms = [m for m in self.metrics if m.is_listwise or m.is_decomposed]
         gms = [m for m in self.metrics if m.is_global]

--- a/tests/eval/test_predict_metrics.py
+++ b/tests/eval/test_predict_metrics.py
@@ -122,7 +122,9 @@ def test_batch_rmse(ml_100k):
 
     # we should have all users
     assert len(umdf) == len(split.test)
-    missing = set(umdf.index.tolist()) - set(split.test.keys())
+
+    # we should only have users who are in the test data
+    missing = set(umdf.index.tolist()) - set(k.user_id for k in split.test.keys())
     assert len(missing) == 0
 
     # we should not have any missing values


### PR DESCRIPTION
When `RunAnalysis.measure` is called with an item list collection with a single key field, such as `user_id`, the resulting list metric data frame had a `MultiIndex` with only one index column. This changes it to properly be a single `Index`.