### PR TITLE
Drop failing x86 wheel builds (2025)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,10 +71,6 @@ jobs:
             pyarch: x64
             target: x86_64
             manylinux: 2_28
-          - host: ubuntu-22.04
-            pyarch: x64
-            target: x86
-            manylinux: 2014
           - host: ubuntu-24.04-arm
             pyarch: arm64
             target: aarch64


### PR DESCRIPTION
This removes the failing x86 wheel builds for the 2025 series.