### PR TITLE
Rework the metric interface and collection to use explicit accumulators

### DIFF
--- a/docs/guide/GettingStarted.ipynb
+++ b/docs/guide/GettingStarted.ipynb
@@ -31,7 +31,7 @@
     "from lenskit.batch import recommend\n",
     "from lenskit.data import ItemListCollection, UserIDKey, load_movielens\n",
     "from lenskit.knn import ItemKNNScorer\n",
-    "from lenskit.metrics import NDCG, RBP, RecipRank, RunAnalysis\n",
+    "from lenskit.metrics import NDCG, RBP, MeasurementCollector, RecipRank\n",
     "from lenskit.pipeline import topn_pipeline\n",
     "from lenskit.splitting import SampleFrac, crossfold_users"
    ]
@@ -84,6 +84,16 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mde48/LensKit/lkpy/src/lenskit/data/movielens.py:143: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.\n",
+      "  return pd.read_csv(\n",
+      "/Users/mde48/LensKit/lkpy/src/lenskit/data/movielens.py:157: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.\n",
+      "  return pd.read_csv(\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
        "<div>\n",
@@ -116,47 +126,47 @@
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>5.0</td>\n",
-       "      <td>874965758</td>\n",
+       "      <td>1997-09-22 22:02:38</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>1</td>\n",
        "      <td>2</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>876893171</td>\n",
+       "      <td>1997-10-15 05:26:11</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>1</td>\n",
        "      <td>3</td>\n",
        "      <td>4.0</td>\n",
-       "      <td>878542960</td>\n",
+       "      <td>1997-11-03 07:42:40</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>1</td>\n",
        "      <td>4</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>876893119</td>\n",
+       "      <td>1997-10-15 05:25:19</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>1</td>\n",
        "      <td>5</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>889751712</td>\n",
+       "      <td>1998-03-13 01:15:12</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   user_id  item_id  rating  timestamp\n",
-       "0        1        1     5.0  874965758\n",
-       "1        1        2     3.0  876893171\n",
-       "2        1        3     4.0  878542960\n",
-       "3        1        4     3.0  876893119\n",
-       "4        1        5     3.0  889751712"
+       "   user_id  item_id  rating           timestamp\n",
+       "0        1        1     5.0 1997-09-22 22:02:38\n",
+       "1        1        2     3.0 1997-10-15 05:26:11\n",
+       "2        1        3     4.0 1997-11-03 07:42:40\n",
+       "3        1        4     3.0 1997-10-15 05:25:19\n",
+       "4        1        5     3.0 1998-03-13 01:15:12"
       ]
      },
      "execution_count": 4,
@@ -227,16 +237,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/mde48/LensKit/lkpy/lenskit/lenskit/als/_explicit.py:59: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /Users/runner/miniforge3/conda-bld/libtorch_1733624403138/work/aten/src/ATen/SparseCsrTensorImpl.cpp:55.)\n",
-      "  rmat = rmat.to_sparse_csr()\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# test data is organized by user\n",
     "all_test = ItemListCollection(UserIDKey)\n",
@@ -272,15 +273,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "ran = RunAnalysis()\n",
-    "ran.add_metric(NDCG())\n",
-    "ran.add_metric(RBP())\n",
-    "ran.add_metric(RecipRank())\n",
-    "results = ran.measure(all_recs, all_test)"
+    "mc = MeasurementCollector()\n",
+    "mc.add_metric(NDCG())\n",
+    "mc.add_metric(RBP())\n",
+    "mc.add_metric(RecipRank())\n",
+    "mc.measure_collection(all_recs, all_test)\n",
+    "list_metrics = mc.list_metrics()"
    ]
   },
   {
@@ -330,15 +332,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>ALS</th>\n",
-       "      <td>0.125894</td>\n",
-       "      <td>0.088839</td>\n",
-       "      <td>0.19244</td>\n",
+       "      <td>0.126339</td>\n",
+       "      <td>0.077297</td>\n",
+       "      <td>0.203852</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>II</th>\n",
-       "      <td>0.095334</td>\n",
-       "      <td>0.036945</td>\n",
-       "      <td>0.10837</td>\n",
+       "      <td>0.094060</td>\n",
+       "      <td>0.043014</td>\n",
+       "      <td>0.107132</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -347,8 +349,8 @@
       "text/plain": [
        "           NDCG       RBP  RecipRank\n",
        "model                               \n",
-       "ALS    0.125894  0.088839    0.19244\n",
-       "II     0.095334  0.036945    0.10837"
+       "ALS    0.126339  0.077297   0.203852\n",
+       "II     0.094060  0.043014   0.107132"
       ]
      },
      "execution_count": 9,
