### PR TITLE
Refactor embedding size configuration for consistency + exponential support

### DIFF
--- a/.github/workflows/check-sources.yml
+++ b/.github/workflows/check-sources.yml
@@ -23,6 +23,9 @@ jobs:
       - name: 🧑🏻‍💻 Set up mise
         uses: jdx/mise-action@v3
 
+      - name: Update mise
+        run: mise upgrade -y
+
       - name: 🪝 Install pre-commit hooks
         run: pre-commit install-hooks
 

--- a/.github/workflows/check-sources.yml
+++ b/.github/workflows/check-sources.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: 🧑🏻‍💻 Set up mise
         uses: jdx/mise-action@v3
+        with:
+          cache: false
 
       - name: 🪝 Install pre-commit hooks
         run: pre-commit install-hooks

--- a/.github/workflows/check-sources.yml
+++ b/.github/workflows/check-sources.yml
@@ -23,9 +23,6 @@ jobs:
       - name: 🧑🏻‍💻 Set up mise
         uses: jdx/mise-action@v3
 
-      - name: Update mise
-        run: mise upgrade -y
-
       - name: 🪝 Install pre-commit hooks
         run: pre-commit install-hooks
 

--- a/.github/workflows/check-sources.yml
+++ b/.github/workflows/check-sources.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🦀 Set up Rust
-        run: rustup install
+      - name: 🧑🏻‍💻 Set up mise
+        uses: jdx/mise-action@v3
 
       - name: 🪝 Install pre-commit hooks
         run: pre-commit install-hooks

