### PR TITLE
Put LightGCN in eval mode after training (2025)

### DIFF
--- a/src/lenskit/graphs/lightgcn.py
+++ b/src/lenskit/graphs/lightgcn.py
@@ -1,6 +1,6 @@
 # This file is part of LensKit.
 # Copyright (C) 2018-2023 Boise State University.
-# Copyright (C) 2023-2025 Drexel University.
+# Copyright (C) 2023-2026 Drexel University.
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
@@ -296,7 +296,7 @@ class LightGCNTrainer(ModelTrainer):
         return {"loss": avg_loss}
 
     def finalize(self):
-        pass
+        self.model.eval()
 
     def batch_loss(self, mb_edges: torch.Tensor, scores: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError()


### PR DESCRIPTION
This adds a `model.eval()` call to the LightGCN trainer's `finalize()`, to put the model in eval mode before inference.

This is the 2025.x version of the change.