@@ -357,7 +359,7 @@
     }
    ],
    "source": [
-    "results.list_metrics().groupby(\"model\").mean()"
+    "list_metrics.groupby(\"model\").mean()"
    ]
   },
   {
@@ -367,7 +369,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfsAAAHpCAYAAACFlZVCAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8ekN5oAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAorUlEQVR4nO3df3DU9YH/8deSn9RADD/cABNiwALJRFQ2yiUa8SoXftwpzKGNPwijB96EOkKSQiEEDsVKRkHKUEg4MEGZKuSmwKC9WImeMNSkpcSEVhvxOgTC5bKFRC4L+DUh4fP9g2HbdRMkZMNnefN8zOwM+9n357Pvz0y3Tz+ffD67DsuyLAEAAGP1s3sCAACgbxF7AAAMR+wBADAcsQcAwHDEHgAAwxF7AAAMR+wBADAcse+CZVnyeDziKwgAACYg9l04e/asoqOjdfbsWbunAgBArxF7AAAMR+wBADAcsQcAwHDEHgAAwxF7AAAMR+wBADAcsQcAwHDEHgAAwxF7AAAMR+wBADAcsQcAwHDEHgAAwxF7AAAMR+wBADAcsQcAwHDEHgAAwxF7AAAMF2r3BICesixL58+f9z6/5ZZb5HA4bJwRAAQ3Yo8bzvnz5zVjxgzv87179yoqKsrGGQFAcOM0PgAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGC4ULsncDNxLd5u9xSM4OhoV/TfPH9oxU5ZoeG2zccE1Wvm2D0FAH2II3sAAAxH7AEAMByxBwDAcMQeAADDEXsAAAxH7AEAMByxBwDAcMQeAADDEXsAAAxH7AEAMByxBwDAcMQeAADDEXsAAAxne+yLioqUkJCgyMhIuVwuHTx4sNuxTU1NeuqppzR27Fj169dPOTk5fmO2bt2q9PR0xcTEKCYmRpMnT9ahQ4f6cA8AAAhutsa+rKxMOTk5KigoUE1NjdLT0zVt2jQ1NDR0Ob6trU1Dhw5VQUGB7rrrri7H7N+/X08++aQ+/vhjVVVVaeTIkcrIyFBjY2Nf7goAAEHLYVmWZdebT5w4URMmTFBxcbF3WWJiombOnKnCwsIrrvvQQw/p7rvv1vr16684rrOzUzExMdq4caPmzLm63+z2eDyKjo5Wa2urBg4ceFXrXA1+zz4wHB3tiv7DDu/z1vFP8nv2vcTv2QNms+3Ivr29XdXV1crIyPBZnpGRocrKyoC9z9dff60LFy5o0KBB3Y5pa2uTx+PxeQAAYArbYt/c3KzOzk45nU6f5U6nU263O2Dvs3TpUo0YMUKTJ0/udkxhYaGio6O9j7i4uIC9PwAAdrP9Aj2Hw+Hz3LIsv2XX6rXXXtOOHTu0e/duRUZGdjsuPz9fra2t3sfJkycD8v4AAASDULveeMiQIQoJCfE7ij916pTf0f61WLt2rVavXq0PP/xQ48ePv+LYiIgIRURE9Po9AQAIRrYd2YeHh8vlcqmiosJneUVFhdLS0nq17TVr1ujll1/Wr3/9a6WkpPRqWwAA3OhsO7KXpLy8PGVlZSklJUWpqanasmWLGhoalJ2dLenS6fXGxkZt3/7Xq9hra2slSefOndPp06dVW1ur8PBwJSUlSbp06n7FihV65513dPvtt3vPHERFRSkqKur67iAAAEHA1thnZmaqpaVFq1atUlNTk5KTk1VeXq74+HhJl75E59v33N9zzz3ef1dXV+udd95RfHy8jh8/LunSl/S0t7frscce81lv5cqVevHFF/t0fwAACEa23mcfrLjPPshZlhydF/76NCRMCtBFnTcr7rMHzGbrkT1wTRwOvkQHAHrA9lvvAABA3yL2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGC4ULsnAAC4vizL0vnz573Pb7nlFjkcDhtnhL5G7AHgJnP+/HnNmDHD+3zv3r2KioqycUboa7afxi8qKlJCQoIiIyPlcrl08ODBbsc2NTXpqaee0tixY9WvXz/l5OR0OW7Xrl1KSkpSRESEkpKStGfPnj6aPQAAwc/W2JeVlSknJ0cFBQWqqalRenq6pk2bpoaGhi7Ht7W1aejQoSooKNBdd93V5ZiqqiplZmYqKytLR44cUVZWln74wx/qd7/7XV/uCgAAQcthWZZl15tPnDhREyZMUHFxsXdZYmKiZs6cqcLCwiuu+9BDD+nuu+/W+vXrfZZnZmbK4/Ho/fff9y6bOnWqYmJitGPHjqual8fjUXR0tFpbWzVw4MCr36Hv4Fq8PWDbAgKpes0cu6eA6+jcuXOcxr/J2HZk397erurqamVkZPgsz8jIUGVl5TVvt6qqym+bU6ZMueI229ra5PF4fB4AAJjCttg3Nzers7NTTqfTZ7nT6ZTb7b7m7brd7h5vs7CwUNHR0d5HXFzcNb8/AADBxvYL9L59u4dlWb2+BaSn28zPz1dra6v3cfLkyV69PwAAwcS2W++GDBmikJAQvyPuU6dO+R2Z90RsbGyPtxkREaGIiIhrfk8AAIKZbUf24eHhcrlcqqio8FleUVGhtLS0a95uamqq3zb37dvXq20CAHAjs/VLdfLy8pSVlaWUlBSlpqZqy5YtamhoUHZ2tqRLp9cbGxu1fftfr2Kvra2VdOlq0tOnT6u2tlbh4eFKSkqSJC1cuFAPPvigXn31Vc2YMUN79+7Vhx9+qN/85jfXff8AAAgGtsY+MzNTLS0tWrVqlZqampScnKzy8nLFx8dLuvQlOt++5/6ee+7x/ru6ulrvvPOO4uPjdfz4cUlSWlqadu7cqeXLl2vFihUaPXq0ysrKNHHixOu2XwAABBNb77MPVtxnj5sN99nfXLjP/uZj+9X4AACgbxF7AAAMR+wBADAcsQcAwHDEHgAAwxF7AAAMR+wBADCcrV+qAwA9wXdVBIajo13Rf/P8oRU7ZYWG2zYfEwT7d1VwZA8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhgu1ewIAgOvLCglT6/gnfZ7DbMQeAG42Does0HC7Z4HriNP4AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA4Yg8AgOGIPQAAhiP2AAAYjtgDAGA422NfVFSkhIQERUZGyuVy6eDBg1ccf+DAAblcLkVGRmrUqFHavHmz35j169dr7Nix6t+/v+Li4pSbm6tvvvmmr3YBAICgZmvsy8rKlJOTo4KCAtXU1Cg9PV3Tpk1TQ0NDl+Pr6+s1ffp0paenq6amRsuWLdOCBQu0a9cu75i3335bS5cu1cqVK1VXV6eSkhKVlZUpPz//eu0WAABBJdTON1+3bp3mzp2refPmSbp0RP7BBx+ouLhYhYWFfuM3b96skSNHav369ZKkxMREHT58WGvXrtWsWbMkSVVVVbr//vv11FNPSZJuv/12Pfnkkzp06ND12SkAAIKMbUf27e3tqq6uVkZGhs/yjIwMVVZWdrlOVVWV3/gpU6bo8OHDunDhgiTpgQceUHV1tTfux44dU3l5uf7xH/+x27m0tbXJ4/H4PAAAMIVtR/bNzc3q7OyU0+n0We50OuV2u7tcx+12dzm+o6NDzc3NGjZsmJ544gmdPn1aDzzwgCzLUkdHh+bPn6+lS5d2O5fCwkK99NJLvd8pAACCkO0X6DkcDp/nlmX5Lfuu8X+7fP/+/XrllVdUVFSkTz/9VLt379avfvUrvfzyy91uMz8/X62trd7HyZMnr3V3AAAIOrYd2Q8ZMkQhISF+R/GnTp3yO3q/LDY2tsvxoaGhGjx4sCRpxYoVysrK8l4HcOedd+r8+fP613/9VxUUFKhfP///vomIiFBEREQgdgsAgKBj25F9eHi4XC6XKioqfJZXVFQoLS2ty3VSU1P9xu/bt08pKSkKCwuTJH399dd+QQ8JCZFlWd6zAAAA3ExsPY2fl5enN954Q6Wlpaqrq1Nubq4aGhqUnZ0t6dLp9Tlz5njHZ2dn68SJE8rLy1NdXZ1KS0tVUlKiRYsWecc88sgjKi4u1s6dO1VfX6+KigqtWLFCjz76qEJCQq77PgIAYDdbb73LzMxUS0uLVq1apaamJiUnJ6u8vFzx8fGSpKamJp977hMSElReXq7c3Fxt2rRJw4cP14YNG7y33UnS8uXL5XA4tHz5cjU2Nmro0KF65JFH9Morr1z3/QMAIBg4LM5t+/F4PIqOjlZra6sGDhwYsO26Fm8P2LaAQKpeM+e7BwUBPkMIVsH+GbL9anwAANC3iD0AAIYj9gAAGI7YAwBgOGIPAIDhiD0AAIYj9gAAGK5HX6pz8eJFff7557rzzjslXfp9+fb2du/rISEhmj9/fpffPw8AAOzRo9jv3LlT//7v/64DBw5IkhYvXqxbb71VoaGXNtPc3KzIyEjNnTs38DMFAADXpEeH4Nu2bfN+b/1lBw4cUH19verr67VmzRr94he/COgEAQBA7/Qo9nV1dUpKSur29UmTJunIkSO9nhQAAAicHp3Gb25uVlRUlPf5sWPHvL8jL0lhYWE6f/584GYHAAB6rUdH9k6nU0ePHvU+Hzp0qM/FeHV1dYqNjQ3c7AAAQK/1KPYPP/xwtz8Va1mWCgsL9fDDDwdkYgAAIDB6dBq/oKBAEyZM0MSJE7Vo0SKNGTNGDodDX3zxhdauXaujR49q+3Z+ghIAgGDSo9iPHj1aFRUVeuaZZ5SZmSmHwyHp0lH9uHHjtG/fPt1xxx19MlEAAHBtehR7Sbrvvvv0pz/9SbW1tfryyy8lSd///vd1zz33BHxyAACg93oce4/Ho6ioKN199926++67vcsvXryoc+fOaeDAgYGcHwAA6KUeXaC3Z88epaSk6JtvvvF77ZtvvtG9996r9957L2CTAwAAvdej2BcXF+snP/mJvve97/m99r3vfU9LlizRxo0bAzY5AADQez2K/WeffaaHHnqo29cffPBB/fGPf+ztnAAAQAD1KPZnzpxRR0dHt69fuHBBZ86c6fWkAABA4PQo9rfffrsOHz7c7euHDx9WfHx8rycFAAACp0ex/+d//mcVFBToL3/5i99rbrdby5cv16xZswI2OQAA0Hs9uvVu6dKl2rt3r77//e9r9uzZGjt2rBwOh+rq6vT2228rLi5OS5cu7au5AgCAa9Cj2A8YMECffPKJ8vPzVVZW5v37fExMjGbPnq3Vq1drwIABfTJRAABwbXr8pTrR0dEqKirSpk2b1NzcLMuyNHToUO9X5wIAgODS49hf1tLSohMnTsjhcCgkJMTnd+0BAEDw6NEFepL0+eef68EHH5TT6dTEiRN133336bbbbtMPfvADn9+6BwAAwaFHR/Zut1uTJk3S0KFDtW7dOo0bN06WZelPf/qTtm7dqvT0dH322We67bbb+mq+AACgh3oU+5/97GeKj4/XJ598osjISO/yqVOnav78+XrggQf0s5/9TIWFhQGfKAAAuDY9Oo1fUVGhJUuW+IT+sv79+2vx4sX64IMPAjY5AADQez2K/bFjxzRhwoRuX09JSdGxY8d6PSkAABA4PYr92bNnr/h79QMGDNC5c+d6PSkAABA4Pb717uzZs12expckj8cjy7J6PSkAABA4PYq9ZVkaM2bMFV/ny3UAAAguPYr9xx9/3FfzAAAAfaRHsZ80aVJfzQMAAPSRHsW+X79+33ma3uFwqKOjo1eTAgAAgdOj2O/Zs6fb1yorK/Xzn/+cC/QAAAgyPYr9jBkz/JZ98cUXys/P13vvvaenn35aL7/8csAmBwAAeq/HP4Rz2f/+7//queee0/jx49XR0aHa2lq99dZbGjlyZCDnBwAAeqnHsW9tbdWSJUt0xx136PPPP9dHH32k9957T8nJyX0xPwAA0Es9Oo3/2muv6dVXX1VsbKx27NjR5Wl9AAAQXHoU+6VLl6p///6644479NZbb+mtt97qctzu3bsDMjkAANB7PYr9nDlz+IY8AABuMD2K/ZtvvtlH0wAAAH3lmq/GBwAANwZiDwCA4Yg9AACGsz32RUVFSkhIUGRkpFwulw4ePHjF8QcOHJDL5VJkZKRGjRqlzZs3+435v//7Pz3//PMaNmyYIiMjlZiYqPLy8r7aBQAAgpqtsS8rK1NOTo4KCgpUU1Oj9PR0TZs2TQ0NDV2Or6+v1/Tp05Wenq6amhotW7ZMCxYs0K5du7xj2tvb9Q//8A86fvy4fvnLX+ro0aPaunWrRowYcb12CwCAoNKjq/EDbd26dZo7d67mzZsnSVq/fr0++OADFRcXq7Cw0G/85s2bNXLkSK1fv16SlJiYqMOHD2vt2rWaNWuWJKm0tFRfffWVKisrFRYWJkmKj4+/PjsEAEAQsu3Ivr29XdXV1crIyPBZnpGRocrKyi7Xqaqq8hs/ZcoUHT58WBcuXJAkvfvuu0pNTdXzzz8vp9Op5ORkrV69Wp2dnd3Opa2tTR6Px+cBAIApbIt9c3OzOjs75XQ6fZY7nU653e4u13G73V2O7+joUHNzsyTp2LFj+uUvf6nOzk6Vl5dr+fLlev311/XKK690O5fCwkJFR0d7H3Fxcb3cOwAAgoftF+h9+xv5LMu64rf0dTX+b5dfvHhRt912m7Zs2SKXy6UnnnhCBQUFKi4u7nab+fn5am1t9T5Onjx5rbsDAEDQse1v9kOGDFFISIjfUfypU6f8jt4vi42N7XJ8aGioBg8eLEkaNmyYwsLCFBIS4h2TmJgot9ut9vZ2hYeH+203IiJCERERvd0lAACCkm1H9uHh4XK5XKqoqPBZXlFRobS0tC7XSU1N9Ru/b98+paSkeC/Gu//++/XnP/9ZFy9e9I758ssvNWzYsC5DDwCA6Ww9jZ+Xl6c33nhDpaWlqqurU25urhoaGpSdnS3p0un1OXPmeMdnZ2frxIkTysvLU11dnUpLS1VSUqJFixZ5x8yfP18tLS1auHChvvzyS/3nf/6nVq9ereeff/667x8AAMHA1lvvMjMz1dLSolWrVqmpqUnJyckqLy/33irX1NTkc899QkKCysvLlZubq02bNmn48OHasGGD97Y7SYqLi9O+ffuUm5ur8ePHa8SIEVq4cKGWLFly3fcPAIBg4LAuX+EGL4/Ho+joaLW2tmrgwIEB265r8faAbQsIpOo1c757UBDgM4RgFeyfIduvxgcAAH2L2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDjbY19UVKSEhARFRkbK5XLp4MGDVxx/4MABuVwuRUZGatSoUdq8eXO3Y3fu3CmHw6GZM2cGeNYAANw4bI19WVmZcnJyVFBQoJqaGqWnp2vatGlqaGjocnx9fb2mT5+u9PR01dTUaNmyZVqwYIF27drlN/bEiRNatGiR0tPT+3o3AAAIarbGft26dZo7d67mzZunxMRErV+/XnFxcSouLu5y/ObNmzVy5EitX79eiYmJmjdvnv7lX/5Fa9eu9RnX2dmpp59+Wi+99JJGjRp1PXYFAICgZVvs29vbVV1drYyMDJ/lGRkZqqys7HKdqqoqv/FTpkzR4cOHdeHCBe+yVatWaejQoZo7d+5VzaWtrU0ej8fnAQCAKWyLfXNzszo7O+V0On2WO51Oud3uLtdxu91dju/o6FBzc7Mk6ZNPPlFJSYm2bt161XMpLCxUdHS09xEXF9fDvQEAIHjZfoGew+HweW5Zlt+y7xp/efnZs2c1e/Zsbd26VUOGDLnqOeTn56u1tdX7OHnyZA/2AACA4BZq1xsPGTJEISEhfkfxp06d8jt6vyw2NrbL8aGhoRo8eLA+//xzHT9+XI888oj39YsXL0qSQkNDdfToUY0ePdpvuxEREYqIiOjtLgEAEJRsO7IPDw+Xy+VSRUWFz/KKigqlpaV1uU5qaqrf+H379iklJUVhYWEaN26c/vjHP6q2ttb7ePTRR/X3f//3qq2t5fQ8AOCmZNuRvSTl5eUpKytLKSkpSk1N1ZYtW9TQ0KDs7GxJl06vNzY2avv27ZKk7Oxsbdy4UXl5eXruuedUVVWlkpIS7dixQ5IUGRmp5ORkn/e49dZbJclvOQAANwtbY5+ZmamWlhatWrVKTU1NSk5OVnl5ueLj4yVJTU1NPvfcJyQkqLy8XLm5udq0aZOGDx+uDRs2aNasWXbtAgAAQc9hXb7CDV4ej0fR0dFqbW3VwIEDA7Zd1+LtAdsWEEjVa+bYPYWrwmcIwSrYP0O2X40PAAD6FrEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwtse+qKhICQkJioyMlMvl0sGDB684/sCBA3K5XIqMjNSoUaO0efNmn9e3bt2q9PR0xcTEKCYmRpMnT9ahQ4f6chcAAAhqtsa+rKxMOTk5KigoUE1NjdLT0zVt2jQ1NDR0Ob6+vl7Tp09Xenq6ampqtGzZMi1YsEC7du3yjtm/f7+efPJJffzxx6qqqtLIkSOVkZGhxsbG67VbAAAEFYdlWZZdbz5x4kRNmDBBxcXF3mWJiYmaOXOmCgsL/cYvWbJE7777rurq6rzLsrOzdeTIEVVVVXX5Hp2dnYqJidHGjRs1Z86cq5qXx+NRdHS0WltbNXDgwB7uVfdci7cHbFtAIFWvubrPht34DCFYBftnyLYj+/b2dlVXVysjI8NneUZGhiorK7tcp6qqym/8lClTdPjwYV24cKHLdb7++mtduHBBgwYN6nYubW1t8ng8Pg8AAExhW+ybm5vV2dkpp9Pps9zpdMrtdne5jtvt7nJ8R0eHmpubu1xn6dKlGjFihCZPntztXAoLCxUdHe19xMXF9XBvAAAIXrZfoOdwOHyeW5blt+y7xne1XJJee+017dixQ7t371ZkZGS328zPz1dra6v3cfLkyZ7sAgAAQS3UrjceMmSIQkJC/I7iT5065Xf0fllsbGyX40NDQzV48GCf5WvXrtXq1av14Ycfavz48VecS0REhCIiIq5hLwAACH62HdmHh4fL5XKpoqLCZ3lFRYXS0tK6XCc1NdVv/L59+5SSkqKwsDDvsjVr1ujll1/Wr3/9a6WkpAR+8gAA3EBsPY2fl5enN954Q6Wlpaqrq1Nubq4aGhqUnZ0t6dLp9b+9gj47O1snTpxQXl6e6urqVFpaqpKSEi1atMg75rXXXtPy5ctVWlqq22+/XW63W263W+fOnbvu+wcAQDCw7TS+JGVmZqqlpUWrVq1SU1OTkpOTVV5ervj4eElSU1OTzz33CQkJKi8vV25urjZt2qThw4drw4YNmjVrlndMUVGR2tvb9dhjj/m818qVK/Xiiy9el/0CACCY2HqffbDiPnvcbIL9HuHL+AwhWAX7Z8j2q/EBAEDfIvYAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABiO2AMAYDhiDwCA4Yg9AACGI/YAABjO9tgXFRUpISFBkZGRcrlcOnjw4BXHHzhwQC6XS5GRkRo1apQ2b97sN2bXrl1KSkpSRESEkpKStGfPnr6aPgAAQc/W2JeVlSknJ0cFBQWqqalRenq6pk2bpoaGhi7H19fXa/r06UpPT1dNTY2WLVumBQsWaNeuXd4xVVVVyszMVFZWlo4cOaKsrCz98Ic/1O9+97vrtVsAAAQVh2VZll1vPnHiRE2YMEHFxcXeZYmJiZo5c6YKCwv9xi9ZskTvvvuu6urqvMuys7N15MgRVVVVSZIyMzPl8Xj0/vvve8dMnTpVMTEx2rFjx1XNy+PxKDo6Wq2trRo4cOC17p4f1+LtAdsWEEjVa+bYPYWrwmcIwSrYP0Ohdr1xe3u7qqurtXTpUp/lGRkZqqys7HKdqqoqZWRk+CybMmWKSkpKdOHCBYWFhamqqkq5ubl+Y9avX9/tXNra2tTW1uZ93traKulS9AOps+3/BXR7QKAE+n/rfYXPEIJVX32GBgwYIIfD0evt2Bb75uZmdXZ2yul0+ix3Op1yu91druN2u7sc39HRoebmZg0bNqzbMd1tU5IKCwv10ksv+S2Pi4u72t0BbmjRP8+2ewrADa2vPkOBOsNsW+wv+/Z/sViWdcX/iulq/LeX93Sb+fn5ysvL8z6/ePGivvrqKw0ePDgg/0WFwPN4PIqLi9PJkycD+qcW4GbBZ+jGMGDAgIBsx7bYDxkyRCEhIX5H3KdOnfI7Mr8sNja2y/GhoaEaPHjwFcd0t01JioiIUEREhM+yW2+99Wp3BTYaOHAg/0cF9AKfoZuDbVfjh4eHy+VyqaKiwmd5RUWF0tLSulwnNTXVb/y+ffuUkpKisLCwK47pbpsAAJjO1tP4eXl5ysrKUkpKilJTU7VlyxY1NDQoO/vS3z7y8/PV2Nio7dsvXYGbnZ2tjRs3Ki8vT88995yqqqpUUlLic5X9woUL9eCDD+rVV1/VjBkztHfvXn344Yf6zW9+Y8s+AgBgN1tjn5mZqZaWFq1atUpNTU1KTk5WeXm54uPjJUlNTU0+99wnJCSovLxcubm52rRpk4YPH64NGzZo1qxZ3jFpaWnauXOnli9frhUrVmj06NEqKyvTxIkTr/v+oe9ERERo5cqVfn9+AXB1+AzdXGy9zx4AAPQ9278uFwAA9C1iDwCA4Yg9AACGI/YAABiO2CPoVFZWKiQkRFOnTvVZfvz4cTkcDtXW1na5XmdnpwoLCzVu3Dj1799fgwYN0t/93d9p27Zt12HWwI3hmWee0cyZM/3+DbPZ/nW5wLeVlpbqhRde0BtvvKGGhgaNHDnyqtZ78cUXtWXLFm3cuFEpKSnyeDw6fPiwzpw508czBoDgRuwRVM6fP6//+I//0O9//3u53W69+eab+rd/+7erWve9997Tj370Iz3++OPeZXfddVdfTRUAbhicxkdQKSsr09ixYzV27FjNnj1b27Zt09V+FURsbKz+67/+S6dPn+7jWQLAjYXYI6iUlJRo9uzZkqSpU6fq3Llz+uijj65q3XXr1un06dOKjY3V+PHjlZ2drffff78vpwsANwRij6Bx9OhRHTp0SE888YQkKTQ0VJmZmSotLb2q9ZOSkvTZZ5/pt7/9rZ599ln95S9/0SOPPKJ58+b15bQBIOjxN3sEjZKSEnV0dGjEiBHeZZZlKSws7KovsuvXr5/uvfde3XvvvcrNzdUvfvELZWVlqaCgQAkJCX01dQAIahzZIyh0dHRo+/btev3111VbW+t9HDlyRPHx8Xr77bevabtJSUmSLl34BwA3K47sERR+9atf6cyZM5o7d66io6N9XnvsscdUUlKif/qnf5J06XT/tyUlJempp57S/fffr7S0NMXGxqq+vl75+fkaM2aMxo0bd132AwCCEbFHUCgpKdHkyZP9Qi9Js2bN0urVq/XVV19Jkvdv+n+rvr5eU6ZM0Y4dO1RYWKjW1lbFxsbqBz/4gV588UWFhvI/dQA3L37iFgAAw/E3ewAADEfsAQAwHLEHAMBwxB4AAMMRewAADEfsAQAwHLEHAMBwxB4AAMMRewDX1UMPPaScnJyrHv/mm2/q1ltv7bP5ADcDYg8AgOGIPQAAhiP2ACRdOr3+wgsvKCcnRzExMXI6ndqyZYvOnz+vZ599VgMGDNDo0aP1/vvve9c5cOCA7rvvPkVERGjYsGFaunSpOjo6vK+fP39ec+bMUVRUlIYNG6bXX3/d733b29v1k5/8RCNGjNAtt9yiiRMnav/+/ddjl4GbBrEH4PXWW29pyJAhOnTokF544QXNnz9fjz/+uNLS0vTpp59qypQpysrK0tdff63GxkZNnz5d9957r44cOaLi4mKVlJTopz/9qXd7ixcv1scff6w9e/Zo37592r9/v6qrq33e89lnn9Unn3yinTt36g9/+IMef/xxTZ06Vf/93/99vXcfMJcFAJZlTZo0yXrggQe8zzs6OqxbbrnFysrK8i5ramqyJFlVVVXWsmXLrLFjx1oXL170vr5p0yYrKirK6uzstM6ePWuFh4dbO3fu9L7e0tJi9e/f31q4cKFlWZb15z//2XI4HFZjY6PPXB5++GErPz/fsizL2rZtmxUdHd0HewzcPPiRbwBe48eP9/47JCREgwcP1p133uld5nQ6JUmnTp1SXV2dUlNT5XA4vK/ff//9OnfunP7nf/5HZ86cUXt7u1JTU72vDxo0SGPHjvU+//TTT2VZlsaMGeMzj7a2Ng0ePDjg+wfcrIg9AK+wsDCf5w6Hw2fZ5bBfvHhRlmX5hF6SLMvyjrv87yu5ePGiQkJCVF1drZCQEJ/XoqKirmkfAPgj9gCuSVJSknbt2uUT/crKSg0YMEAjRoxQTEyMwsLC9Nvf/lYjR46UJJ05c0ZffvmlJk2aJEm655571NnZqVOnTik9Pd22fQFMxwV6AK7Jj370I508eVIvvPCCvvjiC+3du1crV65UXl6e+vXrp6ioKM2dO1eLFy/WRx99pM8++0zPPPOM+vX76//tjBkzRk8//bTmzJmj3bt3q76+Xr///e/16quvqry83Ma9A8zCkT2AazJixAiVl5dr8eLFuuuuuzRo0CDNnTtXy5cv945Zs2aNzp07p0cffVQDBgzQj3/8Y7W2tvpsZ9u2bfrpT3+qH//4x2psbNTgwYOVmpqq6dOnX+9dAozlsK7mD2sAAOCGxWl8AAAMR+wBADAcsQcAwHDEHgAAwxF7AAAMR+wBADAcsQcAwHDEHgAAwxF7AAAMR+wBADAcsQcAwHD/H09u8bxMEb4wAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfsAAAHqCAYAAAADAefsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJwNJREFUeJzt3Q1UVVXex/E/goBvYMoERRQ1voeC8ibmhFOscI29ODmNukyQcWxlaTqUJWYy89QsLF/GGhnJZtScMshVaplRRmoziZEgFb62JkcZHN6qgcQChfusvde6N25ezOzCuWy+n7XOkrPPvufuA91+9+yzz9leNpvNJgAAwFjdrG4AAABoX4Q9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhrM87LOzsyU8PFz8/f0lPj5eioqK2qx78OBBmTRpkq7v5eUlq1atuuC+ly5dquvNnz+/HVoOAEDnYGnY5+XlSXp6umRmZkpJSYlERkZKcnKyVFdXu6x/5swZue6663SIh4SEXHDfH374oTz77LMyYsSIdmo9AACdg6Vhv3LlSpk1a5akpaXJsGHDJCcnR3r27Cnr1q1zWT82NlaWLVsmU6ZMET8/vzb3e/r0aZk2bZo899xzctlll/3gdqm5gerr6/W/AAB0dpaFfVNTkxQXF0tSUtK3jenWTa8XFhb+qH3ff//9MmHCBKd9X0hjY6MOd/tSUVEhgYGB8tVXX/2odgAA0KXDvra2VpqbmyU4ONipXK1XVlZe8n5zc3P1JYGsrKyLfo2qq8LdvoSFhV3y+wMA4GksH6DnTuXl5TJv3jx58cUX9YC/i5WRkSF1dXWORe0HAABT+Fj1xkFBQeLt7S1VVVVO5Wr9+wbftUVdFlCD+0aNGuUoU70H7733nqxevVp316v3/C51/f9CYwAAAOjMLDuz9/X1lejoaCkoKHCUtbS06PWEhIRL2ufNN98sn3zyiZSWljqWmJgYPVhP/ewq6AEAMJ1lZ/aKuu0uNTVVB3JcXJy+b76hoUGPzldSUlIkNDTUcf1dDeo7dOiQ42c1kE6FeO/evWXAgAHSp08fiYiIcHqPXr16Sf/+/c8rBwCgq7A07CdPniw1NTWyZMkSPSgvKipK8vPzHYP2Tp48qUfo2506dUpGjhzpWF++fLleEhMTZffu3ZYcAwAAns7Lxs3k51G336lR+WqwXkBAgBV/FwAA3Mao0fgAAOB8hD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGs/TZ+MClUE94VhMmtZ7syMvLi18mALSBsEeno4L+jjvucKxv27ZNz3wIAHCNbnwAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwnI/VDehKohdstLoJRvA61ySBrdbHPZYrNh9fC1vU+RUvS7G6CQDaEWf2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEsD/vs7GwJDw8Xf39/iY+Pl6KiojbrHjx4UCZNmqTre3l5yapVq86rk5WVJbGxsdKnTx+5/PLLZeLEiXL06NF2PgoAADyXpWGfl5cn6enpkpmZKSUlJRIZGSnJyclSXV3tsv6ZM2fkuuuuk6VLl0pISIjLOnv27JH7779f9u3bJzt37pSzZ8/KLbfcIg0NDe18NAAAeCZL57NfuXKlzJo1S9LS0vR6Tk6OvPHGG7Ju3TpZuHDhefXVGbtaFFfblfz8fKf1DRs26DP84uJiufHGG9vlOAAA8GSWndk3NTXpAE5KSvq2Md266fXCwkK3vU9dXZ3+t1+/fm7bJwAAnYllZ/a1tbXS3NwswcHBTuVq/ciRI255j5aWFpk/f77ccMMNEhER0Wa9xsZGvdjV19e75f0BAPAElg/Qa0/q2n1ZWZnk5uZesJ4a1BcYGOhYwsLCOqyNAAAYG/ZBQUHi7e0tVVVVTuVqva3Bdz/EnDlzZPv27bJr1y656qqrLlg3IyNDd/fbl/Ly8h/9/gAASFcPe19fX4mOjpaCggKnbne1npCQcMn7tdlsOui3bNki7777rlx77bXf+xo/Pz8JCAhwWgAAMIWlo/HVbXepqakSExMjcXFx+r55dYucfXR+SkqKhIaG6m52+6C+Q4cOOX6uqKiQ0tJS6d27twwYMMDRdb9p0ybZtm2bvte+srJSl6vu+R49elh2rAAAdMmwnzx5stTU1MiSJUt0KEdFRelb5+yD9k6ePKlH6NudOnVKRo4c6Vhfvny5XhITE2X37t26bM2aNfrfcePGOb3X+vXrZcaMGR10ZAAAeA5Lw15RXe5qccUe4HbqyXmqm/5Cvm87AABdjeVhD/xQNu/uUjdiqtM6AKBthD06Hy8vsfn4Wt0KAOg0jL7PHgAAEPYAABiPM3sAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCWh312draEh4eLv7+/xMfHS1FRUZt1Dx48KJMmTdL1vby8ZNWqVT96nwAAmM7SsM/Ly5P09HTJzMyUkpISiYyMlOTkZKmurnZZ/8yZM3LdddfJ0qVLJSQkxC37BADAdJaG/cqVK2XWrFmSlpYmw4YNk5ycHOnZs6esW7fOZf3Y2FhZtmyZTJkyRfz8/NyyTwAATGdZ2Dc1NUlxcbEkJSV925hu3fR6YWGhx+wTAExjs9nk9OnTjkWtw2w+Vr1xbW2tNDc3S3BwsFO5Wj9y5EiH7rOxsVEvdvX19Zf0/gDQGTQ0NMgdd9zhWN+2bZv07t3b0jbB8AF6niArK0sCAwMdS1hYmNVNAgCg84d9UFCQeHt7S1VVlVO5Wm9r8F177TMjI0Pq6uocS3l5+SW9PwAAnsiysPf19ZXo6GgpKChwlLW0tOj1hISEDt2nGuwXEBDgtAAAYArLrtkr6ha51NRUiYmJkbi4OH3fvLqWpEbSKykpKRIaGqq72e0D8A4dOuT4uaKiQkpLS/W1pgEDBlzUPgEA6GosDfvJkydLTU2NLFmyRCorKyUqKkry8/MdA+xOnjypR9PbnTp1SkaOHOlYX758uV4SExNl9+7dF7VPAAC6Gi8b91ycR43GVwP11PV7d3bpRy/Y6LZ9Ae5UvCyFX2gXom63YzR+18JofAAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYztJZ7wDgh2AyKffwOtckga3Wxz2WKzYfX/5jNHgyKc7sAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOB+rGwAA6Fg27+5SN2Kq0zrMRtgDQFfj5SU2H1+rW4EORDc+AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYzvKwz87OlvDwcPH395f4+HgpKiq6YP3NmzfLkCFDdP3hw4fLjh07nLafPn1a5syZI1dddZX06NFDhg0bJjk5Oe18FAAAeC5Lwz4vL0/S09MlMzNTSkpKJDIyUpKTk6W6utpl/b1798rUqVNl5syZcuDAAZk4caJeysrKHHXU/vLz8+WFF16Qw4cPy/z583X4v/baax14ZAAAeA5Lw37lypUya9YsSUtLc5yB9+zZU9atW+ey/tNPPy3jx4+XBQsWyNChQ+Xxxx+XUaNGyerVq52+EKSmpsq4ceN0j8E999yjv0R8X48BAACmsizsm5qapLi4WJKSkr5tTLduer2wsNDla1R56/qK6gloXX/MmDH6LL6iokJsNpvs2rVLjh07JrfcckubbWlsbJT6+nqnBQAAU1gW9rW1tdLc3CzBwcFO5Wq9srLS5WtU+ffV//Of/6x7CdQ1e19fX90ToMYF3HjjjW22JSsrSwIDAx1LWFjYjz4+AAA8heUD9NxNhf2+ffv02b3qOVixYoXcf//98s4777T5moyMDKmrq3Ms5eXlHdpmAADak49YJCgoSLy9vaWqqsqpXK2HhIS4fI0qv1D9r7/+WhYtWiRbtmyRCRMm6LIRI0ZIaWmpLF++/LxLAHZ+fn56AQDARJad2asu9ujoaCkoKHCUtbS06PWEhASXr1HlresrO3fudNQ/e/asXtS1/9bUlwq1bwAAuiLLzuztt8mpkfMxMTESFxcnq1atkoaGBj06X0lJSZHQ0FB9TV2ZN2+eJCYm6q55deaem5sr+/fvl7Vr1+rtAQEBersara/usb/mmmtkz549snHjRj3yHwCArsjSsJ88ebLU1NTIkiVL9CC7qKgofY+8fRDeyZMnnc7S1Uj7TZs2yeLFi3V3/cCBA2Xr1q0SERHhqKO+AKhr8NOmTZMvvvhCB/4f//hHuffeey05RgAArOZlU/enwYm69U6NyleD9VRvgbtEL9jIbxoeqXhZinQGfIbgqYo9/DNk3Gh8AADgjLAHAMBwhD0AAIYj7AEAMBxhDwCA4X7QrXfqwTQHDx7U88grapY6NaFN64fXzJ49+7yH2gAAgE4S9uoedhXw7733nl5XD6/p27ev+Pj4OCa38ff31/PNAwAAz/CDTsHXr1+vJ5VpTT2h7vjx43pZtmyZvPDCC+5uIwAA6KiwP3LkiH60bVvUo2o/+uijH9MeAABgZTe+erRta5999pn079/fsd69e3f9bHsAANBJz+zVM+uPHj3qWP/JT37iNBjv8OHDbU5PCwAAOkHY33zzzXpSGVfUI/bV7HSqDgAA6KTd+I8++qiMGjVK4uPj5aGHHpJBgwbpcnW2v3z5cv2vmk4WAAB00rD/6U9/Kjt37pQZM2bo6Wm9vLwcZ/VDhgyRt99+WwYMGNBebQUAAB0xn31cXJwcOnRISktL5dixY7pMzSs/cuTIS3l/AADgaWGv5nrv3bu3REVF6aX10/VOnz7t1vnfAQBABw/Q27Jli77P/ptvvjlv29dffy2xsbHy+uuvu6FZAADAkrBfs2aNPPzww9KzZ8/ztvXq1UseeeQRWb16tdsaBwAAOjjsy8rKZNy4cW1uv/HGG+WTTz5xQ7MAAIAlYf/ll1/KuXPn2tx+9uxZXQcAAHTSsA8PD5f9+/e3uV1tu+aaa9zRLgAAYEXY33nnnfrBOlVVVedtq6yslMWLF8ukSZPc1TYAANDRt94tXLhQtm3bpu+rv/vuu2Xw4MGO2fBefPFFCQsL03UAAIDn+EFh36dPH3n//fclIyND8vLyHNfn+/btq8NfPTdf1QEAAJ34oTqBgYHyl7/8RbKzs6W2tlY/KlfNfmd/dC4AAOjkYW/3+eefy4kTJ3TIe3t7O81rDwAAOukAPeXgwYP6fno1t72a/U49K//yyy+Xm266yWmuewAA0AnP7NWI+8TERN1tv3LlSj3TnerGVxPjPPfcc/Kzn/1MP3hHhT8AAOiEYf+nP/1J30evBun5+/s7ysePHy+zZ8+WsWPH6jpZWVnt0VYAANDe3fhqLnv1/PvWQW/Xo0cPWbBggbz11luX0g4AAOAJYf/ZZ5/JqFGj2tyuZsRTdQAAQCcN+6+++uqC89Wre+zVnPYAAKAT33qnAt9VN75SX1+vB+wBAIBOGvYqyAcNGnTB7TxcBwCAThz2u3btar+WAAAA68Ne3WMPAAAMDvtu3bp9bze92n7u3Lkf2y4AAGBF2G/ZsqXNbYWFhfLMM89IS0uLO9oFAACsCPs77rjjvDL1PHw1h/3rr78u06ZNk//7v/9zV9sAAIAVE+HYnTp1SmbNmiXDhw/X3falpaXy/PPP68fpAgCAThz2dXV1+pG5AwYM0DPgFRQU6LP6iIiI9mkhAADouG78p556Sp588kkJCQmRl156yWW3PgAA6MRhr67Nqwlv1Fm96rJXiyuvvvqqu9oHAAA6MuxTUlJ4Qh4AACaH/YYNG9qvJQAAwLNG4wMAgM6BsAcAwHCEPQAAhiPsAQAwnOVhn52dLeHh4eLv7y/x8fFSVFR0wfqbN2+WIUOG6Prq6X07duw4r87hw4fl9ttvl8DAQOnVq5fExsbKyZMn2/EoAADwXJaGfV5enqSnp0tmZqaUlJRIZGSkJCcnS3V1tcv6e/fulalTp8rMmTPlwIEDMnHiRL2UlZU56vzrX/+SsWPH6i8Eu3fvlo8//lgee+wx/eUAAICuyMtms9msenN1Jq/OulevXq3X1Yx5YWFhMnfuXP0An++aPHmyNDQ0yPbt2x1lo0ePlqioKMnJydHrU6ZMke7du8vf//73S25XfX297hVQjwYOCAgQd4lesNFt+wLcqXhZSqf4hfIZgqcq9vDPkGVn9k1NTVJcXCxJSUnfNqZbN72upst1RZW3rq+ongB7ffVl4Y033pBBgwbp8ssvv1x/odi6desF29LY2KgDvvUCAIApLAv72tpaaW5uluDgYKdytV5ZWenyNar8QvVV9//p06dl6dKlMn78eHn77bfll7/8pdx5552yZ8+eNtuSlZWlz+Tti+pdAADAFJYP0HMndWavqAl6fve73+nufXU54NZbb3V087uSkZGhu+ztS3l5eQe2GgAAD3pcrjsFBQWJt7e3VFVVOZWrdTWrniuq/EL11T59fHxk2LBhTnWGDh0q//znP9tsi5+fn14AADCRZWf2vr6+Eh0dLQUFBU5n5mo9ISHB5WtUeev6ys6dOx311T7VgL+jR4861Tl27Jhcc8017XIcAAB4OsvO7BV1211qaqrExMRIXFycrFq1So+2T0tLc8yyFxoaqq+pK/PmzZPExERZsWKFTJgwQXJzc2X//v2ydu1axz4XLFigR+3feOON8vOf/1zy8/Pl9ddf17fhAQDQFVka9iqUa2pqZMmSJXqQnbrGrsLZPghPPQhHjdC3GzNmjGzatEkWL14sixYtkoEDB+qR9hEREY46akCeuj6vviA88MADMnjwYHnllVf0vfcAAHRFlt5n76m4zx5djaffI2zHffbwVMUe/hkyajQ+AAA4H2EPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwnEeEfXZ2toSHh4u/v7/Ex8dLUVHRBetv3rxZhgwZousPHz5cduzY0Wbde++9V7y8vGTVqlXt0HIAADyf5WGfl5cn6enpkpmZKSUlJRIZGSnJyclSXV3tsv7evXtl6tSpMnPmTDlw4IBMnDhRL2VlZefV3bJli+zbt0+uvPLKDjgSAAA8k+Vhv3LlSpk1a5akpaXJsGHDJCcnR3r27Cnr1q1zWf/pp5+W8ePHy4IFC2To0KHy+OOPy6hRo2T16tVO9SoqKmTu3Lny4osvSvfu3TvoaAAA8DyWhn1TU5MUFxdLUlLStw3q1k2vFxYWunyNKm9dX1E9Aa3rt7S0yPTp0/UXguuvv/5729HY2Cj19fVOCwAAprA07Gtra6W5uVmCg4OdytV6ZWWly9eo8u+r/+STT4qPj4888MADF9WOrKwsCQwMdCxhYWGXdDwAAHgiy7vx3U31FKiu/g0bNuiBeRcjIyND6urqHEt5eXm7txMAgC4R9kFBQeLt7S1VVVVO5Wo9JCTE5WtU+YXq/+Mf/9CD+66++mp9dq+WEydOyIMPPqhH/Lvi5+cnAQEBTgsAAKawNOx9fX0lOjpaCgoKnK63q/WEhASXr1HlresrO3fudNRX1+o//vhjKS0tdSxqNL66fv/WW2+18xEBAOB5fKxugLrtLjU1VWJiYiQuLk7fD9/Q0KBH5yspKSkSGhqqr6sr8+bNk8TERFmxYoVMmDBBcnNzZf/+/bJ27Vq9vX///nppTY3GV2f+gwcPtuAIAQDo4mE/efJkqampkSVLluhBdlFRUZKfn+8YhHfy5Ek9Qt9uzJgxsmnTJlm8eLEsWrRIBg4cKFu3bpWIiAgLjwIAAM/lZbPZbFY3wtOoW+/UqHw1WM+d1++jF2x0274AdypeltIpfqF8huCpPP0zZNxofAAA4IywBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGM4jwj47O1vCw8PF399f4uPjpaio6IL1N2/eLEOGDNH1hw8fLjt27HBsO3v2rDzyyCO6vFevXnLllVdKSkqKnDp1qgOOBAAAz2N52Ofl5Ul6erpkZmZKSUmJREZGSnJyslRXV7usv3fvXpk6darMnDlTDhw4IBMnTtRLWVmZ3n7mzBm9n8cee0z/++qrr8rRo0fl9ttv7+AjAwDAM3jZbDablQ1QZ/KxsbGyevVqvd7S0iJhYWEyd+5cWbhw4Xn1J0+eLA0NDbJ9+3ZH2ejRoyUqKkpycnJcvseHH34ocXFxcuLECbn66qu/t0319fUSGBgodXV1EhAQIO4SvWCj2/YFuFPxspRO8QvlMwRPVezhnyFLz+ybmpqkuLhYkpKSvm1Qt256vbCw0OVrVHnr+orqCWirvqJC28vLS/r27evG1gMA0Dn4WPnmtbW10tzcLMHBwU7lav3IkSMuX1NZWemyvip35ZtvvtHX8FXXf1tn6Y2NjXppfWYPAIApLL9m357UYL1f//rXoq5UrFmzps16WVlZutvevqjLCAAAmMLSsA8KChJvb2+pqqpyKlfrISEhLl+jyi+mvj3o1XX6nTt3XvDae0ZGhu7qty/l5eU/6rgAAPAkloa9r6+vREdHS0FBgaNMDdBT6wkJCS5fo8pb11dUmLeubw/6Tz/9VN555x3p37//Bdvh5+envwy0XgAAMIWl1+wVddtdamqqxMTE6BHzq1at0qPt09LS9HZ1j3xoaKjualfmzZsniYmJsmLFCpkwYYLk5ubK/v37Ze3atY6g/9WvfqVvu1Mj9tWYAPv1/H79+ukvGAAAdCWWh726la6mpkaWLFmiQ1ndQpefn+8YhHfy5Ek9Qt9uzJgxsmnTJlm8eLEsWrRIBg4cKFu3bpWIiAi9vaKiQl577TX9s9pXa7t27ZJx48Z16PEBACBd/T57T8R99uhqPP0eYTvus4enKvbwz5DRo/EBAABhDwCA8TizBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBADAcYQ8AgOEIewAADEfYAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAAAxH2AMAYDjCHgAAwxH2AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMN5RNhnZ2dLeHi4+Pv7S3x8vBQVFV2w/ubNm2XIkCG6/vDhw2XHjh1O2202myxZskSuuOIK6dGjhyQlJcmnn37azkcBAIBnsjzs8/LyJD09XTIzM6WkpEQiIyMlOTlZqqurXdbfu3evTJ06VWbOnCkHDhyQiRMn6qWsrMxR56mnnpJnnnlGcnJy5IMPPpBevXrpfX7zzTcdeGQAAHgGL5s6DbaQOpOPjY2V1atX6/WWlhYJCwuTuXPnysKFC8+rP3nyZGloaJDt27c7ykaPHi1RUVE63NXhXHnllfLggw/KQw89pLfX1dVJcHCwbNiwQaZMmfK9baqvr5fAwED9uoCAALcda/SCjW7bF+BOxctSOsUvlM8QPFWxh3+GLD2zb2pqkuLiYt3N7mhQt256vbCw0OVrVHnr+oo6a7fXP378uFRWVjrVUcGtvlS0tU8AAEzmY+Wb19bWSnNzsz7rbk2tHzlyxOVrVJC7qq/K7dvtZW3V+a7Gxka92KkzevsZvjs1N37t1v0B7uLu/9bbC58hdLXPUJ8+fcTLy6tzh72nyMrKkj/84Q/nlavLCUBXEPjne61uAtCpBbbTZ8hdl5MtDfugoCDx9vaWqqoqp3K1HhIS4vI1qvxC9e3/qjI1Gr91HXVd35WMjAw9SNBOjRv44osvpH///m75RoX2+RatvoyVl5e7dVwF0FXwGeoc1Jm9O1ga9r6+vhIdHS0FBQV6RL09aNX6nDlzXL4mISFBb58/f76jbOfOnbpcufbaa3Xgqzr2cFf/UatR+bNnz3a5Tz8/P7201rdvX7cdJ9qPCnrCHuAzBA/vxldn1KmpqRITEyNxcXGyatUqPdo+LS1Nb09JSZHQ0FDd1a7MmzdPEhMTZcWKFTJhwgTJzc2V/fv3y9q1a/V2dSauvgg88cQTMnDgQB3+jz32mB6hb/9CAQBAV2J52Ktb6WpqavRDcNQAOnU2np+f7xhgd/LkST1C327MmDGyadMmWbx4sSxatEgH+tatWyUiIsJR5+GHH9ZfGO655x753//+J2PHjtX7VA/hAQCgq7H8PnvgUqi7J1Rvjxpv8d1LMAD4DMEZYQ8AgOEsf1wuAABoX4Q9AACGI+wBADAcYQ8AgOEIe3gcNWGRerKieo5Ca//+97/1cxRKS0tdvk7Ns7B06VIZMmSI9OjRQ/r166cnQPrrX//aQS0HPN+MGTMczxxp/TPMZvl99sB3/e1vf9NTHKt/T506pR+IdDHU/AbPPvusni5ZPaRJPTlRPXDpyy+/5JcMoEsj7OFRTp8+LXl5eTqk1UOWNmzYoB+edDFee+01ue++++Suu+5ylEVGRrZjawGgc6AbHx7l5Zdf1t3wgwcPlrvvvlvWrVsnF/vcJzUnwrvvvqufyAgA+BZhD4+iuu5VyCvjx4/X0zvu2bPnol67cuVKHfQq9EeMGCH33nuvvPnmm+3cYgDwfIQ9PMbRo0elqKhIpk6dqtd9fHz03AnqC8DFGDZsmJSVlcm+ffvkN7/5jVRXV8ttt90mv/3tb9u55QDg2bhmD4+hQv3cuXNOA/JUF7569r0adHcx1KRJsbGxelGzH77wwgsyffp0efTRR/UMiADQFXFmD4+gQn7jxo166mJ1a519+eijj3T4v/TSS5e0X3W2r6hZEAGgq+LMHh5h+/bt+ha5mTNnSmBgoNO2SZMm6bN+dQ3f3t3/Xddff73u/r/hhhv0NMjquv3x48f1rHiDBg3Sg/4AoKsi7OERVJgnJSWdF/T2sH/qqaf0ffPKlClTzqtTXl4uycnJugdATX2rBvapwL/pppvk97//vb7+DwBdFVPcAgBgOK7ZAwBgOMIeAADDEfYAABiOsAcAwHCEPQAAhiPsAQAwHGEPAIDhCHsAHWrcuHF63oKLtWHDBunbt2+7tgkwHWEPAIDhCHsAAAxH2ANwdK/PnTtXd7FfdtllEhwcLM8995yeMTAtLU369OkjAwYMkDfffNPxG9uzZ4/ExcXpaYivuOIKWbhwoZ7B0E69NiUlRXr37q23q1kNv6uxsVEeeughCQ0NlV69ekl8fLzs3r2bvwrgRoQ9AIfnn39egoKCpKioSAf/7Nmz5a677tIzCZaUlMgtt9wi06dPlzNnzkhFRYX84he/kNjYWD0V8Zo1a/SERk888YRjfwsWLNBfCLZt2yZvv/22DnG1n9bmzJkjhYWFkpubKx9//LF+PzXD4aeffspfBnAXGwDYbLbExETb2LFjHb+Lc+fO2Xr16mWbPn26o+y///2vTf1vo7Cw0LZo0SLb4MGDbS0tLY7t2dnZtt69e9uam5ttX331lc3X19f28ssvO7Z//vnnth49etjmzZun10+cOGHz9va2VVRUOP0Nbr75ZltGRob+ef369bbAwED+RsCPwLyfABxGjBjh+Nnb21v69+8vw4cPd5Sprn2lurpaDh8+LAkJCeLl5eXYfsMNN8jp06flP//5j3z55ZfS1NSku+Xt+vXrJ4MHD3asf/LJJ9Lc3CyDBg06r2tfvTcA9yDsATh0797d6behgrx1mT3YW1pa3PJbU18M1JeK4uJi/W9r6jo/APcg7AFckqFDh8orr7yiLgU6vgS8//77eiDfVVddpc/i1ReFDz74QK6++mq9XZ3tHzt2TBITE/X6yJEj9Zm96in42c9+xl8CaCcM0ANwSe677z4pLy/XA/mOHDmiB+FlZmZKenq6dOvWTZ+Zz5w5Uw/Se/fdd6WsrExmzJiht9mp7vtp06bpEfuvvvqqHD9+XA8OzMrKkjfeeIO/DOAmnNkDuCTqVrkdO3boMI+MjNRn8ircFy9e7KizbNky3VV/22236TP+Bx98UOrq6pz2s379ej2CX21TI/zV3QCjR4+WW2+9lb8M4CZeapSeu3YGAAA8D934AAAYjrAHAMBwhD0AAIYj7AEAMBxhDwCA4Qh7AAAMR9gDAGA4wh4AAMMR9gAAGI6wBwDAcIQ9AACGI+wBABCz/T82bW3bwb/J3QAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 511.111x500 with 1 Axes>"
       ]
