### PR TITLE
Fix Conda builds + GNN tests

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -65,6 +65,7 @@ outputs:
             - lenskit.data
             - lenskit.als
             - lenskit.knn
+          pip_check: false
       - script:
           - python -m lenskit --verbose doctor --full
       - script:
@@ -108,6 +109,7 @@ outputs:
       - python:
           imports:
             - lenskit.sklearn.svd
+          pip_check: false
       - script:
           - pytest -m "not slow" tests/sklearn
         files:
@@ -138,6 +140,7 @@ outputs:
       - python:
           imports:
             - lenskit.implicit
+          pip_check: false
       - script:
           - pytest -m "not slow" tests/implicit
         files:
@@ -168,6 +171,7 @@ outputs:
       - python:
           imports:
             - lenskit.hpf
+          pip_check: false
       - script:
           - pytest -m "not slow" tests/hpf
         files:
@@ -197,9 +201,10 @@ outputs:
     tests:
       - python:
           imports:
-            - lenskit.hpf
+            - lenskit.graphs.lightgcn
+          pip_check: false
       - script:
-          - pytest -m "not slow" tests/hpf
+          - pytest -m "not slow" tests/graphs
         files:
           source:
             - tests/


### PR DESCRIPTION
This fixes the broken Conda builds by disabling `pip_check`, and fixes the tests for the GNN package to correctly test it instead of HPF.