### PR TITLE
Enable CI tests for the hyperparameter tuning

### DIFF
--- a/tests/tuning/test_basic_tuning.py
+++ b/tests/tuning/test_basic_tuning.py
@@ -14,6 +14,7 @@ from lenskit.tuning import PipelineTuner, TuningSpec
 
 
 @mark.slow
+@mark.realdata
 def test_tune_bias(ml_100k, tmpdir):
     spec = TuningSpec.load(Path("pipelines/bias-search.toml"))
     tuner = PipelineTuner(spec, Path(tmpdir))

--- a/tests/tuning/test_iterative_tuning.py
+++ b/tests/tuning/test_iterative_tuning.py
@@ -14,6 +14,7 @@ from lenskit.tuning import PipelineTuner, TuningSpec
 
 
 @mark.slow
+@mark.realdata
 def test_tune_als(ml_100k, tmpdir):
     spec = TuningSpec.load(Path("pipelines/als-implicit-search.toml"))
     spec.search.method = "random"


### PR DESCRIPTION
Add appropriate markers to enable hyperparameter tuning tests in the CI runs.