### PR TITLE
Resolves #956: Fix NDCG ZeroDivisionError

### DIFF
--- a/src/lenskit/metrics/ranking/_dcg.py
+++ b/src/lenskit/metrics/ranking/_dcg.py
@@ -96,6 +96,9 @@ class NDCG(ListMetric, RankingMetricBase):
     def measure_list(self, recs: ItemList, test: ItemList) -> float:
         recs = self.truncate(recs)
 
+        if len(test) == 0:
+            return float("nan")
+
         if self.gain:
             realized = _graded_dcg(recs, test, self.gain, self.weight)
 

--- a/tests/eval/test_rank_ndcg.py
+++ b/tests/eval/test_rank_ndcg.py
@@ -24,6 +24,13 @@ def test_ndcg_empty():
     assert call_metric(NDCG, recs, truth) == approx(0.0)
 
 
+def test_ndcg_empty_truth_returns_nan():
+    recs = ItemList([1, 2, 3], ordered=True)
+    truth = ItemList(ordered=True)
+    val = call_metric(NDCG, recs, truth)
+    assert np.isnan(val)
+
+
 def test_ndcg_no_match():
     recs = ItemList([4], ordered=True)
     truth = ItemList([1, 2, 3], rating=[3.0, 5.0, 4.0])


### PR DESCRIPTION
This PR resolves #956. It updates NDCG to safely handle cases where the ideal DCG is zero by returning NaN instead of raising ZeroDivisionError