### PR TITLE
Automatically fall back to SciPy when Torch does not have enough memory for EASE

### DIFF
--- a/src/lenskit/knn/ease.py
+++ b/src/lenskit/knn/ease.py
@@ -127,10 +127,6 @@ class EASEScorer(Component[ItemList], Trainable):
         di = np.diag_indices(n_ok)
         cooc[di] += self.config.regularization
 
-        # this is a silly trick to *transfer* ownership of the object to another
-        # function, allowing for earlier freeing of the matrix memory.
-        cooc = [cooc]
-
         log.debug("inverting Gram-matrix")
         timer = Stopwatch()
         mat = None
@@ -202,22 +198,22 @@ class EASEScorer(Component[ItemList], Trainable):
         return items.update(scored)
 
 
-def _chol_invert_scipy(cooc: list[NPMatrix[np.float32]]) -> NPMatrix[np.float32]:
+def _chol_invert_scipy(cooc: NPMatrix[np.float32]) -> NPMatrix[np.float32]:
     """
     Invert the co-occurrance matrix using SciPy.
     """
-    return spla.inv(cooc.pop(), assume_a="pos", overwrite_a=True)
+    return spla.inv(cooc, assume_a="pos", overwrite_a=True)
 
 
 def _chol_invert_torch(
-    cooc: list[NPMatrix[np.float32]], device: str, *, raise_oom: bool = False
+    cooc: NPMatrix[np.float32], device: str, *, raise_oom: bool = False
 ) -> NPMatrix[np.float32] | None:
     """
     Invert the co-occurrance matrix using SciPy.
     """
 
     with torch.inference_mode():
-        cooc_t = torch.from_numpy(cooc.pop()).to(device)
+        cooc_t = torch.from_numpy(cooc).to(device)
         del cooc
 
         decomp, info = torch.linalg.cholesky_ex(cooc_t)


### PR DESCRIPTION
When PyTorch has insufficient memory to invert the matrix in EASE training, SciPy might still succeed, both because it uses CPU memory and because it can (theoretically) solve in-place. This PR adds auto-fallback logic to EASE (with a warning).

To disable auto-fallback, set `LK_EASE_SOLVER=torch`.