### PR TITLE
Put LightGCN in eval mode after training

### DIFF
--- a/src/lenskit/graphs/lightgcn.py
+++ b/src/lenskit/graphs/lightgcn.py
@@ -296,7 +296,7 @@ class LightGCNTrainer(ModelTrainer):
         return {"loss": avg_loss}
 
     def finalize(self):
-        pass
+        self.model.eval()
 
     def batch_loss(self, mb_edges: torch.Tensor, scores: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError()


### PR DESCRIPTION
This puts the LightGCN model into eval mode after training completes (cf. #975).