### PR TITLE
Remove deprecated IterativeTraining abstract class

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -36,6 +36,8 @@ Breaking Changes
 - Stopped providing wheels for macOS on Intel.  Users who still need to run
   LensKit on Intel-based Macs should use the Conda packages (available in conda-forge and
   `prefix.dev`_).
+- Removed the deprecated ``lenskit.training.IterativeTraining`` base class in
+  favor of :class:`lenskit.training.UsesTrainer`.
 
 .. _prefix.dev: https://prefix.dev/channels/lenskit/
 

--- a/src/lenskit/training.py
+++ b/src/lenskit/training.py
@@ -13,9 +13,7 @@ from __future__ import annotations
 
 import os
 import re
-import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
 from dataclasses import dataclass, field
 from time import perf_counter
 from typing import TYPE_CHECKING, Literal, Protocol, overload, runtime_checkable
@@ -203,28 +201,19 @@ class Trainable(Protocol):  # pragma: nocover
         raise NotImplementedError()
 
 
-class IterativeTraining(ABC, Trainable):
+class UsesTrainer(Component, ABC, Trainable):
     """
-    Base class for components that support iterative training.  This both
-    automates the :meth:`Trainable.train` method for iterative training in terms
-    of initialization, epoch, and finalization methods, and exposes those
-    methods to client code that may wish to directly control the iterative
-    training process.
+    Base class for models that implement :class:`Trainable` via a
+    :class:`ModelTrainer`.
 
-    .. deprecated: 2025.3
-
-        This base class is deprecated in favor of :class:`ModelTrainer` and
-        :class:`UsesTrainer`, which are a better fit for integration with
-        tools like Ray Tune.
+    The component's configuration must have an ``epochs`` attribute defining the
+    number of epochs to train.
 
     Stability:
         Full
     """
 
     trained_epochs: int = 0
-    """
-    The number of epochs for which this model has been trained.
-    """
 
     @property
     def expected_training_epochs(self) -> int | None:
@@ -236,70 +225,6 @@ class IterativeTraining(ABC, Trainable):
         cfg = getattr(self, "config", None)
         if cfg:
             return getattr(cfg, "epochs", None)
-
-    def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()) -> None:
-        """
-        Implementation of :meth:`Trainable.train` that uses the training loop.
-        It also uses the :attr:`trained_epochs` attribute to detect if the model
-        has already been trained for the purposes of honoring
-        :attr:`TrainingOptions.retrain`, and updates that attribute as model
-        training progresses.
-        """
-        if self.trained_epochs > 0 and not options.retrain:
-            return
-
-        self.trained_epochs = 0
-        log = _log.bind(model=f"{self.__class__.__module__}.{self.__class__.__qualname__}")
-        log.info("training model")
-        n = self.expected_training_epochs
-        log.debug("creating training loop")
-        loop = self.training_loop(data, options)
-        log.debug("beginning training epochs")
-        with item_progress("Training epochs", total=n) as pb:
-            start = perf_counter()
-            for i, metrics in enumerate(loop, 1):
-                metrics = metrics or {}
-                now = perf_counter()
-                elapsed = now - start
-                log.info("finished epoch", time="{:.1f}s".format(elapsed), epoch=i, **metrics)
-                self.trained_epochs += 1
-                start = now
-                pb.update()
-
-        log.info("model training finished", epochs=self.trained_epochs)
-
-    @abstractmethod
-    def training_loop(
-        self, data: Dataset, options: TrainingOptions
-    ) -> Iterator[dict[str, float] | None]:
-        """
-        Training loop implementation, to be supplied by the derived class.  This
-        method should return a iterator that, when iterated, will perform each
-        training epoch; when training is complete, it should finalize the model
-        and signal iteration completion.
-
-        Each epoch can yield metrics, such as training or validation loss, to be
-        logged with structured logging and can be used by calling code to do
-        other analysis.
-
-        See :ref:`iterative-training` for more details on writing iterative
-        training loops.
-        """
-        raise NotImplementedError()
-
-
-class UsesTrainer(IterativeTraining, Component, ABC):
-    """
-    Base class for models that implement :class:`Trainable` via a
-    :class:`ModelTrainer`.  This class implements :class:`IterativeTraining` for
-    compatibility, but the :class:`IterativeTraining` interface is deprecated.
-
-    The component's configuration must have an ``epochs`` attribute defining the
-    number of epochs to train.
-
-    Stability:
-        Full
-    """
 
     def train(self, data: Dataset, options: TrainingOptions = TrainingOptions()) -> None:
         """
@@ -334,33 +259,6 @@ class UsesTrainer(IterativeTraining, Component, ABC):
         trainer.finalize()
 
         log.info("model training finished", epochs=self.trained_epochs)
-
-    def training_loop(self, data: Dataset, options: TrainingOptions):
-        warnings.warn("IteratativeTraining API is deprecated", DeprecationWarning)
-
-        log = _log.bind(model=f"{self.__class__.__module__}.{self.__class__.__qualname__}")
-        log.info("training model")
-        n = self.expected_training_epochs
-        assert n is not None, "no training epochs configured"
-        log.debug("creating model trainer")
-        trainer = self.create_trainer(data, options)
-
-        log.debug("beginning training epochs")
-        with item_progress("Training epochs", total=n) as pb:
-            start = perf_counter()
-            for i in range(1, n + 1):
-                metrics = trainer.train_epoch()
-                metrics = metrics or {}
-                now = perf_counter()
-                elapsed = now - start
-                log.info("finished epoch", time="{:.1f}s".format(elapsed), epoch=i, **metrics)
-                start = now
-                self.trained_epochs += 1
-                pb.update()
-                yield metrics
-
-        log.debug("finalizing model")
-        trainer.finalize()
 
     @abstractmethod
     def create_trainer(


### PR DESCRIPTION
This removes the deprecated `IterativeTraining` class in favor of `UsesTrainer`.