@@ -377,14 +379,14 @@
     }
    ],
    "source": [
-    "sns.catplot(results.list_metrics().reset_index(), x=\"model\", y=\"NDCG\", kind=\"bar\")\n",
+    "sns.catplot(list_metrics.reset_index(), x=\"model\", y=\"NDCG\", kind=\"bar\")\n",
     "plt.show()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -398,7 +400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/guide/batch.rst
+++ b/docs/guide/batch.rst
@@ -49,7 +49,7 @@ Configure and train the model:
 
 Generate recommendations:
 
-    >>> recs = recommend(pop_pipe, split.test.keys(), n_jobs=1)
+    >>> recs = recommend(pop_pipe, split.test.keys())
     >>> recs.to_df()
               user_id  item_id     score  rank
     0 ...                                    1
@@ -60,9 +60,9 @@ And measure their results:
 
     >>> collect = MeasurementCollector()
     >>> collect.add_metric(RBP())
-    >>> collect.measure(recs, split.test)
+    >>> collect.measure_collection(recs, split.test)
     >>> collect.summary_metrics()    # doctest: +ELLIPSIS
-    { ... "RBP.mean": "0.06...", ... }
+    { ... 'RBP.mean': 0.06..., ... }
 
 
 The :py:func:`predict` function works similarly, but for rating predictions.

--- a/docs/guide/batch.rst
+++ b/docs/guide/batch.rst
@@ -62,7 +62,7 @@ And measure their results:
     >>> collect.add_metric(RBP())
     >>> collect.measure_collection(recs, split.test)
     >>> collect.summary_metrics()    # doctest: +ELLIPSIS
-    { ... 'RBP.mean': 0.06..., ... }
+    {... 'RBP.mean': 0.06..., ...}
 
 
 The :py:func:`predict` function works similarly, but for rating predictions.

--- a/docs/guide/batch.rst
+++ b/docs/guide/batch.rst
@@ -34,7 +34,7 @@ For an example, let's start with importing things to run a quick batch:
     >>> from lenskit.batch import recommend
     >>> from lenskit.data import load_movielens
     >>> from lenskit.splitting import sample_users, SampleN
-    >>> from lenskit.metrics import RunAnalysis, RBP
+    >>> from lenskit.metrics import MeasurementCollector, RBP
 
 Load and split some data:
 
@@ -58,13 +58,11 @@ Generate recommendations:
 
 And measure their results:
 
-    >>> ra = RunAnalysis()
-    >>> ra.add_metric(RBP())
-    >>> scores = ra.measure(recs, split.test)
-    >>> scores.list_summary()    # doctest: +ELLIPSIS
-              mean    median     std
-    metric
-    RBP    0.06...   0.02... 0.07...
+    >>> collect = MeasurementCollector()
+    >>> collect.add_metric(RBP())
+    >>> collect.measure(recs, split.test)
+    >>> collect.summary_metrics()    # doctest: +ELLIPSIS
+    { ... "RBP.mean": "0.06...", ... }
 
 
 The :py:func:`predict` function works similarly, but for rating predictions.

--- a/docs/guide/documenting.rst
+++ b/docs/guide/documenting.rst
@@ -86,22 +86,20 @@ Reporting Metrics
 ~~~~~~~~~~~~~~~~~
 
 Reporting the metrics themselves is relatively straightforward.  The
-:py:meth:`lenskit.bulk.RunAnalysis.measure` method returns a results object
-contianing the metrics for individual lists, the global metrics, and easy access
-(through :meth:`~lenskit.bulk.RunAnalysis.list_summary`) to summary statistics
-of per-list metrics, optionally grouped by keys such as model name.
+:py:meth:`lenskit.eval.MeasurementCollector.list_metrics` and
+:py:meth:`lenskit.eval.MeasurementCollector.summary_metrics` methods return the
+individual list metrics or overall summaries for a set of lists.
 
 The following code will produce a table of algorithm scores for hit rate, NDCG
 and MRR, assuming that your algorithm identifier is in a column named ``model``
 and the target list length is in ``N``::
 
-    rla = RunAnalysis()
-    rla.add_metric(Hit(n=N))
-    rla.add_metric(NDCG(n=N))
-    rla.add_metric(RecipRank(n=N))
-    results = rla.measure(recs, test)
-    # group by agorithm
-    model_metrics = results.list_summary('model')
+    mc = MeasurementCollector()
+    mc.add_metric(Hit(n=N))
+    mc.add_metric(NDCG(n=N))
+    mc.add_metric(RecipRank(n=N))
+    mc.measure(recs, test)
+    mc.list_metrics()
 
 You can then use :py:meth:`pandas.DataFrame.to_latex` to convert ``algo_scores``
 to a LaTeX table to include in your paper.

--- a/docs/guide/evaluation/predictions.rst
+++ b/docs/guide/evaluation/predictions.rst
@@ -28,7 +28,7 @@ There are two ways to directly call a prediction accuracy metric:
 
 * Pass a single item list with scores and a ``rating`` field.
 
-For evaluation, you will usually want to use :class:`~lenskit.metrics.RunAnalysis`,
+For evaluation, you will usually want to use :class:`~lenskit.metrics.MeasurementCollector`,
 which takes care of calling the prediction metric for you.
 
 Missing Data

--- a/docs/guide/evaluation/rankings.rst
+++ b/docs/guide/evaluation/rankings.rst
@@ -9,9 +9,9 @@ The :py:mod:`lenskit.metrics.ranking` module contains the core top-*N* ranking
 accuracy metrics (including rank-oblivious list metrics like precision, recall,
 and hit rate).
 
-Ranking metrics extend the :py:class:`RankingMetricBase` base class in addition
-to :py:class:`ListMetric` and/or :py:class:`GlobalMetric`, return a score given
-a recommendation list and a test rating list, both as :py:class:`item lists
+Ranking metrics extend the :py:class:`RankingMetricBase` base class, often in
+addition to :py:class:`ListMetric`, and return a score given a recommendation
+list and a test rating list, both as :py:class:`item lists
 <lenskit.data.ItemList>`; most metrics require the recommendation item list to
 be :py:attr:`~lenskit.data.ItemList.ordered`.
 

--- a/docs/guide/migrating.rst
+++ b/docs/guide/migrating.rst
@@ -64,6 +64,11 @@ fall into the following categories:
   also directly supports “global” metrics that are computed over an entire run
   instead of one list at a time.
 
+  .. versionchanged:: 2026.1
+
+    ``RunAnalysis`` has been superseded by
+    :class:`~lenskit.metrics.MeasurementCollector`.
+
 .. important::
 
     The default options of some metrics, particularly

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -94,6 +94,9 @@ Performance Changes
 Minor Changes
 -------------
 
+- :func:`lenskit.metrics.call_metric` has been renamed to
+  :func:`~lenskit.metrics.measure_list`, and the old name preserved as a
+  deprecated alias.
 - Pipeline type-checking for `ArrayLike` component inputs no longer works, due to
   a breaking change in NumPy 2.4.  No LensKit components used `ArrayLike` as an
   input or output data type.

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -42,7 +42,8 @@ Breaking Changes
   is now decomposed. All metrics based on listwise measurements or intermediate
   results should directly extend from ``Metric`` or :class:`~lenskit.metrics.ListMetric`.
   (:pr:`983`)
-- ``GlobalMetric`` no longer inherits from ``Metric``, and may be removed in a future release.
+- ``GlobalMetric`` has been removed. Code needing to compute global metrics
+  should directly compute over item lists.
 - :class:`~lenskit.metrics.MeasurementCollector` no longer supports defaults
   when adding metrics.
 - :class:`~lenskit.metrics.RunAnalysis` is deprecated, and no longer supports

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -47,7 +47,8 @@ Breaking Changes
   when adding metrics.
 - :class:`~lenskit.metrics.RunAnalysis` is deprecated, and no longer supports
   explicit defaults or global metrics.  Use
-  :class:`~lenskit.metrics.MeasurementCollector` instead.
+  :class:`~lenskit.metrics.MeasurementCollector` instead.  Its global metric
+  columns have also changed in some cases.
 - Stopped providing wheels for macOS on Intel.  Users who still need to run
   LensKit on Intel-based Macs should use the Conda packages (available in conda-forge and
   `prefix.dev`_).

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -49,6 +49,8 @@ Breaking Changes
   explicit defaults or global metrics.  Use
   :class:`~lenskit.metrics.MeasurementCollector` instead.  Its global metric
   columns have also changed in some cases.
+- :class:`~lenskit.metrics.ListGini` and :class:`~lenskit.metrics.ExposureGini`
+  now require an item vocabulary or dataset as input.
 - Stopped providing wheels for macOS on Intel.  Users who still need to run
   LensKit on Intel-based Macs should use the Conda packages (available in conda-forge and
   `prefix.dev`_).

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -43,6 +43,11 @@ Breaking Changes
   results should directly extend from ``Metric`` or :class:`~lenskit.metrics.ListMetric`.
   (:pr:`983`)
 - ``GlobalMetric`` no longer inherits from ``Metric``, and may be removed in a future release.
+- :class:`~lenskit.metrics.MeasurementCollector` no longer supports defaults
+  when adding metrics.
+- :class:`~lenskit.metrics.RunAnalysis` is deprecated, and no longer supports
+  explicit defaults or global metrics.  Use
+  :class:`~lenskit.metrics.MeasurementCollector` instead.
 - Stopped providing wheels for macOS on Intel.  Users who still need to run
   LensKit on Intel-based Macs should use the Conda packages (available in conda-forge and
   `prefix.dev`_).

--- a/src/lenskit/data/accum/__init__.py
+++ b/src/lenskit/data/accum/__init__.py
@@ -1,0 +1,19 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2026 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+"""
+Data accumulation support
+"""
+
+from ._proto import Accumulator, AccumulatorFactory
+from ._value import ValueStatAccumulator, ValueStatistics
+
+__all__ = [
+    "Accumulator",
+    "AccumulatorFactory",
+    "ValueStatAccumulator",
+    "ValueStatistics",
+]

--- a/src/lenskit/data/accum/_object.py
+++ b/src/lenskit/data/accum/_object.py
@@ -1,0 +1,27 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2026 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+from ._proto import Accumulator
+
+
+class ObjectListAccumulator[T](Accumulator[T, list[T]]):
+    """
+    An accumulator lists of objects.
+    """
+
+    values: list[T]
+
+    def __init__(self):
+        self.values = []
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+    def add(self, value: T):
+        self.values.append(value)
+
+    def accumulate(self) -> list[T]:
+        return self.values

--- a/src/lenskit/data/accum/_proto.py
+++ b/src/lenskit/data/accum/_proto.py
@@ -1,0 +1,40 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2026 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class AccumulatorFactory[X, R](Protocol):
+    def create_accumulator(self) -> Accumulator[X, R]:
+        """
+        Create an accumulator for the results of this object.
+
+        Return:
+            An accumulator.
+        """
+        ...
+
+
+@runtime_checkable
+class Accumulator[X, R](Protocol):
+    """
+    Protocol implemented by data accumulators.
+    """
+
+    def add(self, value: X) -> None:
+        """
+        Add a single value to this accumulator.
+        """
+        ...
+
+    def accumulate(self) -> R:
+        """
+        Compute the accumulated value from this accumulator.
+        """
+        ...

--- a/src/lenskit/data/accum/_value.py
+++ b/src/lenskit/data/accum/_value.py
@@ -1,0 +1,62 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2026 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+from typing import TypedDict
+
+import numpy as np
+
+from ._proto import Accumulator
+
+INITIAL_SIZE = 1024
+
+
+class ValueStatistics(TypedDict):
+    """
+    Collected statitsics from :class:`ValueAccumulator`.
+    """
+
+    n: int
+    mean: float
+    median: float
+    std: float
+
+
+class ValueStatAccumulator(Accumulator[float | None, ValueStatistics]):
+    """
+    An accumulator for single real values, computing basic statistics.
+    """
+
+    _values: np.ndarray[tuple[int], np.dtype[np.float64]]
+    _n: int = 0
+
+    def __init__(self):
+        self._values = np.empty(INITIAL_SIZE)
+        self._n = 0
+
+    @property
+    def values(self) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
+        return self._values[: self._n]
+
+    def __len__(self) -> int:
+        return self._n
+
+    def add(self, value: float | None):
+        if value is None or np.isnan(value):
+            return
+
+        if self._n == len(self._values):
+            self._values.resize(self._n * 2)
+        self._values[self._n] = value
+        self._n += 1
+
+    def accumulate(self) -> ValueStatistics:
+        n = self._n
+        return {
+            "n": n,
+            "mean": np.mean(self._values[:n]).item(),
+            "median": np.median(self._values[:n]).item(),
+            "std": np.std(self._values[:n]).item(),
+        }

--- a/src/lenskit/metrics/__init__.py
+++ b/src/lenskit/metrics/__init__.py
@@ -8,6 +8,7 @@
 Metrics for evaluating recommender outputs.
 """
 
+import warnings
 from typing import Callable
 
 from lenskit.data import ItemList
@@ -77,6 +78,24 @@ __all__ = [
 
 
 def call_metric[**P](
+    metric: Metric | MetricFunction | Callable[P, Metric],
+    outs: ItemList,
+    test: ItemList | None = None,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> MetricResult | None:
+    """
+    Deprecated alias for :func:`measure_list`.
+
+    .. deprecated:: 2026.1
+
+        Use :func:`measure_list`.
+    """
+    warnings.warn("call_metric is deprecated, use measure_list instead", DeprecationWarning)
+    return measure_list(metric, outs, test, *args, **kwargs)
+
+
+def measure_list[**P](
     metric: Metric | MetricFunction | Callable[P, Metric],
     outs: ItemList,
     test: ItemList | None = None,

--- a/src/lenskit/metrics/__init__.py
+++ b/src/lenskit/metrics/__init__.py
@@ -13,7 +13,7 @@ from typing import Callable
 
 from lenskit.data import ItemList
 
-from ._base import GlobalMetric, ListMetric, Metric, MetricFunction, MetricResult, MetricVal
+from ._base import ListMetric, Metric, MetricFunction, MetricResult, MetricVal
 from ._collect import MeasurementCollector
 from ._quick import quick_measure_model
 from .basic import ListLength, TestItemCount
@@ -47,7 +47,6 @@ __all__ = [
     "MetricVal",
     "MeasurementCollector",
     "ListMetric",
-    "GlobalMetric",
     "RankingMetricBase",
     "RunAnalysis",
     "RunAnalysisResult",

--- a/src/lenskit/metrics/__init__.py
+++ b/src/lenskit/metrics/__init__.py
@@ -74,13 +74,6 @@ __all__ = [
 ]
 
 P = ParamSpec("P")
-MetricAccumulator = MeasurementCollector
-"""
-Deprecated alias for :class:`MeasurementCollector`.
-
-.. deprecated:: 2025.5
-    Use the new name.
-"""
 
 
 def call_metric(

--- a/src/lenskit/metrics/__init__.py
+++ b/src/lenskit/metrics/__init__.py
@@ -8,11 +8,11 @@
 Metrics for evaluating recommender outputs.
 """
 
-from typing import Callable, ParamSpec
+from typing import Callable
 
 from lenskit.data import ItemList
 
-from ._base import GlobalMetric, ListMetric, Metric, MetricFunction
+from ._base import GlobalMetric, ListMetric, Metric, MetricFunction, MetricResult, MetricVal
 from ._collect import MeasurementCollector
 from ._quick import quick_measure_model
 from .basic import ListLength, TestItemCount
@@ -42,6 +42,8 @@ from .reranking import least_item_promoted, rank_biased_overlap
 __all__ = [
     "Metric",
     "MetricFunction",
+    "MetricResult",
+    "MetricVal",
     "MeasurementCollector",
     "ListMetric",
     "GlobalMetric",
@@ -73,24 +75,20 @@ __all__ = [
     "RankBiasedEntropy",
 ]
 
-P = ParamSpec("P")
 
-
-def call_metric(
-    metric: ListMetric | MetricFunction | Callable[P, ListMetric],
+def call_metric[**P](
+    metric: Metric | MetricFunction | Callable[P, Metric],
     outs: ItemList,
     test: ItemList | None = None,
     *args: P.args,
     **kwargs: P.kwargs,
-) -> float:
+) -> MetricResult | None:
     """
-    Call a metric, instantiating it if necessary.  This intended to be a quick
-    convenience when you just need to call a metric with its default settings
-    and don't want to mess around with object/class distinctions.  You usually
-    don't actually want to use it.
+    Call a metric to measure a list, instantiating it if necessary.  This
+    intended to be a quick convenience when you just need to call a metric with
+    its default settings and don't want to mess around with object/class
+    distinctions.  You usually don't actually want to use it.
 
-    Supports both the base :class:`Metric` protocol and the extensions in
-    :class:`PredictMetric`.
 
     Args:
         metric:
@@ -106,8 +104,9 @@ def call_metric(
     if isinstance(metric, type):
         metric = metric(*args, **kwargs)
 
-    if isinstance(metric, ListMetric):
-        return metric.measure_list(outs, test)  # type: ignore
+    if isinstance(metric, Metric):
+        x = metric.measure_list(outs, test)  # type: ignore
+        return metric.extract_list_metrics(x)
     elif isinstance(metric, Callable):
         return metric(outs, test)  # type: ignore
     else:  # pragma: nocover

--- a/src/lenskit/metrics/_base.py
+++ b/src/lenskit/metrics/_base.py
@@ -16,6 +16,9 @@ from lenskit.data.accum import (
     ValueStatistics,
 )
 
+type MetricVal = float | int | object
+type MetricResult = MetricVal | Mapping[str, MetricVal]
+
 
 class MetricFunction(Protocol):
     "Interface for per-list metrics implemented as simple functions."
@@ -24,7 +27,7 @@ class MetricFunction(Protocol):
     def __call__(self, output: ItemList, test: ItemList, /) -> float: ...
 
 
-class Metric[L, S: float | Mapping[str, float | int | object]](ABC, AccumulatorFactory[L, S]):
+class Metric[L, S: MetricResult](ABC, AccumulatorFactory[L, S]):
     """
     Base class for LensKit metrics.  Individual metrics need to implement a
     sub-interface, such as :class:`ListMetric` and/or :class:`GlobalMetric`.
@@ -81,7 +84,7 @@ class Metric[L, S: float | Mapping[str, float | int | object]](ABC, AccumulatorF
         """
         raise NotImplementedError()  # pragma: no cover
 
-    def extract_list_metrics(self, data: L, /) -> float | dict[str, float] | None:
+    def extract_list_metrics(self, data: L, /) -> MetricResult | None:
         """
         Extract per-list metric(s) from intermediate measurement data.
 
@@ -134,6 +137,18 @@ class ListMetric(Metric[float, ValueStatistics]):
     @override
     def create_accumulator(self) -> ValueStatAccumulator:
         return ValueStatAccumulator()
+
+
+class FunctionMetric(ListMetric):
+    """
+    Wrapper for list metrics implemented as bare functions.
+    """
+
+    def __init__(self, function: MetricFunction):
+        self._function = function
+
+    def measure_list(self, output: ItemList, test: ItemList, /) -> float:
+        return self._function(output, test)
 
 
 class GlobalMetric:

--- a/src/lenskit/metrics/_base.py
+++ b/src/lenskit/metrics/_base.py
@@ -107,7 +107,7 @@ class Metric[L, S: MetricResult](ABC, AccumulatorFactory[L, S]):
         raise NotImplementedError()
 
 
-class ListMetric(Metric[float, ValueStatistics]):
+class ListMetric(Metric[float | None, ValueStatistics]):
     """
     Base class for metrics defined on individual recommendation outputs.  This
     is the most common type of metric.
@@ -125,7 +125,7 @@ class ListMetric(Metric[float, ValueStatistics]):
     default: ClassVar[float | None] = 0.0
 
     @abstractmethod
-    def measure_list(self, output: ItemList, test: ItemList, /) -> float: ...
+    def measure_list(self, output: ItemList, test: ItemList, /) -> float | None: ...
 
     @override
     def extract_list_metrics(self, data: Any, /) -> float:
@@ -146,6 +146,10 @@ class FunctionMetric(ListMetric):
 
     def __init__(self, function: MetricFunction):
         self._function = function
+
+    @property
+    def label(self) -> str:
+        return self._function.__name__  # type: ignore
 
     def measure_list(self, output: ItemList, test: ItemList, /) -> float:
         return self._function(output, test)

--- a/src/lenskit/metrics/_base.py
+++ b/src/lenskit/metrics/_base.py
@@ -4,13 +4,17 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
+# pyright: strict
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Protocol
-
-import numpy as np
-import pyarrow as pa
+from typing import Any, ClassVar, Mapping, Protocol, override
 
 from lenskit.data import ItemList, ItemListCollection
+from lenskit.data.accum import (
+    Accumulator,
+    AccumulatorFactory,
+    ValueStatAccumulator,
+    ValueStatistics,
+)
 
 
 class MetricFunction(Protocol):
@@ -20,7 +24,7 @@ class MetricFunction(Protocol):
     def __call__(self, output: ItemList, test: ItemList, /) -> float: ...
 
 
-class Metric(ABC):
+class Metric[L, S: float | Mapping[str, float | int | object]](ABC, AccumulatorFactory[L, S]):
     """
     Base class for LensKit metrics.  Individual metrics need to implement a
     sub-interface, such as :class:`ListMetric` and/or :class:`GlobalMetric`.
@@ -28,9 +32,15 @@ class Metric(ABC):
     This class defines the interface for metrics. Subclasses should implement
     the `measure_list` method to compute metric values.
 
-    The `summarize()` method has a default implementation that computes the
-    mean of the per-list metric values, but subclasses can override it to provide
+    The `summarize()` method has a default implementation that computes the mean
+    of the per-list metric values, but subclasses can override it to provide
     more appropriate summary statistics.
+
+    .. versionchanged:: 2026.1
+
+        Removed the ``summarize`` method in favor of requiring metrics to
+        implement :class:`AccumulatorFactory` to allow metric-controlled
+        accumulation.
 
     Stability:
         Full
@@ -39,9 +49,9 @@ class Metric(ABC):
 
         For simplicity in the analysis code, you cannot simply implement the
         properties of this class on an arbitrary class in order to implement a
-        metric with all available behavior such as labeling and defaults;
-        you must actually extend this class. This requirement may be relaxed
-        in the future.
+        metric with all available behavior such as labeling and defaults; you
+        must actually extend this class. This requirement may be relaxed in the
+        future.
 
     The default value to impute when computing statistics over missing values.
     If ``None``, no imputation is done (necessary for metrics like RMSE, where
@@ -60,7 +70,7 @@ class Metric(ABC):
         return f"Metric {self.label}"
 
     @abstractmethod
-    def measure_list(self, output: ItemList, test: ItemList, /) -> Any:
+    def measure_list(self, output: ItemList, test: ItemList, /) -> L:
         """
         Compute measurements for a single list.
 
@@ -71,7 +81,7 @@ class Metric(ABC):
         """
         raise NotImplementedError()  # pragma: no cover
 
-    def extract_list_metrics(self, data: Any, /) -> float | dict[str, float] | None:
+    def extract_list_metrics(self, data: L, /) -> float | dict[str, float] | None:
         """
         Extract per-list metric(s) from intermediate measurement data.
 
@@ -83,28 +93,27 @@ class Metric(ABC):
         return None
 
     @abstractmethod
-    def summarize(self, values: list[Any] | pa.Array | pa.ChunkedArray, /) -> dict[str, float]:
+    def create_accumulator(self) -> Accumulator[L, S]:  # pragma: nocov
         """
-        Aggregate intermediate values into summary statistics.
+        Creaet an accumulator to aggregate per-list measurements into summary
+        metrics.
 
-        Returns:
-            A dictionary of summary statistics.
+        Each result from :meth:`measure_list` is passed to
+        :meth:`Accumulator.add`.
         """
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError()
 
 
-class ListMetric(Metric):
+class ListMetric(Metric[float, ValueStatistics]):
     """
-    Base class for metrics that measure individual recommendation (or
-    prediction) lists, and whose results may be aggregated to compute overall
-    metrics.
+    Base class for metrics defined on individual recommendation outputs.  This
+    is the most common type of metric.
 
     For prediction metrics, this is *macro-averaging*.
 
-    Default behavior:
-        Implements `summarize()` by averaging per-list results (mean, ignoring NaNs).
-
-    This class implements the Metric interface in terms of the measure_list method.
+    Metrics based on this class implement :meth:`measure_list` to compute a
+    single numeric value for each list, and the accumulated result will be basic
+    statistical summaries of those values.
 
     Stability:
         Full
@@ -113,45 +122,18 @@ class ListMetric(Metric):
     default: ClassVar[float | None] = 0.0
 
     @abstractmethod
-    def measure_list(self, output: ItemList, test: ItemList, /) -> float:
-        """
-        Compute the metric value for a single result list.
+    def measure_list(self, output: ItemList, test: ItemList, /) -> float: ...
 
-        Individual metric classes need to implement this method.
-        """
-        raise NotImplementedError()  # pragma: no cover
-
+    @override
     def extract_list_metrics(self, data: Any, /) -> float:
         """
         Return the given per-list metric result.
         """
         return data
 
-    def summarize(
-        self, values: list[Any] | pa.Array | pa.ChunkedArray, /
-    ) -> dict[str, float | None]:
-        """
-        Summarize per-list metric values
-
-        Returns:
-            A dictionary containing mean, median, and std.
-        """
-        if isinstance(values, (pa.Array, pa.ChunkedArray)):
-            values = values.to_pylist()
-
-        numeric_values = [
-            float(v) for v in values if isinstance(v, (int, float, np.integer, np.floating))
-        ]
-
-        if not numeric_values:
-            return {"mean": None, "median": None, "std": None}
-
-        arr = np.array(numeric_values, dtype=np.float64)
-        return {
-            "mean": float(np.mean(arr)),
-            "median": float(np.median(arr)),
-            "std": float(np.std(arr, ddof=1)) if len(arr) > 1 else 0.0,
-        }
+    @override
+    def create_accumulator(self) -> ValueStatAccumulator:
+        return ValueStatAccumulator()
 
 
 class GlobalMetric:

--- a/src/lenskit/metrics/_base.py
+++ b/src/lenskit/metrics/_base.py
@@ -96,7 +96,7 @@ class Metric[L, S: MetricResult](ABC, AccumulatorFactory[L, S]):
         return None
 
     @abstractmethod
-    def create_accumulator(self) -> Accumulator[L, S]:  # pragma: nocov
+    def create_accumulator(self) -> Accumulator[L, S]:  # pragma: no cover
         """
         Creaet an accumulator to aggregate per-list measurements into summary
         metrics.

--- a/src/lenskit/metrics/_base.py
+++ b/src/lenskit/metrics/_base.py
@@ -8,7 +8,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Mapping, Protocol, override
 
-from lenskit.data import ItemList, ItemListCollection
+from lenskit.data import ItemList
 from lenskit.data.accum import (
     Accumulator,
     AccumulatorFactory,
@@ -29,8 +29,8 @@ class MetricFunction(Protocol):
 
 class Metric[L, S: MetricResult](ABC, AccumulatorFactory[L, S]):
     """
-    Base class for LensKit metrics.  Individual metrics need to implement a
-    sub-interface, such as :class:`ListMetric` and/or :class:`GlobalMetric`.
+    Base class for LensKit metrics.  Simple metrics that compute a single value
+    for a list should extend :class:`ListMetric`.
 
     This class defines the interface for metrics. Subclasses should implement
     the `measure_list` method to compute metric values.
@@ -153,23 +153,3 @@ class FunctionMetric(ListMetric):
 
     def measure_list(self, output: ItemList, test: ItemList, /) -> float:
         return self._function(output, test)
-
-
-class GlobalMetric:
-    """
-    Base class for metrics that measure entire runs at a time.
-
-    For prediction metrics, this is *micro-averaging*.
-
-    Stability:
-        Full
-    """
-
-    @abstractmethod
-    def measure_run(self, output: ItemListCollection, test: ItemListCollection, /) -> float:
-        """
-        Compute a metric value for an entire run.
-
-        Individual metric classes need to implement this method.
-        """
-        raise NotImplementedError()  # pragma: no cover

--- a/src/lenskit/metrics/_collect.py
+++ b/src/lenskit/metrics/_collect.py
@@ -159,9 +159,6 @@ class MeasurementCollector:
                 key_kwargs = keys | dict(zip(outputs.key_fields, key))
                 list_test = test.lookup_projected(key)
 
-                if out is None:
-                    out = ItemList()
-
                 if list_test is None:
                     no_test_count += 1
                     list_test = ItemList([])
@@ -228,12 +225,7 @@ def _wrap_metric(
     assert isinstance(m, Metric), f"invalid type for metric {m}"
 
     if label is None:
-        if isinstance(m, Metric):
-            wl = m.label
-        elif isinstance(m, type):
-            wl = m.__name__  # type: ignore
-        else:
-            wl = type(m).__name__
+        wl = m.label
     else:
         wl = label
 

--- a/src/lenskit/metrics/_collect.py
+++ b/src/lenskit/metrics/_collect.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import pandas as pd
@@ -28,7 +28,7 @@ from ._base import (
 _log = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass
 class MetricState:
     """
     Internal class for storing metrics with their configuration and
@@ -73,6 +73,25 @@ class MeasurementCollector:
         self._metrics = []
         self._list_records = []
         self._key_fields = []
+
+    def empty_copy(self):
+        """
+        Create a copy of this measurement collector with no collected data.
+        """
+        copy = MeasurementCollector()
+        copy._metrics = [
+            replace(m, accumulator=m.metric.create_accumulator()) for m in self._metrics
+        ]
+        return copy
+
+    def reset(self):
+        """
+        Remove all collected data from this collector.
+        """
+        self._key_fields = []
+        self._list_records = []
+        for state in self._metrics:
+            state.accumulator = state.metric.create_accumulator()
 
     def add_metric(
         self,

--- a/src/lenskit/metrics/_collect.py
+++ b/src/lenskit/metrics/_collect.py
@@ -96,6 +96,13 @@ class MeasurementCollector:
         for state in self._metrics:
             state.accumulator = state.metric.create_accumulator()
 
+    @property
+    def metric_names(self) -> list[str]:
+        """
+        Get the list of metric names.
+        """
+        return [m.label for m in self._metrics]
+
     def add_metric(
         self,
         metric: Metric | MetricFunction | type[Metric],
@@ -173,12 +180,9 @@ class MeasurementCollector:
         if no_test_count:
             _log.warning("could not find test data for %d lists", no_test_count)
 
-    def list_metrics(self, fill_missing: bool = True) -> pd.DataFrame:
+    def list_metrics(self) -> pd.DataFrame:
         """
         Get the per-list metric results as a DataFrame.
-
-        Args:
-            fill_missing: If True, fill missing values with metric defaults.
 
         Returns:
             DataFrame with one row per list and one column per metric.

--- a/src/lenskit/metrics/_collect.py
+++ b/src/lenskit/metrics/_collect.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Any
@@ -15,6 +14,7 @@ import pandas as pd
 
 from lenskit.data import ItemList, ItemListCollection
 from lenskit.data.accum import Accumulator
+from lenskit.logging import get_logger, item_progress
 
 from ._base import (
     FunctionMetric,
@@ -25,7 +25,7 @@ from ._base import (
     MetricVal,
 )
 
-_log = logging.getLogger(__name__)
+_log = get_logger(__name__)
 
 
 @dataclass
@@ -54,8 +54,8 @@ class MeasurementCollector:
     """
     Collect metric measurements over multiple recommendation lists.
 
-    This class separates metric collection and aggregation from the main
-    evaluation loop.
+    This class automates collecting metric values and translating accumulated
+    summaries into data frames.
 
     .. versionchanged:: 2026.1
 
@@ -67,12 +67,15 @@ class MeasurementCollector:
 
     _metrics: list[MetricState]
     _list_records: list[dict[str, float | int | object]]
-    _key_fields: list[str]
+    key_fields: list[str]
+    """
+    Columns naming the keys of measured lists.
+    """
 
     def __init__(self):
         self._metrics = []
         self._list_records = []
-        self._key_fields = []
+        self.key_fields = []
 
     def empty_copy(self):
         """
@@ -88,7 +91,7 @@ class MeasurementCollector:
         """
         Remove all collected data from this collector.
         """
-        self._key_fields = []
+        self.key_fields = []
         self._list_records = []
         for state in self._metrics:
             state.accumulator = state.metric.create_accumulator()
@@ -123,8 +126,8 @@ class MeasurementCollector:
             **keys:
                 Identifying keys for this list (e.g., user_id).
         """
-        if not self._key_fields:
-            self._key_fields = list(keys.keys())
+        if not self.key_fields:
+            self.key_fields = list(keys.keys())
 
         rec = dict(keys)
         for state in self._metrics:
@@ -134,6 +137,41 @@ class MeasurementCollector:
             _add_values(rec, state.label, lv)
 
         self._list_records.append(rec)
+
+    def measure_collection(
+        self, outputs: ItemListCollection, test: ItemListCollection, **keys: Any
+    ):
+        """
+        Measure a collection of item lists against truth data.
+
+        Args:
+            outputs:
+                The item lists to measure.
+            test:
+                Test data item lists.
+            keys:
+                Additional keys to label measurements from these lists.
+        """
+
+        _log.debug("measuring %d metrics for %d output lists", len(self._metrics), len(outputs))
+        no_test_count = 0
+        with item_progress("Measuring", len(outputs)) as pb:
+            for key, out in outputs:
+                key_kwargs = keys | dict(zip(outputs.key_fields, key))
+                list_test = test.lookup_projected(key)
+
+                if out is None:
+                    out = ItemList()
+
+                if list_test is None:
+                    no_test_count += 1
+                    list_test = ItemList([])
+
+                self.measure_list(out, list_test, **key_kwargs)
+                pb.update()
+
+        if no_test_count:
+            _log.warning("could not find test data for %d lists", no_test_count)
 
     def list_metrics(self, fill_missing: bool = True) -> pd.DataFrame:
         """
@@ -147,14 +185,19 @@ class MeasurementCollector:
         """
 
         df = pd.DataFrame.from_records(self._list_records)
-        if self._key_fields:
-            df.set_index(self._key_fields, inplace=True, drop=True)
+        if self.key_fields:
+            df.set_index(self.key_fields, inplace=True, drop=True)
 
         return df
 
     def summary_metrics(self) -> dict[str, float]:
         """
         Compute summary statistics by calling each metric's summarize() method.
+
+        .. note::
+
+            This returns *overall* summaries — summaries are not collected
+            separately for different calls to :meth:`measure_collection`.
 
         Returns:
             A dictionary with flattened metric results.

--- a/src/lenskit/metrics/_collect.py
+++ b/src/lenskit/metrics/_collect.py
@@ -18,7 +18,6 @@ from lenskit.logging import get_logger, item_progress
 
 from ._base import (
     FunctionMetric,
-    GlobalMetric,
     Metric,
     MetricFunction,
     MetricResult,
@@ -41,13 +40,6 @@ class MetricState:
     metric: Metric
     accumulator: Accumulator[Any, MetricResult]
     label: str
-
-    def measure_run(self, run: ItemListCollection, test: ItemListCollection) -> float:
-        """Only global metrics support run-level measurement."""
-        if isinstance(self.metric, GlobalMetric):
-            return self.metric.measure_run(run, test)
-        else:
-            raise TypeError(f"metric {self.metric} does not support global measurement")
 
 
 class MeasurementCollector:

--- a/src/lenskit/metrics/_collect.py
+++ b/src/lenskit/metrics/_collect.py
@@ -7,60 +7,40 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, TypeVar
+from typing import Any
 
-import numpy as np
 import pandas as pd
-import pyarrow as pa
 
 from lenskit.data import ItemList, ItemListCollection
+from lenskit.data.accum import Accumulator
 
-from ._base import GlobalMetric, ListMetric, Metric, MetricFunction
+from ._base import (
+    FunctionMetric,
+    GlobalMetric,
+    Metric,
+    MetricFunction,
+    MetricResult,
+    MetricVal,
+)
 
 _log = logging.getLogger(__name__)
-K1 = TypeVar("K1", bound=tuple)
-K2 = TypeVar("K2", bound=tuple)
 
 
 @dataclass(frozen=True)
-class MetricWrapper:
+class MetricState:
     """
-    Internal class for storing metrics with their configuration.
+    Internal class for storing metrics with their configuration and
+    accumulators.
 
     Stability:
         Internal
     """
 
-    metric: Metric | MetricFunction
+    metric: Metric
+    accumulator: Accumulator[Any, MetricResult]
     label: str
-    default: float | None = None
-
-    @property
-    def is_listwise(self) -> bool:
-        "Check if this metric is listwise."
-        return isinstance(self.metric, (ListMetric, Callable))
-
-    @property
-    def is_global(self) -> bool:
-        "Check if this metric is global."
-        return isinstance(self.metric, GlobalMetric)
-
-    def measure_list(self, list: ItemList, test: ItemList) -> Any:
-        """Get intermediate measurement data from the metric."""
-        if isinstance(self.metric, Callable):
-            return self.metric(list, test)
-        return self.metric.measure_list(list, test)
-
-    def extract_list_metrics(self, intermediate_data: Any) -> float | dict[str, float] | None:
-        """Extract per-list metrics from intermediate data."""
-        return self.metric.extract_list_metrics(intermediate_data)
-
-    def summarize(
-        self, values: list[Any] | pa.Array | pa.ChunkedArray
-    ) -> dict[str, float | None] | float | None:
-        """Aggregate intermediate values into summary statistics."""
-        return self.metric.summarize(values)
 
     def measure_run(self, run: ItemListCollection, test: ItemListCollection) -> float:
         """Only global metrics support run-level measurement."""
@@ -77,24 +57,27 @@ class MeasurementCollector:
     This class separates metric collection and aggregation from the main
     evaluation loop.
 
-    .. versionchanged:: 2025.5
-        This class was renamed from ``MetricAccumulator``.  ``MetricAccumulator``
-        is preserved as a deprecated alias for ``MeasurementCollector``.
+    .. versionchanged:: 2026.1
+
+        ``metrics`` is no longer publicly exposed as a list of wrappers.
 
     Stability:
         Caller
     """
 
+    _metrics: list[MetricState]
+    _list_records: list[dict[str, float | int | object]]
+    _key_fields: list[str]
+
     def __init__(self):
-        self.metrics: list[MetricWrapper] = []
-        self._records: list[dict[str, Any]] = []
-        self._key_fields: list[str] = []
+        self._metrics = []
+        self._list_records = []
+        self._key_fields = []
 
     def add_metric(
         self,
         metric: Metric | MetricFunction | type[Metric],
         label: str | None = None,
-        default: float | None = None,
     ):
         """
         Add a metric to this accumulator.
@@ -105,13 +88,9 @@ class MeasurementCollector:
             label:
                 The label to use for the metric's results. If unset, obtains
                 from the metric.
-            default:
-                The default value to use when a user does not have
-                recommendations. If unset, obtains from the metric's ``default``
-                attribute (if specified).
         """
-        wrapper = self._wrap_metric(metric, label, default)
-        self.metrics.append(wrapper)
+        wrapper = _wrap_metric(metric, label)
+        self._metrics.append(wrapper)
 
     def measure_list(self, output: ItemList, test: ItemList, **keys: Any):
         """
@@ -129,15 +108,13 @@ class MeasurementCollector:
             self._key_fields = list(keys.keys())
 
         rec = dict(keys)
-        for wrapper in self.metrics:
-            if wrapper.is_global:
-                continue
+        for state in self._metrics:
+            intermediate = state.metric.measure_list(output, test)
+            state.accumulator.add(intermediate)
+            lv = state.metric.extract_list_metrics(intermediate)
+            _add_values(rec, state.label, lv)
 
-            intermediate_data = wrapper.measure_list(output, test)
-
-            rec[f"_intermediate_{wrapper.label}"] = intermediate_data
-
-        self._records.append(rec)
+        self._list_records.append(rec)
 
     def list_metrics(self, fill_missing: bool = True) -> pd.DataFrame:
         """
@@ -149,50 +126,10 @@ class MeasurementCollector:
         Returns:
             DataFrame with one row per list and one column per metric.
         """
-        if not self._records:
-            return pd.DataFrame()
 
-        extracted_records = []
-
-        for record in self._records:
-            new_record = {k: v for k, v in record.items() if not k.startswith("_intermediate_")}
-
-            for wrapper in self.metrics:
-                if wrapper.is_global:
-                    continue
-
-                intermediate_key = f"_intermediate_{wrapper.label}"
-                if intermediate_key in record:
-                    intermediate_data = record[intermediate_key]
-
-                    extracted_val = wrapper.extract_list_metrics(intermediate_data)
-
-                    if extracted_val is None and wrapper.default is not None:
-                        extracted_val = wrapper.default
-
-                    if isinstance(extracted_val, dict):
-                        for k, v in extracted_val.items():
-                            new_record[f"{wrapper.label}.{k}"] = v
-                    else:
-                        new_record[wrapper.label] = extracted_val
-
-            extracted_records.append(new_record)
-
-        df = pd.DataFrame(extracted_records)
-
+        df = pd.DataFrame.from_records(self._list_records)
         if self._key_fields:
             df.set_index(self._key_fields, inplace=True, drop=True)
-
-        if fill_missing:
-            for wrapper in self.metrics:
-                if wrapper.default is not None and not wrapper.is_global:
-                    label = wrapper.label
-                    nested_cols = [c for c in df.columns if c.startswith(f"{label}.")]
-                    if nested_cols:
-                        for col in nested_cols:
-                            df[col] = df[col].fillna(wrapper.default)
-                    elif label in df.columns:
-                        df[label] = df[label].fillna(wrapper.default)
 
         return df
 
@@ -205,65 +142,62 @@ class MeasurementCollector:
         """
         results = {}
 
-        for wrapper in self.metrics:
-            if wrapper.is_global:
-                continue
-
-            label = wrapper.label
-            intermediate_key = f"_intermediate_{label}"
-
-            intermediate_values = []
-            for record in self._records:
-                if intermediate_key in record and record[intermediate_key] is not None:
-                    intermediate_values.append(record[intermediate_key])
-
-            if intermediate_values:
-                summary = wrapper.summarize(intermediate_values)
-                if summary is not None:
-                    if isinstance(summary, dict):
-                        for key, value in summary.items():
-                            results[f"{label}.{key}"] = value
-                    else:
-                        results[label] = summary
+        for state in self._metrics:
+            agg = state.accumulator.accumulate()
+            _add_values(results, state.label, agg)
 
         return results
-
-    def _wrap_metric(
-        self,
-        m: Metric | MetricFunction | type[Metric],
-        label: str | None = None,
-        default: float | None = None,
-    ) -> MetricWrapper:
-        """Wrap a metric with its configuration."""
-        if isinstance(m, type):
-            m = m()
-
-        if label is None:
-            if isinstance(m, Metric):
-                wl = m.label
-            elif isinstance(m, type):
-                wl = m.__name__  # type: ignore
-            else:
-                wl = type(m).__name__
-        else:
-            wl = label
-
-        if default is None:
-            if isinstance(m, ListMetric):
-                default = m.default
-
-            if default is not None and not isinstance(
-                default, (float, int, np.floating, np.integer)
-            ):
-                raise TypeError(f"metric {m} has unsupported default {default}")
-
-        return MetricWrapper(m, wl, default)  # type: ignore
 
     def _validate_setup(self):
         """Validate that the accumulator is properly configured."""
         seen = set()
-        for m in self.metrics:
+        for m in self._metrics:
             lbl = m.label
             if lbl in seen:
                 raise RuntimeError(f"duplicate metric: {lbl}")
             seen.add(lbl)
+
+
+def _wrap_metric(
+    m: Metric | MetricFunction | type[Metric],
+    label: str | None = None,
+) -> MetricState:
+    """Wrap a metric with its configuration."""
+    if isinstance(m, type):
+        m = m()
+    elif not isinstance(m, Metric):
+        m = FunctionMetric(m)
+    assert isinstance(m, Metric), f"invalid type for metric {m}"
+
+    if label is None:
+        if isinstance(m, Metric):
+            wl = m.label
+        elif isinstance(m, type):
+            wl = m.__name__  # type: ignore
+        else:
+            wl = type(m).__name__
+    else:
+        wl = label
+
+    return MetricState(m, m.create_accumulator(), wl)
+
+
+def _add_values(record: dict[str, MetricVal], name: str, data: MetricResult | None):
+    """
+    Add metric values to a record dictionary, a specified metric name.
+
+    Args:
+        record:
+            The record to receive the data.
+        name:
+            The metric name for the data.
+        data:
+            The input data values.
+    """
+    if data is None:
+        return
+    elif isinstance(data, Mapping):
+        for k, v in data.items():
+            record[f"{name}.{k}"] = v
+    else:
+        record[name] = data

--- a/src/lenskit/metrics/basic.py
+++ b/src/lenskit/metrics/basic.py
@@ -8,8 +8,6 @@
 Basic set statistics.
 """
 
-import numpy as np
-
 from lenskit.data.items import ItemList
 
 from ._base import ListMetric, Metric
@@ -28,9 +26,6 @@ class ListLength(ListMetric):
     def measure_list(self, recs: ItemList, test: ItemList) -> float:
         return len(recs)
 
-    def summarize(self, values):
-        return float(np.mean(values))
-
 
 class TestItemCount(Metric):
     """
@@ -42,5 +37,5 @@ class TestItemCount(Metric):
 
     label = "TestItemCount"  # type: ignore
 
-    def __call__(self, recs: ItemList, test: ItemList) -> float:
+    def measure_list(self, recs: ItemList, test: ItemList) -> float:
         return len(test)

--- a/src/lenskit/metrics/bulk.py
+++ b/src/lenskit/metrics/bulk.py
@@ -122,6 +122,11 @@ class RunAnalysis:
     This class now uses :class:`MetricAccumulator` internally to separate
     accumulation from looping, while maintaining the same external interface.
 
+    .. versionchanged:: 2026.1
+
+        Global metric outputs from this class have changed column names in some
+        cases, to simplify logic.
+
     .. deprecated:: 2026.1
 
         This class is deprecated in favor of directly using

--- a/src/lenskit/metrics/bulk.py
+++ b/src/lenskit/metrics/bulk.py
@@ -10,12 +10,10 @@ import logging
 import warnings
 from typing import TypeVar
 
-import numpy as np
 import pandas as pd
 
-from lenskit.data import ItemList, ItemListCollection
+from lenskit.data import ItemListCollection
 from lenskit.diagnostics import DataWarning
-from lenskit.logging import item_progress
 from lenskit.metrics import MeasurementCollector
 
 from ._base import Metric, MetricFunction
@@ -28,6 +26,11 @@ K2 = TypeVar("K2", bound=tuple)
 class RunAnalysisResult:
     """
     Results of a bulk metric computation.
+
+    .. deprecated:: 2026.1
+
+        This class is deprecated in favor of directly using
+        :class:`~lenskit.metrics.MeasurementCollector`.
 
     Stability:
         Caller
@@ -119,6 +122,11 @@ class RunAnalysis:
     This class now uses :class:`MetricAccumulator` internally to separate
     accumulation from looping, while maintaining the same external interface.
 
+    .. deprecated:: 2026.1
+
+        This class is deprecated in favor of directly using
+        :class:`~lenskit.metrics.MeasurementCollector`.
+
     Args:
         metrics:
             A list of metrics; you can also add them with :meth:`add_metric`,
@@ -128,10 +136,20 @@ class RunAnalysis:
         Caller
     """
 
+    collector: MeasurementCollector
+    """
+    The measurement collector for this analysis.
+    """
+    _defaults: dict[str, float]
+
     def __init__(self, *metrics: Metric):
-        self._accumulator = MeasurementCollector()
+        warnings.warn(
+            "RunAnalysis is deprectated, use MeasurementCollector instead", DeprecationWarning
+        )
+        self.collector = MeasurementCollector()
+        self._defaults = {}
         for metric in metrics:
-            self._accumulator.add_metric(metric)
+            self.collector.add_metric(metric)
 
     def add_metric(
         self,
@@ -153,17 +171,9 @@ class RunAnalysis:
                 recommendations. If unset, obtains from the metric's ``default``
                 attribute (if specified).
         """
-        self._accumulator.add_metric(metric, label, default)
-
-    @property
-    def metrics(self) -> list:
-        """
-        The list of metrics to compute.
-
-        .. deprecated:: 2025.4
-            Access metrics through the accumulator interface instead.
-        """
-        return self._accumulator.metrics
+        self.collector.add_metric(metric, label)
+        if default is not None:
+            self._defaults[self.collector._metrics[-1].label] = default
 
     def compute(
         self, outputs: ItemListCollection[K1], test: ItemListCollection[K2]
@@ -182,66 +192,14 @@ class RunAnalysis:
         """
         Measure a set of outputs against a set of test data.
         """
-        self._accumulator._validate_setup()
 
-        if len(outputs.key_fields) > 1:
-            index = pd.MultiIndex.from_tuples(outputs.keys())
-            index.names = list(outputs.key_fields)
-        else:
-            index = pd.Index([k[0] for k in outputs.keys()])
-            index.name = outputs.key_fields[0]
+        copy = self.collector.empty_copy()
+        copy._validate_setup()
 
-        n = len(outputs)
-        _log.debug("measuring %d metrics for %d output lists", len(self._accumulator.metrics), n)
+        copy.measure_collection(outputs, test)
 
-        no_test_count = 0
-        with item_progress("Measuring", n) as pb:
-            for key, out in outputs:
-                key_kwargs = dict(zip(outputs.key_fields, key))
-                list_test = test.lookup_projected(key)
-                if out is None or (list_test is None and not out):
-                    continue
-                elif list_test is None:
-                    no_test_count += 1
-                    list_test = ItemList([])
-                self._accumulator.measure_list(out, list_test, **key_kwargs)
-                pb.update()
+        res = RunAnalysisResult(
+            copy.list_metrics(), pd.Series(copy.summary_metrics()), self._defaults
+        )
 
-        if no_test_count:
-            _log.warning("could not find test data for %d lists", no_test_count)
-
-        list_results = self._accumulator.list_metrics(fill_missing=False)
-
-        global_metrics = [m for m in self._accumulator.metrics if m.is_global]
-
-        _log.debug("computing %d global metrics", len(global_metrics))
-
-        global_results = {}
-        for metric_wrapper in global_metrics:
-            result = metric_wrapper.measure_run(outputs, test)
-
-            if result is None and metric_wrapper.default is not None:
-                result = metric_wrapper.default
-
-            if result is not None:
-                global_results[metric_wrapper.label] = result
-
-        summary_results = self._accumulator.summary_metrics()
-        for key, value in summary_results.items():
-            if "." in key:
-                base_metric = key.split(".", 1)[0]
-                if base_metric not in global_results:
-                    global_results[base_metric] = value
-            else:
-                if key not in global_results:
-                    global_results[key] = value
-
-        global_results = pd.Series(global_results, dtype=np.float64)
-
-        defaults = {
-            metric_wrapper.label: metric_wrapper.default
-            for metric_wrapper in self._accumulator.metrics
-            if metric_wrapper.default is not None
-        }
-
-        return RunAnalysisResult(list_results, global_results, defaults)
+        return res

--- a/src/lenskit/metrics/predict.py
+++ b/src/lenskit/metrics/predict.py
@@ -12,6 +12,8 @@ and instructions on using these metrics.
 from __future__ import annotations
 
 import logging
+from math import sqrt
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -19,10 +21,11 @@ from numpy.typing import NDArray
 from typing_extensions import Callable, Literal, TypeAlias, override
 
 from lenskit.data import ItemList
+from lenskit.data.accum import ValueStatAccumulator
 from lenskit.data.adapt import ITEM_COMPAT_COLUMN, normalize_columns
 from lenskit.data.types import AliasedColumn
 
-from ._base import ListMetric, Metric
+from ._base import Metric
 
 _log = logging.getLogger(__name__)
 
@@ -108,7 +111,7 @@ class PredictMetric(Metric):
         return pred_s, rate_s
 
 
-class RMSE(PredictMetric, ListMetric):
+class RMSE(PredictMetric):
     """
     Compute RMSE (root mean squared error).  This is computed as:
 
@@ -125,14 +128,23 @@ class RMSE(PredictMetric, ListMetric):
     """
 
     @override
-    def measure_list(self, predictions: ItemList, test: ItemList | None = None, /) -> float:
+    def measure_list(
+        self, predictions: ItemList, test: ItemList | None = None, /
+    ) -> tuple[float, int]:
         ps, ts = self.align_scores(predictions, test)
         err = ps - ts
         err *= err
-        return np.sqrt(np.mean(err))
+        return np.sum(err), np.sum(np.isfinite(err))
+
+    def extract_list_metrics(self, data: tuple[float, int]):
+        val, n = data
+        return sqrt(val / n)
+
+    def create_accumulator(self):
+        return AvgErrorAccumulator(root=True)
 
 
-class MAE(PredictMetric, ListMetric):
+class MAE(PredictMetric):
     """
     Compute MAE (mean absolute error).  This is computed as:
 
@@ -149,7 +161,47 @@ class MAE(PredictMetric, ListMetric):
     """
 
     @override
-    def measure_list(self, predictions: ItemList, test: ItemList | None = None, /) -> float:
+    def measure_list(
+        self, predictions: ItemList, test: ItemList | None = None, /
+    ) -> tuple[float, int]:
         ps, ts = self.align_scores(predictions, test)
         err = ps - ts
-        return np.mean(np.abs(err)).item()
+        return np.sum(np.abs(err)), np.sum(np.isfinite(err))
+
+    def extract_list_metrics(self, data: tuple[float, int]):
+        val, n = data
+        return val / n
+
+    def create_accumulator(self):
+        return AvgErrorAccumulator(root=False)
+
+
+class AvgErrorAccumulator:
+    _root: bool
+    _singles: ValueStatAccumulator
+    _total_val: float
+    _total_n: int
+
+    def __init__(self, root: bool = False):
+        self._root = root
+        self._singles = ValueStatAccumulator()
+        self._total_val = 0.0
+        self._total_n = 0
+
+    def add(self, value: tuple[float, int]):
+        val, n = value
+        self._total_val += val
+        self._total_n += n
+
+        x = val / n
+        if self._root:
+            x = sqrt(x)
+        self._singles.add(x)
+
+    def accumulate(self) -> dict[str, float]:
+        stats = self._singles.accumulate()
+        x = self._total_val / self._total_n
+        if self._root:
+            x = sqrt(x)
+
+        return cast(dict[str, float], stats) | {"global": x}

--- a/src/lenskit/metrics/ranking/_gini.py
+++ b/src/lenskit/metrics/ranking/_gini.py
@@ -7,12 +7,10 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
-import pyarrow as pa
-import pyarrow.compute as pc
+from numpy.typing import NDArray
 from typing_extensions import override
 
-from lenskit.data import Dataset, ItemList
+from lenskit.data import Dataset, ItemList, Vocabulary
 from lenskit.logging import get_logger
 from lenskit.stats import gini
 
@@ -25,24 +23,28 @@ _log = get_logger(__name__)
 class GiniBase(RankingMetricBase):
     """
     Base class for Gini diversity / popularity concentration metrics.
+
+    Args:
+        n:
+            The maximum recommendation list length.
+        items:
+            The item vocabulary or a dataset from which to extract the items.
     """
 
-    item_count: int
+    item_vocab: Vocabulary
 
     def __init__(
         self,
         n: int | None = None,
         *,
         k: int | None = None,
-        items: int | pd.Series | pd.DataFrame | Dataset,
+        items: Vocabulary | Dataset,
     ):
         super().__init__(n, k=k)
-        if isinstance(items, int):
-            self.item_count = items
-        elif isinstance(items, Dataset):
-            self.item_count = items.item_count
+        if isinstance(items, Dataset):
+            self.item_vocab = items.items
         else:
-            self.item_count = len(items)
+            self.item_vocab = items
 
 
 class ListGini(GiniBase):
@@ -56,30 +58,17 @@ class ListGini(GiniBase):
         n:
             The maximum recommendation list length.
         items:
-            The total number of items, a data frame or series of item data, or a
-            dataset. If a frame or series is provided, its length will be used
-            as the number of items.  If a dataset is provided, its item count
-            will be used.
+            The item vocabulary or a dataset from which to extract the items.
 
     Stability:
         Caller
     """
 
     @override
-    def measure_list(self, output: ItemList, test):
+    def measure_list(self, output: ItemList, test) -> tuple[NDArray[np.int32], float]:
         recs = self.truncate(output)
-        return recs.ids(format="arrow")
-
-    @override
-    def summarize(self, values: list[pa.Array] | pa.ChunkedArray, /):
-        log = _log.bind(metric=self.label, item_count=self.item_count)
-        log.debug("aggregating for %d lists", len(values))
-        chunked = pa.chunked_array(values)
-        vc_tbl = pc.value_counts(chunked)
-        log.debug("found %d distinct items", len(vc_tbl))
-        counts = np.zeros(self.item_count, np.int32)
-        counts[: len(vc_tbl)] = np.asarray(vc_tbl.field("counts"), dtype=np.int32)
-        return gini(counts)
+        ids = recs.numbers(vocabulary=self.item_vocab)
+        return (ids, 1.0)
 
 
 class ExposureGini(GiniBase):
@@ -93,10 +82,7 @@ class ExposureGini(GiniBase):
         n:
             The maximum recommendation list length.
         items:
-            The total number of items, a data frame or series of item data, or a
-            dataset. If a frame or series is provided, its length will be used
-            as the number of items.  If a dataset is provided, its item count
-            will be used.
+            The item vocabulary or a dataset from which to extract the items.
         weight:
             The rank weighting model to use.  Defaults to
             :class:`GeometricRankWeight` with the specified patience parameter.
@@ -112,27 +98,32 @@ class ExposureGini(GiniBase):
         n: int | None = None,
         *,
         k: int | None = None,
-        items: int | pd.Series | pd.DataFrame | Dataset,
+        items: Vocabulary | Dataset,
         weight: RankWeight = GeometricRankWeight(),
     ):
         super().__init__(n=n, k=k, items=items)
         self.weight = weight
 
     @override
-    def measure_list(self, output: ItemList, test):
+    def measure_list(self, output: ItemList, test) -> tuple[NDArray[np.int32], NDArray[np.float64]]:
         recs = self.truncate(output)
-        weights = self.weight.weight(np.arange(1, len(recs) + 1))
-        return (recs.ids(format="arrow"), pa.array(weights, type=pa.float32()))
+        ids = recs.numbers(vocabulary=self.item_vocab)
+        weights = self.weight.weight(np.arange(1, len(recs) + 1, dtype=np.int32))
+        return (ids, weights)
 
-    @override
-    def summarize(self, values: list[tuple[pa.Array, pa.FloatArray]]):
-        log = _log.bind(metric=self.label, item_count=self.item_count)
-        log.debug("aggregating for %d lists", len(values))
-        table = pa.Table.from_batches(
-            pa.RecordBatch.from_arrays([iv, ev], ["item_id", "exposure"]) for (iv, ev) in values
-        )
-        exp_tbl = table.group_by("item_id").aggregate([("exposure", "sum")])
-        log.debug("found %d distinct items", exp_tbl.num_rows)
-        exp = np.zeros(self.item_count, np.float32)
-        exp[: exp_tbl.num_rows] = np.asarray(exp_tbl.column("exposure_sum"), dtype=np.float32)
-        return gini(exp)
+
+class GiniAccumulator:
+    n_items: int
+    totals: np.ndarray[tuple[int], np.dtype[np.float64]]
+
+    def __init__(self, n: int):
+        self.n_items = n
+        self.totals = np.zeros(n)
+
+    def add(self, value: tuple[NDArray[np.int32], NDArray[np.float32] | float]) -> None:
+        items, values = value
+        self.totals[items] += values
+
+    def accumulate(self) -> float:
+        dist = self.totals / self.totals.sum()
+        return gini(dist)

--- a/src/lenskit/metrics/ranking/_gini.py
+++ b/src/lenskit/metrics/ranking/_gini.py
@@ -46,6 +46,9 @@ class GiniBase(RankingMetricBase):
         else:
             self.item_vocab = items
 
+    def create_accumulator(self):
+        return GiniAccumulator(len(self.item_vocab))
+
 
 class ListGini(GiniBase):
     """

--- a/tests/data/test_value_accumulator.py
+++ b/tests/data/test_value_accumulator.py
@@ -1,6 +1,6 @@
 # This file is part of LensKit.
 # Copyright (C) 2018-2023 Boise State University.
-# Copyright (C) 2023-2025 Drexel University.
+# Copyright (C) 2023-2026 Drexel University.
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
@@ -8,7 +8,7 @@ import numpy as np
 
 import hypothesis.strategies as st
 from hypothesis import given
-from pytest import approx
+from pytest import approx, mark
 
 from lenskit.data.accum import ValueStatAccumulator
 
@@ -64,6 +64,7 @@ def test_collect_list_nan(xs):
     assert rv["std"] == approx(np.std(xs[finite]), nan_ok=True)
 
 
+@mark.skip("accumulator splitting not yet implemented")
 @given(st.lists(st.floats(allow_infinity=False)), st.lists(st.floats(allow_infinity=False)))
 def test_split_combine(xs, ys):
     acc = ValueStatAccumulator()

--- a/tests/data/test_value_accumulator.py
+++ b/tests/data/test_value_accumulator.py
@@ -1,0 +1,86 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2025 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+
+import hypothesis.strategies as st
+from hypothesis import given
+from pytest import approx
+
+from lenskit.data.accum import ValueStatAccumulator
+
+
+def test_collect_empty():
+    acc = ValueStatAccumulator()
+    rv = acc.accumulate()
+
+    assert rv["n"] == 0
+    assert np.isnan(rv["mean"])
+    assert np.isnan(rv["median"])
+    assert np.isnan(rv["std"])
+
+
+@given(st.floats(allow_infinity=False, allow_nan=False))
+def test_collect_one(x):
+    acc = ValueStatAccumulator()
+    acc.add(x)
+    rv = acc.accumulate()
+
+    assert rv["n"] == 1
+    assert rv["mean"] == x
+    assert rv["median"] == x
+    assert rv["std"] == approx(0.0)
+
+
+@given(st.lists(st.floats(allow_infinity=False, allow_nan=False), min_size=2))
+def test_collect_list(xs):
+    acc = ValueStatAccumulator()
+    for i, x in enumerate(xs):
+        assert len(acc) == i
+        acc.add(x)
+    rv = acc.accumulate()
+
+    assert rv["n"] == len(xs)
+    assert rv["mean"] == approx(np.mean(xs))
+    assert rv["median"] == approx(np.median(xs))
+    assert rv["std"] == approx(np.std(xs), nan_ok=True)
+
+
+@given(st.lists(st.floats(allow_infinity=False)))
+def test_collect_list_nan(xs):
+    acc = ValueStatAccumulator()
+    for x in xs:
+        acc.add(x)
+    rv = acc.accumulate()
+
+    xs = np.array(xs)
+    finite = np.isfinite(xs)
+    assert rv["n"] == np.sum(finite)
+    assert rv["mean"] == approx(np.mean(xs[finite]), nan_ok=True)
+    assert rv["median"] == approx(np.median(xs[finite]), nan_ok=True)
+    assert rv["std"] == approx(np.std(xs[finite]), nan_ok=True)
+
+
+@given(st.lists(st.floats(allow_infinity=False)), st.lists(st.floats(allow_infinity=False)))
+def test_split_combine(xs, ys):
+    acc = ValueStatAccumulator()
+    right = acc.split_accumulator()
+
+    for x in xs:
+        acc.add(x)
+
+    for y in ys:
+        right.add(y)
+
+    acc.combine(right)
+    rv = acc.accumulate()
+
+    xs = np.array(xs + ys)
+    finite = np.isfinite(xs)
+    assert rv["n"] == np.sum(finite)
+    assert rv["mean"] == approx(np.mean(xs[finite]), nan_ok=True)
+    assert rv["median"] == approx(np.median(xs[finite]), nan_ok=True)
+    assert rv["std"] == approx(np.std(xs[finite]), nan_ok=True)

--- a/tests/eval/test_bulk_metrics.py
+++ b/tests/eval/test_bulk_metrics.py
@@ -10,7 +10,6 @@ from pytest import approx, raises
 
 from lenskit.data import ItemListCollection
 from lenskit.data.adapt import ITEM_COMPAT_COLUMN, USER_COMPAT_COLUMN
-from lenskit.metrics._base import GlobalMetric
 from lenskit.metrics.basic import ListLength
 from lenskit.metrics.bulk import RunAnalysis
 from lenskit.metrics.predict import RMSE

--- a/tests/eval/test_bulk_metrics.py
+++ b/tests/eval/test_bulk_metrics.py
@@ -23,12 +23,6 @@ def test_bulk_measure_function(ml_ratings: pd.DataFrame):
     bms.add_metric(ListLength(), "length")
     bms.add_metric(RMSE)
 
-    class DummyGlobalMetric(GlobalMetric):
-        def measure_run(self, output, test):
-            return None
-
-    bms.add_metric(DummyGlobalMetric(), label="global_metric", default=123.0)
-
     data = ItemListCollection.from_df(
         ml_ratings.rename(columns={"rating": "score"}), USER_COMPAT_COLUMN, ITEM_COMPAT_COLUMN
     )
@@ -40,10 +34,6 @@ def test_bulk_measure_function(ml_ratings: pd.DataFrame):
     stats = metrics.list_summary()
     assert stats.loc["length", "mean"] == approx(ml_ratings["user_id"].value_counts().mean())
     assert stats.loc["RMSE", "mean"] == approx(0)
-
-    # check global fallback metric
-    global_metrics = metrics.global_metrics()
-    assert global_metrics["global_metric"] == 123.0
 
 
 def test_recs(demo_recs):
@@ -61,8 +51,8 @@ def test_recs(demo_recs):
     scores = metrics.list_metrics()
     stats = metrics.list_summary()
     print(stats)
-    for m in bms.metrics:
-        assert stats.loc[m.label, "mean"] == approx(scores[m.label].mean())
+    for m in bms.collector.metric_names:
+        assert stats.loc[m, "mean"] == approx(scores[m].mean())
 
 
 def test_duplicate_metric(demo_recs):
@@ -96,6 +86,6 @@ def test_recs_multi(demo_recs):
     scores = metrics.list_metrics()
     stats = metrics.list_summary("rep")
     print(stats)
-    for m in bms.metrics:
-        assert stats.loc[(1, m.label), "mean"] == approx(scores.loc[1, m.label].mean())
-        assert stats.loc[(2, m.label), "mean"] == approx(scores.loc[2, m.label].mean())
+    for m in bms.collector.metric_names:
+        assert stats.loc[(1, m), "mean"] == approx(scores.loc[1, m].mean())
+        assert stats.loc[(2, m), "mean"] == approx(scores.loc[2, m].mean())

--- a/tests/eval/test_measurement_collector.py
+++ b/tests/eval/test_measurement_collector.py
@@ -15,8 +15,8 @@ from pytest import approx, fixture, mark, raises
 from lenskit.basic import PopScorer
 from lenskit.data import ItemList, ItemListCollection
 from lenskit.metrics import NDCG, Recall
-from lenskit.metrics._base import GlobalMetric, ListMetric, Metric
-from lenskit.metrics._collect import MeasurementCollector, MetricWrapper
+from lenskit.metrics._base import FunctionMetric, GlobalMetric, ListMetric, Metric
+from lenskit.metrics._collect import MeasurementCollector, _wrap_metric
 from lenskit.metrics.basic import ListLength
 from lenskit.splitting import split_temporal_fraction
 
@@ -44,18 +44,12 @@ def sample_lists():
 def test_accumulator_empty_and_unmeasured_defaults():
     acc = MeasurementCollector()
     # initial state
-    assert acc.metrics == []
     assert acc.list_metrics().empty
     assert not acc.summary_metrics()
 
     # measuring with no metrics
     acc.measure_list(ItemList([1]), ItemList([1]), user="u1")
     assert acc.list_metrics().empty
-    assert not acc.summary_metrics()
-
-    # add metrics but do not measure
-    acc.add_metric(Recall(5))
-    acc.add_metric(NDCG(5))
     assert not acc.summary_metrics()
 
 
@@ -74,7 +68,7 @@ def test_accumulator_measures_list_and_summary(sample_lists):
 
     assert len(list_metrics) == 2
     assert set(list_metrics["N"]) == {2.0, 3.0}
-    assert approx(summary["N"]) == 2.5
+    assert approx(summary["N.mean"]) == 2.5
 
 
 def test_accumulator_empty_itemlists():
@@ -103,8 +97,7 @@ def test_list_metrics_no_key_fields():
 
 
 def test_wrap_metric_with_class():
-    acc = MeasurementCollector()
-    wrapper = acc._wrap_metric(ListLength, label="ListLength", default=None)
+    wrapper = _wrap_metric(ListLength, label="ListLength")
     assert isinstance(wrapper.metric, ListLength)
     assert wrapper.label == "ListLength"
 
@@ -113,9 +106,8 @@ def test_wrap_metric_function_label():
     def custom_metric(recs, test):
         return len(recs)
 
-    acc = MeasurementCollector()
-    wrapper = acc._wrap_metric(custom_metric, None, None)
-    assert wrapper.label == "function"
+    wrapper = _wrap_metric(custom_metric, None)
+    assert wrapper.label == "custom_metric"
 
 
 # key fields and duplicates
@@ -146,26 +138,25 @@ def test_accumulator_key_fields(keys, expected_names):
     [
         (ListLength(), ListLength),
         (ListLength, ListLength),
-        (lambda r, t: len(r), type(lambda: None)),
+        (lambda r, t: len(r), FunctionMetric),
     ],
 )
 def test_add_metric_types(metric_input, expected_type):
     acc = MeasurementCollector()
     acc.add_metric(metric_input)
-    assert isinstance(acc.metrics[0].metric, expected_type)
+    assert isinstance(acc._metrics[0].metric, expected_type)
 
 
-def test_custom_labels_and_defaults():
+def test_custom_labels():
     acc = MeasurementCollector()
     acc.add_metric(ListLength(), label="CustomLength")
-    assert acc.metrics[0].label == "CustomLength"
-    acc.add_metric(ListLength(), default=99.0)
-    assert acc.metrics[1].default == 99.0
+    assert acc._metrics[0].label == "CustomLength"
 
 
 # global, callable, scalar metrics
 
 
+@mark.skip("global metrics disabled")
 def test_global_metric():
     class DummyGlobalMetric(GlobalMetric):
         label = "dummy_global"
@@ -175,10 +166,10 @@ def test_global_metric():
 
     acc = MeasurementCollector()
     acc.add_metric(DummyGlobalMetric())
-    result = acc.metrics[0].measure_run(ItemListCollection([]), ItemListCollection([]))
+    result = acc._metrics[0].measure_run(ItemListCollection([]), ItemListCollection([]))
     assert result == 42.0
-    assert acc.metrics[0].is_global
-    assert not acc.metrics[0].is_listwise
+    # assert acc._metrics[0].is_global
+    # assert not acc._metrics[0].is_listwise
 
 
 def test_callable_metric():
@@ -189,105 +180,8 @@ def test_callable_metric():
     acc.add_metric(_callable, label="callable_metric")
     recs = ItemList([1, 2, 3])
     test_il = ItemList([1])
-    result = acc.metrics[0].measure_list(recs, test_il)
+    result = acc._metrics[0].metric.measure_list(recs, test_il)
     assert result == 3
-    wrapper = acc.metrics[0]
-    assert wrapper.is_listwise
-    assert not wrapper.is_global
-
-
-def test_scalar_metric():
-    class ScalarMetric(Metric):
-        label = "scalar"
-
-        def measure_list(self, recs, test):
-            return 5
-
-        def summarize(self, values):
-            return 99.0
-
-    acc = MeasurementCollector()
-    acc.add_metric(ScalarMetric())
-    acc.measure_list(ItemList([1]), ItemList([1]), user="u1")
-    summary = acc.summary_metrics()
-    assert summary["scalar"] == 99.0
-
-
-# metrics returning mixed
-
-
-def test_mixed_metric_behavior():
-    class MixedMetric(Metric):
-        label = "Mixed"
-
-        def __init__(self):
-            self.call_count = 0
-
-        def measure_list(self, recs, test):
-            self.call_count += 1
-            return 1.0 if self.call_count % 2 == 1 else {"b": 2.0}
-
-        def extract_list_metrics(self, data):
-            return data
-
-        def summarize(self, values):
-            numeric_vals = [v if isinstance(v, float) else v["b"] for v in values]
-            return {"mean": np.mean(numeric_vals)}
-
-    acc = MeasurementCollector()
-    acc.add_metric(MixedMetric())
-    acc.measure_list(ItemList([1]), ItemList([1]), user="u1")
-    acc.measure_list(ItemList([2]), ItemList([2]), user="u2")
-
-    df = acc.list_metrics()
-    summary = acc.summary_metrics()
-
-    assert "Mixed.mean" in summary
-    assert summary["Mixed.mean"] == 1.5
-    assert len(df) == 2
-
-
-def test_none_extract_metric():
-    class NoneExtractMetric(Metric):
-        label = "none_extract"
-
-        def measure_list(self, output, test):
-            return 4
-
-        def extract_list_metrics(self, data):
-            return None
-
-        def summarize(self, values):
-            return {"mean": sum(values) / len(values)}
-
-    acc = MeasurementCollector()
-    acc.add_metric(NoneExtractMetric())
-    acc.measure_list(ItemList([1]), ItemList([1]), user="u1")
-    df = acc.list_metrics()
-    assert pd.isna(df.loc["u1", "none_extract"])
-
-
-# metricWrapper properties and summarization
-
-
-def test_measure_metric_with_none_summarize():
-    """Test metric that returns None from summarize."""
-
-    class NoSummarizeMetric(Metric):
-        label = "no_summarize"
-
-        def measure_list(self, recs, test):
-            return 7.0
-
-        def summarize(self, values):
-            return None
-
-    acc = MeasurementCollector()
-    acc.add_metric(NoSummarizeMetric())
-    acc.measure_list(ItemList([1]), ItemList([1]), user="u1")
-
-    summary = acc.summary_metrics()
-    assert "no_summarize" not in summary
 
 
 # test with movielens data
@@ -319,45 +213,18 @@ def test_full_workflow_integration_improved(ml_ds):
     assert len(summary) > 0
     for key, value in summary.items():
         if value is not None:
-            if "std" in key.lower():
+            if key.endswith(".std") or key.endswith(".n"):
                 assert value >= 0
             else:
                 assert 0 <= value <= 1
 
 
-# test edge cases in Metric.summarize
-
-
-def test_list_metric_summarize_edge_cases():
-    class TestListMetric(ListMetric):
-        def measure_list(self, output, test):
-            return len(output)
-
-    metric = TestListMetric()
-
-    # with empty list
-    result = metric.summarize([])
-    assert result["mean"] is None
-    assert result["median"] is None
-    assert result["std"] is None
-
-    # with PyArrow array input
-    arr = pa.array([1.0, 2.0, 3.0])
-    result = metric.summarize(arr)
-    assert result["mean"] == 2.0
-    assert result["median"] == 2.0
-    assert result["std"] == 1.0
-
-
 def test_empty_intermediate_values():
-    class TestMetric(Metric):
+    class TestMetric(ListMetric):
         label = "test"
 
         def measure_list(self, recs, test):
             return None  # no intermediate data
-
-        def summarize(self, values):
-            return {"mean": 0.0}
 
     acc = MeasurementCollector()
     acc.add_metric(TestMetric())
@@ -375,19 +242,27 @@ def test_accumulator_duplicate_labels():
         acc._validate_setup()
 
 
-def test_accumulator_with_default_value_on_none_result():
-    class NoneMetric(Metric):
-        label = "none_metric"
+def test_some_lists_none():
+    class TestMetric(ListMetric):
+        label = "test"
 
         def measure_list(self, recs, test):
-            return None
-
-        def summarize(self, values):
-            return {"mean": 123}
+            if len(recs):
+                return len(recs)
+            else:
+                return None
 
     acc = MeasurementCollector()
-    acc.add_metric(NoneMetric(), default=99.0)
-    acc.measure_list(ItemList([1]), ItemList([1]), user="u1")
-    metrics = acc.list_metrics()
-    # none should fall back to default value
-    assert metrics.loc["u1", "none_metric"] == 99.0
+    acc.add_metric(TestMetric())
+
+    acc.measure_list(ItemList([3]), ItemList(), x=1)
+    acc.measure_list(ItemList([]), ItemList(), x=2)
+    acc.measure_list(ItemList([5, 20, 3]), ItemList(), x=3)
+
+    lms = acc.list_metrics()
+    assert lms.loc[1, "test"] == 1
+    assert pd.isna(lms.loc[2, "test"])
+    assert lms.loc[3, "test"] == 3
+
+    summary = acc.summary_metrics()
+    assert summary["test.mean"] == 2

--- a/tests/eval/test_measurement_collector.py
+++ b/tests/eval/test_measurement_collector.py
@@ -272,4 +272,4 @@ def test_reset():
     assert np.all(lms["N"] == 6)
     sms = acc.summary_metrics()
     assert sms["N.mean"] == approx(6.0)
-    assert sms["RecipRank.mean"] == approx(0.625)
+    assert sms["RecipRank.mean"] == approx(0.375)

--- a/tests/eval/test_measurement_collector.py
+++ b/tests/eval/test_measurement_collector.py
@@ -133,7 +133,7 @@ def test_accumulator_key_fields(keys, expected_names):
     acc = MeasurementCollector()
     acc.add_metric(ListLength())
     acc.measure_list(ItemList([1, 2]), ItemList([2]), **keys)
-    assert acc._key_fields == expected_names
+    assert acc.key_fields == expected_names
     metrics = acc.list_metrics()
     assert set(metrics.index.names) == set(expected_names)
 

--- a/tests/eval/test_measurement_collector.py
+++ b/tests/eval/test_measurement_collector.py
@@ -15,7 +15,7 @@ from pytest import approx, fixture, mark, raises
 from lenskit.basic import PopScorer
 from lenskit.data import ItemList, ItemListCollection
 from lenskit.metrics import NDCG, Recall
-from lenskit.metrics._base import FunctionMetric, GlobalMetric, ListMetric, Metric
+from lenskit.metrics._base import FunctionMetric, ListMetric, Metric
 from lenskit.metrics._collect import MeasurementCollector, _wrap_metric
 from lenskit.metrics.basic import ListLength
 from lenskit.splitting import split_temporal_fraction
@@ -151,25 +151,6 @@ def test_custom_labels():
     acc = MeasurementCollector()
     acc.add_metric(ListLength(), label="CustomLength")
     assert acc._metrics[0].label == "CustomLength"
-
-
-# global, callable, scalar metrics
-
-
-@mark.skip("global metrics disabled")
-def test_global_metric():
-    class DummyGlobalMetric(GlobalMetric):
-        label = "dummy_global"
-
-        def measure_run(self, run, test):
-            return 42.0
-
-    acc = MeasurementCollector()
-    acc.add_metric(DummyGlobalMetric())
-    result = acc._metrics[0].measure_run(ItemListCollection([]), ItemListCollection([]))
-    assert result == 42.0
-    # assert acc._metrics[0].is_global
-    # assert not acc._metrics[0].is_listwise
 
 
 def test_callable_metric():

--- a/tests/eval/test_measurement_collector.py
+++ b/tests/eval/test_measurement_collector.py
@@ -14,10 +14,9 @@ from pytest import approx, fixture, mark, raises
 
 from lenskit.basic import PopScorer
 from lenskit.data import ItemList, ItemListCollection
-from lenskit.metrics import NDCG, Recall
+from lenskit.metrics import NDCG, ListLength, Recall, RecipRank
 from lenskit.metrics._base import FunctionMetric, ListMetric, Metric
 from lenskit.metrics._collect import MeasurementCollector, _wrap_metric
-from lenskit.metrics.basic import ListLength
 from lenskit.splitting import split_temporal_fraction
 
 _log = logging.getLogger(__name__)
@@ -247,3 +246,30 @@ def test_some_lists_none():
 
     summary = acc.summary_metrics()
     assert summary["test.mean"] == 2
+
+
+def test_reset():
+    acc = MeasurementCollector()
+    acc.add_metric(ListLength())
+    acc.add_metric(RecipRank())
+
+    acc.measure_list(ItemList([1, 2, 3, 4, 5]), ItemList([4]))
+    acc.measure_list(ItemList([5, 4, 3, 2, 1]), ItemList([1]))
+
+    lms = acc.list_metrics()
+    assert len(lms) == 2
+    assert np.all(lms["N"] == 5)
+    sms = acc.summary_metrics()
+    assert sms["N.mean"] == approx(5.0)
+    assert sms["RecipRank.mean"] == approx(0.225)
+
+    acc.reset()
+    acc.measure_list(ItemList([1, 2, 3, 4, 5, 10]), ItemList([2]))
+    acc.measure_list(ItemList([5, 4, 3, 2, 1, 10]), ItemList([2]))
+
+    lms = acc.list_metrics()
+    assert len(lms) == 2
+    assert np.all(lms["N"] == 6)
+    sms = acc.summary_metrics()
+    assert sms["N.mean"] == approx(6.0)
+    assert sms["RecipRank.mean"] == approx(0.625)

--- a/tests/eval/test_predict_metrics.py
+++ b/tests/eval/test_predict_metrics.py
@@ -143,5 +143,5 @@ def test_batch_rmse(ml_100k):
     assert mdf.loc["MAE", "mean"] == approx(0.76, abs=0.05)
 
     # we should have global metrics
-    assert gs["RMSE"] == approx(0.93, abs=0.05)
-    assert gs["MAE"] == approx(0.76, abs=0.05)
+    assert gs["RMSE.global"] == approx(0.93, abs=0.05)
+    assert gs["MAE.global"] == approx(0.76, abs=0.05)


### PR DESCRIPTION
This overhauls the metric interface and the metric collection code to use explicit accumulator objects, so different metrics can have different accumulation behavior, and allowing things like Gini to be computed with less memory consumption.

It also simplifies and deprecates `RunAnalysis` in favor of directly using `MeasurementCollector`.

Several of the old `MeasurementCollector` tests are removed because the measurement collector is responsible for much less logic now.

Closes #866, #968.