### PR TITLE
Build free-threaded wheels for Python 3.14t

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -112,6 +112,7 @@ jobs:
 
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
+        if: matrix.plat.host != 'windows-latest'
         with:
           args: --release --out dist -i 3.14t
           target: ${{ matrix.plat.target }}

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -39,7 +39,7 @@ New Features
   :meth:`~lenskit.training.TrainingOptions.envvar` method to query them.  This allows for
   open-ended configuration of training processes.
 - Added support for free-threaded Python, including binary distributions for
-  Python 3.14t (:issue:`916`, :pr:`1022`).
+  Python 3.14t on Linux and macOS (:issue:`916`, :pr:`1022`).
 
 Performance Changes
 -------------------


### PR DESCRIPTION
This adds free-threaded wheels to the build set.

Closes #916.