### PR TITLE
Remove macOS Intel wheel builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,10 +79,6 @@ jobs:
             pyarch: x64
             target: x64
             manylinux: auto
-          - host: macos-15-intel
-            pyarch: x64
-            target: x86_64
-            manylinux: auto
           - host: macos-14
             pyarch: arm64
             target: aarch64

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -26,6 +26,11 @@ Breaking Changes
   results should directly extend from ``Metric`` or :class:`~lenskit.metrics.ListMetric`.
   (:pr:`983`)
 - ``GlobalMetric`` no longer inherits from ``Metric``, and may be removed in a future release.
+- Stopped providing wheels for macOS on Intel.  Users who still need to run
+  LensKit on Intel-based Macs should use the Conda packages (available in conda-forge and
+  `prefix.dev`_).
+
+.. _prefix.dev: https://prefix.dev/channels/lenskit/
 
 New Features
 ------------


### PR DESCRIPTION
This removes macOS on Intel from our wheel builds, due to dropped support from an upstream dependency.

Intel Mac users should install LensKit with Conda.