### PR TITLE
Fix Jupyter progress bar rate limit

### DIFF
--- a/src/lenskit/logging/progress/_notebook.py
+++ b/src/lenskit/logging/progress/_notebook.py
@@ -42,6 +42,7 @@ class JupyterProgress(Progress):  # pragma: nocover
         fields: dict[str, str | None],
     ):
         super().__init__()
+        self._limit = RateLimit()
         self.current = 0
         self.total = total
         if total:


### PR DESCRIPTION
This adds a missing `_limit` instantiation to the Jupyter progress bar implementation.