--- a/.github/workflows/check-sources.yml
+++ b/.github/workflows/check-sources.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🧑🏻‍💻 Set up mise
-        uses: jdx/mise-action@v3
+      - name: 🦀 Set up Rust
+        run: rustup install
 
       - name: 🪝 Install pre-commit hooks
         run: pre-commit install-hooks

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "deno.enable": true,
   "files.exclude": {
     "**/__pycache__": true,
     ".hypothesis/": true,

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,5 +1,5 @@
 [tools]
-rust = { version = "stable", components = "rustfmt" }
+rust = { version = "stable", components = "rustfmt,cargo,rustc" }
 shfmt = "latest"
 uv = "latest"
 pre-commit = "4"

--- a/src/lenskit/als/_common.py
+++ b/src/lenskit/als/_common.py
@@ -11,7 +11,7 @@ from typing import Literal, Mapping, TypeAlias, cast
 
 import numpy as np
 import structlog
-from pydantic import BaseModel, PositiveFloat, PositiveInt
+from pydantic import AliasChoices, BaseModel, Field, PositiveFloat, PositiveInt
 from scipy.sparse import coo_array
 from typing_extensions import Generic, NamedTuple, TypeVar, override
 
@@ -37,6 +37,13 @@ class ALSConfig(EmbeddingSizeMixin, BaseModel):
     Configuration for ALS scorers.
     """
 
+    embedding_size: PositiveInt = Field(
+        default=50, validation_alias=AliasChoices("embedding_size", "features")
+    )
+    """
+    The dimension of user and item embeddings (number of latent features to
+    learn).
+    """
     epochs: PositiveInt = 10
     """
     The number of epochs to train.

--- a/src/lenskit/als/_common.py
+++ b/src/lenskit/als/_common.py
@@ -32,7 +32,7 @@ Scorer = TypeVar("Scorer", bound="ALSBase")
 Config = TypeVar("Config", bound="ALSConfig")
 
 
-class ALSConfig(EmbeddingSizeMixin, BaseModel):
+class ALSConfig(BaseModel, EmbeddingSizeMixin):
     """
     Configuration for ALS scorers.
     """

--- a/src/lenskit/config/common.py
+++ b/src/lenskit/config/common.py
@@ -10,7 +10,7 @@ Mixins with commonly-used component configuration capabilities.
 
 from __future__ import annotations
 
-from pydantic import AliasChoices, Field, PositiveInt, model_validator
+from pydantic import PositiveInt, model_validator
 
 
 class EmbeddingSizeMixin:
@@ -32,9 +32,7 @@ class EmbeddingSizeMixin:
         cfg = SVDConfig(embedding_size=32)
     """
 
-    embedding_size: PositiveInt = Field(
-        default=50, validation_alias=AliasChoices("embedding_size", "features")
-    )
+    embedding_size: PositiveInt = 64
     """
     The dimension of user and item embeddings (number of latent features to
     learn).

--- a/src/lenskit/config/common.py
+++ b/src/lenskit/config/common.py
@@ -19,8 +19,7 @@ class EmbeddingSizeMixin:
 
     Component configuration classes can extend this class to inherit a
     standardized definition of an embedding size, along with useful behavior
-    like configuring with base-2 logs.  A derived class can override the
-    definition of :attr:`embedding_size` to change the default.
+    like configuring with base-2 logs.
 
     Example usage:
 
@@ -32,7 +31,7 @@ class EmbeddingSizeMixin:
         cfg = SVDConfig(embedding_size=32)
     """
 
-    embedding_size: PositiveInt = 64
+    embedding_size: PositiveInt
     """
     The dimension of user and item embeddings (number of latent features to
     learn).

--- a/src/lenskit/config/common.py
+++ b/src/lenskit/config/common.py
@@ -1,0 +1,53 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+"""
+Mixins with commonly-used component configuration capabilities.
+"""
+
+from __future__ import annotations
+
+from pydantic import AliasChoices, Field, PositiveInt, model_validator
+
+
+class EmbeddingSizeMixin:
+    """
+    Mixin for configuring embedding sizes (# of latent dimensions).
+
+    Component configuration classes can extend this class to inherit a
+    standardized definition of an embedding size, along with useful behavior
+    like configuring with base-2 logs.  A derived class can override the
+    definition of :attr:`embedding_size` to change the default.
+
+    Example usage:
+
+    .. code:: python
+
+        class SVDConfig(EmbeddingSizeMixin, BaseModel):
+            pass
+
+        cfg = SVDConfig(embedding_size=32)
+    """
+
+    embedding_size: PositiveInt = Field(
+        default=50, validation_alias=AliasChoices("embedding_size", "features")
+    )
+    """
+    The dimension of user and item embeddings (number of latent features to
+    learn).
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def lkmv_embedding_size(cls, data):
+        match data:
+            case {"embedding_size_exp": e}:
+                # convert embedding size and remove from data
+                return {"embedding_size": 2**e} | {
+                    k: v for k, v in data.items() if k != "embedding_size_exp"
+                }
+            case _:
+                return data

--- a/src/lenskit/flexmf/_base.py
+++ b/src/lenskit/flexmf/_base.py
@@ -6,12 +6,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Literal
 
 import numpy as np
 import torch
+from pydantic import BaseModel, PositiveInt
 
+from lenskit.config.common import EmbeddingSizeMixin
 from lenskit.data import ItemList, QueryInput, RecQuery, Vocabulary
 from lenskit.logging import get_logger
 from lenskit.pipeline import Component
@@ -24,8 +25,7 @@ from ._model import FlexMFModel
 _log = get_logger(__name__)
 
 
-@dataclass
-class FlexMFConfigBase:
+class FlexMFConfigBase(EmbeddingSizeMixin, BaseModel):
     """
     Common configuration for all FlexMF scoring components.
 
@@ -33,10 +33,7 @@ class FlexMFConfigBase:
         Experimental
     """
 
-    embedding_size: int = 50
-    """
-    The dimension of the embedding space (number of latent features).
-    """
+    embedding_size: PositiveInt = 64
 
     batch_size: int = 8 * 1024
     """

--- a/src/lenskit/flexmf/_explicit.py
+++ b/src/lenskit/flexmf/_explicit.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import torch
 from torch.nn import functional as F
 from typing_extensions import Literal, override
@@ -23,7 +21,6 @@ from ._training import (
 )
 
 
-@dataclass
 class FlexMFExplicitConfig(FlexMFConfigBase):
     """
     Configuration for :class:`FlexMFExplicitScorer`.  This class overrides

--- a/src/lenskit/flexmf/_implicit.py
+++ b/src/lenskit/flexmf/_implicit.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
 import numpy as np
@@ -27,7 +26,6 @@ ImplicitLoss: TypeAlias = Literal["logistic", "pairwise", "warp"]
 NegativeStrategy: TypeAlias = Literal["uniform", "popular", "misranked"]
 
 
-@dataclass
 class FlexMFImplicitConfig(FlexMFConfigBase):
     """
     Configuration for :class:`FlexMFImplicitScorer`.  It inherits base model

--- a/src/lenskit/funksvd.py
+++ b/src/lenskit/funksvd.py
@@ -18,6 +18,7 @@ from typing_extensions import override
 
 from lenskit._accel import FunkSVDTrainer
 from lenskit.basic import BiasModel, Damping
+from lenskit.config.common import EmbeddingSizeMixin
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery, Vocabulary
 from lenskit.data.types import NPMatrix
 from lenskit.logging import Stopwatch, get_logger
@@ -30,7 +31,7 @@ _logger = get_logger(__name__)
 INITIAL_VALUE = 0.1
 
 
-class FunkSVDConfig(BaseModel):
+class FunkSVDConfig(EmbeddingSizeMixin, BaseModel):
     "Configuration for :class:`FunkSVDScorer`."
 
     embedding_size: PositiveInt = Field(

--- a/src/lenskit/graphs/lightgcn.py
+++ b/src/lenskit/graphs/lightgcn.py
@@ -11,16 +11,16 @@ LightGCN recommendation.
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass
 
 import numpy as np
 import torch
-from pydantic import PositiveFloat, PositiveInt, model_validator
+from pydantic import BaseModel, PositiveFloat, PositiveInt, model_validator
 from structlog.stdlib import BoundLogger
 from torch_geometric.nn import LightGCN
 from typing_extensions import Literal, Self
 
 from lenskit import logging
+from lenskit.config.common import EmbeddingSizeMixin
 from lenskit.data import BatchIter, Dataset, ItemList, QueryInput, RecQuery, Vocabulary
 from lenskit.data.matrix import COOStructure
 from lenskit.data.relationships import MatrixRelationshipSet
@@ -32,8 +32,7 @@ from lenskit.training import ModelTrainer, TrainingOptions, UsesTrainer
 _log = logging.get_logger(__name__)
 
 
-@dataclass
-class LightGCNConfig:
+class LightGCNConfig(EmbeddingSizeMixin, BaseModel):
     """
     Configuration for :class:`LightGCNScorer`.
 

--- a/src/lenskit/logging/multiprocess/_protocol.py
+++ b/src/lenskit/logging/multiprocess/_protocol.py
@@ -44,7 +44,7 @@ class LogChannel(Enum):
 
 
 class ProgressField(NamedTuple):
-    value: int | float | str
+    value: int | float | str | None
     format: str | None = None
 
 

--- a/src/lenskit/logging/progress/_rich.py
+++ b/src/lenskit/logging/progress/_rich.py
@@ -83,8 +83,10 @@ class RichProgress(Progress):
 
         fields = {}
         if update.fields:
-            cls._field_format = _make_format({n: f.format for (n, f) in update.fields.items()})
-            fields = {n: f.value for (n, f) in update.fields.items()}
+            cls._field_format = _make_format(
+                {n: f.format for (n, f) in update.fields.items() if f.value is not None}
+            )
+            fields = {n: f.value for (n, f) in update.fields.items() if f.value is not None}
         else:
             cls._field_format = ""
 

--- a/src/lenskit/sklearn/nmf.py
+++ b/src/lenskit/sklearn/nmf.py
@@ -14,10 +14,11 @@ This module contains a non-negative factorization implicit-feedback scorer built
 from __future__ import annotations
 
 import numpy as np
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, PositiveInt
 from sklearn.decomposition import non_negative_factorization
 from typing_extensions import Literal, override
 
+from lenskit.config.common import EmbeddingSizeMixin
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery
 from lenskit.data.types import NPMatrix
 from lenskit.data.vocab import Vocabulary
@@ -28,7 +29,7 @@ from lenskit.training import Trainable, TrainingOptions
 _log = get_logger(__name__)
 
 
-class NMFConfig(BaseModel, extra="forbid"):
+class NMFConfig(EmbeddingSizeMixin, BaseModel, extra="forbid"):
     """
     Configuration for :class:`NMFScorer`.
     See the documentation for :func:`sklearn.decomposition.non_negative_factorization`
@@ -37,9 +38,9 @@ class NMFConfig(BaseModel, extra="forbid"):
     """
 
     beta_loss: Literal["frobenius", "kullback-leibler", "itakura-saito"] = "frobenius"
-    max_iter: int = Field(default=200, validation_alias=AliasChoices("max_iter", "epochs"))
-    n_components: int | None = Field(
-        default=None, validation_alias=AliasChoices("n_components", "embedding_size")
+    max_iter: PositiveInt = Field(default=200, validation_alias=AliasChoices("max_iter", "epochs"))
+    embedding_size: PositiveInt | None = Field(
+        default=None, validation_alias=AliasChoices("embedding_size", "n_components")
     )
     alpha_W: float = 0.0
     alpha_H: float | Literal["same"] = "same"
@@ -78,7 +79,7 @@ class NMFScorer(Component[ItemList], Trainable):
             r_mat,
             beta_loss=self.config.beta_loss,
             max_iter=self.config.max_iter,
-            n_components=self.config.n_components,
+            n_components=self.config.embedding_size,
             alpha_W=self.config.alpha_W,
             alpha_H=self.config.alpha_H,
             l1_ratio=self.config.l1_ratio,

--- a/src/lenskit/sklearn/svd.py
+++ b/src/lenskit/sklearn/svd.py
@@ -13,15 +13,14 @@ This module contains a truncated SVD explicit-feedback scorer built on
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, BaseModel, Field
 from sklearn.decomposition import TruncatedSVD
 from typing_extensions import Literal, override
 
 from lenskit.basic import BiasModel, Damping
+from lenskit.config.common import EmbeddingSizeMixin
 from lenskit.data import Dataset, ItemList, QueryInput, RecQuery
 from lenskit.data.vocab import Vocabulary
 from lenskit.logging import Stopwatch, get_logger
@@ -31,8 +30,7 @@ from lenskit.training import Trainable, TrainingOptions
 _log = get_logger(__name__)
 
 
-@dataclass
-class BiasedSVDConfig:
+class BiasedSVDConfig(EmbeddingSizeMixin, BaseModel):
     embedding_size: int = Field(
         default=50, validation_alias=AliasChoices("embedding_size", "features")
     )

--- a/tests/flexmf/test_flexmf_implicit.py
+++ b/tests/flexmf/test_flexmf_implicit.py
@@ -30,6 +30,26 @@ class TestFlexMFWARP(BasicComponentTests, ScorerTests):
     config = FlexMFImplicitConfig(loss="warp")
 
 
+def test_config_defaults():
+    cfg = FlexMFImplicitConfig()
+    assert cfg.embedding_size == 64
+
+
+def test_config_exp_ctor():
+    cfg = FlexMFImplicitConfig(embedding_size_exp=5)  # type: ignore
+    assert cfg.embedding_size == 32
+
+
+def test_config_exp_dict():
+    cfg = FlexMFImplicitConfig.model_validate({"embedding_size_exp": 10})
+    assert cfg.embedding_size == 1024
+
+
+def test_config_exp_json():
+    cfg = FlexMFImplicitConfig.model_validate_json('{"embedding_size_exp": 2}')
+    assert cfg.embedding_size == 4
+
+
 @mark.slow
 @mark.parametrize(["loss", "reg"], product(["logistic", "pairwise"], ["L2", "AdamW"]))
 def test_flexmf_train_config(ml_ds, loss, reg):

--- a/tests/models/test_als_implicit.py
+++ b/tests/models/test_als_implicit.py
@@ -33,6 +33,16 @@ class TestImplicitALS(BasicComponentTests, ScorerTests):
     expected_ndcg = 0.22
 
 
+def test_config_defaults():
+    cfg = ImplicitMFConfig()
+    assert cfg.embedding_size == 50
+
+
+def test_config_es_alias():
+    cfg = ImplicitMFConfig(features=72)  # type: ignore
+    assert cfg.embedding_size == 72
+
+
 def test_config_exp_ctor():
     cfg = ImplicitMFConfig(embedding_size_exp=5)  # type: ignore
     assert cfg.embedding_size == 32

--- a/tests/models/test_als_implicit.py
+++ b/tests/models/test_als_implicit.py
@@ -13,6 +13,7 @@ import pandas as pd
 from pytest import approx, mark
 
 from lenskit.als import ImplicitMFScorer
+from lenskit.als._implicit import ImplicitMFConfig
 from lenskit.data import Dataset, ItemList, RecQuery, from_interactions_df, load_movielens_df
 from lenskit.metrics import quick_measure_model
 from lenskit.pipeline import topn_pipeline
@@ -30,6 +31,21 @@ simple_dsr = from_interactions_df(simple_dfr)
 class TestImplicitALS(BasicComponentTests, ScorerTests):
     component = ImplicitMFScorer
     expected_ndcg = 0.22
+
+
+def test_config_exp_ctor():
+    cfg = ImplicitMFConfig(embedding_size_exp=5)  # type: ignore
+    assert cfg.embedding_size == 32
+
+
+def test_config_exp_dict():
+    cfg = ImplicitMFConfig.model_validate({"embedding_size_exp": 10})
+    assert cfg.embedding_size == 1024
+
+
+def test_config_exp_json():
+    cfg = ImplicitMFConfig.model_validate_json('{"embedding_size_exp": 2}')
+    assert cfg.embedding_size == 4
 
 
 def test_als_basic_build():


### PR DESCRIPTION
This adds the idea of “common configuration mixins”, to define common behavior across multiple configuration classes, and defines one for `embedding_size`, that has the useful behavior of supporting an `embedding_size_exp` alias to specify the embedding size as a power of 2.