### PR TITLE
Expose default nodes from pipelines and builders

### DIFF
--- a/src/lenskit/pipeline/_builder.py
+++ b/src/lenskit/pipeline/_builder.py
@@ -179,6 +179,14 @@ class PipelineBuilder:
         else:
             raise KeyError(f"node {node}")
 
+    @property
+    def default_node(self) -> Node[Any] | None:
+        "Get the default node for this pipeline."
+        if self._default is None:
+            return None
+        else:
+            return self.node(self._default)
+
     def create_input[T](self, name: str, *types: type[T] | UnionType | None) -> Node[T]:
         """
         Create an input node for the pipeline.  Pipelines expect their inputs to

--- a/src/lenskit/pipeline/_impl.py
+++ b/src/lenskit/pipeline/_impl.py
@@ -183,6 +183,11 @@ class Pipeline:
         else:
             raise KeyError(node)
 
+    @property
+    def default_node(self) -> Node[Any] | None:
+        "Get the default node for this pipeline."
+        return self._default
+
     def component_names(self) -> list[str]:
         """
         Get the component names (in topological order).

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -256,6 +256,10 @@ def test_chain_component_names():
     pipe = pipe.build()
     assert pipe.component_names() == ["incr", "triple"]
 
+    dn = pipe.default_node
+    assert dn is not None
+    assert dn.name == "triple"
+
 
 def test_simple_graph():
     pipe = PipelineBuilder()


### PR DESCRIPTION
This adds a `default_node` property to both pipelines and builders, improving inspectability.

Closes #973, closes #972.