### PR TITLE
Clarify batch inference interfaces with more explicit and limited types

### DIFF
--- a/docs/_ext/lk_stability.py
+++ b/docs/_ext/lk_stability.py
@@ -81,7 +81,7 @@ def scan_stability_notes(app, domain, objtype, contentnode):
                                 "stability-levels",
                                 classes=["xref", "std", "std-ref"],
                             ),
-                            refdoc="api/operations",
+                            # refdoc="releases/index",
                             refdomain="std",
                             reftype="ref",
                             reftarget="stability-levels",

--- a/docs/guide/batch.rst
+++ b/docs/guide/batch.rst
@@ -15,12 +15,6 @@ By default, the batch facilities operate in parallel over the test users; this
 can be controlled by environment variables (see :ref:`parallel-config`) or
 through an ``n_jobs`` keyword argument to the various functions and classes.
 
-.. admonition:: Import Protection
-    :class: important
-
-    Scripts using batch pipeline operations must be *protected*; see
-    :ref:`parallel-protecting`.
-
 Simple Runs
 ~~~~~~~~~~~
 
@@ -80,36 +74,28 @@ wrappers around a more general facility, the :py:class:`BatchPipelineRunner`.
 Batch Queries
 ~~~~~~~~~~~~~
 
-.. py:currentmodule:: lenskit.data
-
 The batch inference functions and methods (:func:`~lenskit.batch.recommend`,
-:meth:`~lenskit.batch.BatchPipelineRunner.run`, etc.) accept multiple types of
-input to specify the set of users or test items.
+:meth:`~lenskit.batch.BatchPipelineRunner.run`, etc.) batch recommendation
+requests in the following formats:
 
-* An iterable (e.g. list) of recommendation queries (as :class:`RecQuery`
-  objects).  The queries must have at least one of :attr:`RecQuery.query_id` and
-  :attr:`RecQuery.user_id` set, so that the output can be properly indexed.
-  Queries should all have the identification method (i.e., all queries have a
-  ``query_id``, or all queries have only a ``user_id``).
+* An iterable of identifiers, which are taken to be user IDs and used as both the
+  :attr:`~lenskit.data.RecQuery.user_id` and the
+  :attr:`~lenskit.data.RecQuery.query_id` to make otherwise-empty
+  :attr:`queries <lenskit.data.RecQuery>`.
 
-* An iterable of 2-element ``(query, items)`` tuples.  The query is a
-  :class:`RecQuery` as in the previous method, and the items is an :class:`ItemList`
-  containing the candidate items (for recommendation) or the items to score (for
-  prediction and scoring).  This is the most general form of input.
+* An iterable of :attr:`~lenskit.data.RecQuery` objects, specifying the
+  recommendation queries.
 
-* An iterable (e.g. list) of user IDs.  These are passed as
-  :attr:`RecQuery.user_id`, and the resulting outputs are mapped to  ID.
+* An iterable of dictionaries, each of which conforms to
+  :class:`~lenskit.batch.BatchRecRequest`.
 
-* An :class:`ItemListCollection`.  At least one field of the collection key
-  should be ``user_id``, and these user IDs are used as the query user IDs. The
-  item lists themselves are used as in the tuple method above. Results are
-  indexed by the entire key.
+* An :class:`~lenskit.data.ItemListCollection`, which is translated to a
+  collection of recommendation requests with :class:`TestRequestAdapter`.  This
+  translation extracts user and query IDs from the item list keys, and uses the
+  item lists themselves as test items for rating prediction (and uses default
+  candidate sets for recommendation).
 
-* A mapping (dictionary) of IDs to item lists.  This behaves like the item
-  list collection; the IDs are taken to be user IDs.
+.. versionchanged:: 2026.1
 
-* A :class:`pandas.DataFrame`, which is converted to an item list collection.
-
-.. deprecated:: 2025.6
-
-    Mappings and data frames are deprecated in favor of other input types.
+    Restricted the batch inputs to the types above, in order to make input
+    clearer and more explicit.

--- a/docs/guide/queries.rst
+++ b/docs/guide/queries.rst
@@ -14,7 +14,7 @@ Queries are represented by the :class:`.RecQuery` class, and can have any or all
 of the following components:
 
 - A user ID (:attr:`RecQuery.user_id`)
-- A user's historical items (:attr:`RecQuery.user_items`)
+- A user's historical items (:attr:`RecQuery.history_items`)
 
 .. admonition:: Future Work
     :class: note

--- a/docs/releases/2025.rst
+++ b/docs/releases/2025.rst
@@ -88,8 +88,8 @@ Deprecations
 - ``AllTrainingItemsCandidateSelector`` is deprecated in favor of
   :class:`~lenskit.basic.TrainingItemCandidateSelector` with suitable
   configuration.
-- :attr:`lenskit.data.RecQuery.user_items` is deprecated in favor of
-  :class:`~lenskit.data.RecQuery.history_items`.
+- ``RecQuery.user_items`` is deprecated in favor of
+  :attr:`~lenskit.data.RecQuery.history_items`.
 - Removed fixed defaults for ``row_entity`` and ``col_entity`` on
   :meth:`~lenskit.dataset.RelationshipSet.matrix`, now defaulting to the first
   and last entities involved in the relationship.  This does not change anything

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -76,6 +76,8 @@ Breaking Changes
   (:issue:`835`).
 - Removed the deprecated unrated and all-items candidate selectors, in favor of
   :class:`~lenskit.basic.TrainingItemsCandidateSelector` (:issue:`935`).
+- Several input types to batch inference are no longer supported, to reduce
+  ambiguity and implicit behavior (:issue:`958`, :pr:`1074`).
 
 .. _prefix.dev: https://prefix.dev/channels/lenskit/
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -113,7 +113,7 @@ mid-stream unless absolutely necessary and clearly-communicated.
 
 As of 2026, these versions are:
 
-*   Python 3.11
+*   Python 3.12
 *   Pandas 2.3
 *   NumPy 2.0
 *   SciPy 1.13.0

--- a/src/lenskit/basic/bias.py
+++ b/src/lenskit/basic/bias.py
@@ -338,7 +338,7 @@ class BiasScorer(Component[ItemList], Trainable):
             query:
                 The recommendation query.  If the query has an item list with
                 ratings, those ratings are used to compute a new bias instead of
-                using the user's recorded bias.
+                using the user's historical bias.
             items:
                 The items to score.
         Returns:
@@ -346,7 +346,7 @@ class BiasScorer(Component[ItemList], Trainable):
         """
         query = RecQuery.create(query)
 
-        scores, _bias = self.model.compute_for_items(items, query.user_id, query.user_items)
+        scores, _bias = self.model.compute_for_items(items, query.user_id, query.query_items)
         return ItemList(items, scores=scores)
 
 

--- a/src/lenskit/basic/history.py
+++ b/src/lenskit/basic/history.py
@@ -87,7 +87,6 @@ class UserTrainingHistoryLookup(Component[ItemList], Trainable):
         if query.history_items is None:
             trace(log, "looking up user history")
             query.history_items = self.interactions.row_items(query.user_id)
-            query.user_items = query.history_items
             if query.history_items is not None:
                 log.debug("fetched %d history items", len(query.history_items))
             else:
@@ -138,8 +137,8 @@ class KnownRatingScorer(Component[ItemList], Trainable):
 
         # figure out what scores we start with
         ilist = None
-        if self.config.source == "query" and query.user_items is not None:
-            ilist = query.user_items
+        if self.config.source == "query" and query.query_items is not None:
+            ilist = query.query_items
 
         elif (
             self.config.source == "training"

--- a/src/lenskit/batch/__init__.py
+++ b/src/lenskit/batch/__init__.py
@@ -18,10 +18,19 @@ import pandas as pd
 from lenskit.data import ID, GenericKey, ItemList, ItemListCollection, RecQuery, UserIDKey
 from lenskit.pipeline import Pipeline, PipelineProfiler
 
+from ._queries import BatchRecRequest, TestRequestAdapter
 from ._results import BatchResults
 from ._runner import BatchPipelineRunner, InvocationSpec
 
-__all__ = ["BatchPipelineRunner", "BatchResults", "InvocationSpec", "predict", "recommend"]
+__all__ = [
+    "BatchPipelineRunner",
+    "BatchResults",
+    "BatchRecRequest",
+    "TestRequestAdapter",
+    "InvocationSpec",
+    "predict",
+    "recommend",
+]
 
 
 def predict(

--- a/src/lenskit/batch/__init__.py
+++ b/src/lenskit/batch/__init__.py
@@ -10,12 +10,9 @@ Batch-run recommendation pipelines for evaluation.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Mapping
+from typing import overload
 
-import pandas as pd
-
-from lenskit.data import ID, GenericKey, ItemList, ItemListCollection, RecQuery, UserIDKey
+from lenskit.data import GenericKey, ItemListCollection
 from lenskit.pipeline import Pipeline, PipelineProfiler
 
 from ._queries import BatchInput, BatchRecRequest, TestRequestAdapter
@@ -34,9 +31,25 @@ __all__ = [
 ]
 
 
+@overload
+def predict[K: GenericKey](
+    pipeline: Pipeline,
+    test: ItemListCollection[K],
+    *,
+    n_jobs: int | None = None,
+    use_ray: bool | None = None,
+) -> ItemListCollection[K]: ...
+@overload
 def predict(
     pipeline: Pipeline,
-    test: ItemListCollection[GenericKey] | Mapping[ID, ItemList] | pd.DataFrame,
+    test: BatchInput,
+    *,
+    n_jobs: int | None = None,
+    use_ray: bool | None = None,
+) -> ItemListCollection[GenericKey]: ...
+def predict(
+    pipeline: Pipeline,
+    test: BatchInput,
     *,
     n_jobs: int | None = None,
     use_ray: bool | None = None,
@@ -62,12 +75,25 @@ def predict(
     return outs.output("predictions")  # type: ignore
 
 
+@overload
+def score[K: GenericKey](
+    pipeline: Pipeline,
+    test: ItemListCollection[K],
+    *,
+    n_jobs: int | None = None,
+    use_ray: bool | None = None,
+) -> ItemListCollection[K]: ...
+@overload
 def score(
     pipeline: Pipeline,
-    test: Iterable[tuple[RecQuery, ItemList]]
-    | ItemListCollection[GenericKey]
-    | Mapping[ID, ItemList]
-    | pd.DataFrame,
+    test: BatchInput,
+    *,
+    n_jobs: int | None = None,
+    use_ray: bool | None = None,
+) -> ItemListCollection[GenericKey]: ...
+def score(
+    pipeline: Pipeline,
+    test: BatchInput,
     *,
     n_jobs: int | None = None,
     use_ray: bool | None = None,
@@ -92,21 +118,38 @@ def score(
     return outs.output("scores")  # type: ignore
 
 
-def recommend(
+@overload
+def recommend[K: GenericKey](
     pipeline: Pipeline,
-    queries: Iterable[RecQuery]
-    | Iterable[tuple[RecQuery, ItemList]]
-    | Iterable[ID | GenericKey]
-    | ItemListCollection[GenericKey]
-    | Mapping[ID, ItemList]
-    | pd.DataFrame,
+    queries: ItemListCollection[K],
     n: int | None = None,
     *,
     n_jobs: int | None = None,
     use_ray: bool | None = None,
     profiler: PipelineProfiler | None = None,
     users=None,
-) -> ItemListCollection[UserIDKey]:
+) -> ItemListCollection[K]: ...
+@overload
+def recommend(
+    pipeline: Pipeline,
+    queries: BatchInput,
+    n: int | None = None,
+    *,
+    n_jobs: int | None = None,
+    use_ray: bool | None = None,
+    profiler: PipelineProfiler | None = None,
+    users=None,
+) -> ItemListCollection[GenericKey]: ...
+def recommend(
+    pipeline: Pipeline,
+    queries: BatchInput,
+    n: int | None = None,
+    *,
+    n_jobs: int | None = None,
+    use_ray: bool | None = None,
+    profiler: PipelineProfiler | None = None,
+    users=None,
+) -> ItemListCollection[GenericKey]:
     """
     Convenience function to batch-generate recommendations from a pipeline. This
     is a batch version of :func:`lenskit.recommend`, and is a convenience

--- a/src/lenskit/batch/__init__.py
+++ b/src/lenskit/batch/__init__.py
@@ -18,7 +18,7 @@ import pandas as pd
 from lenskit.data import ID, GenericKey, ItemList, ItemListCollection, RecQuery, UserIDKey
 from lenskit.pipeline import Pipeline, PipelineProfiler
 
-from ._queries import BatchRecRequest, TestRequestAdapter
+from ._queries import BatchInput, BatchRecRequest, TestRequestAdapter
 from ._results import BatchResults
 from ._runner import BatchPipelineRunner, InvocationSpec
 
@@ -26,6 +26,7 @@ __all__ = [
     "BatchPipelineRunner",
     "BatchResults",
     "BatchRecRequest",
+    "BatchInput",
     "TestRequestAdapter",
     "InvocationSpec",
     "predict",

--- a/src/lenskit/batch/_queries.py
+++ b/src/lenskit/batch/_queries.py
@@ -11,6 +11,8 @@ from collections.abc import Iterable, Iterator, Mapping, Sized
 from dataclasses import dataclass
 from typing import Literal, TypedDict
 
+import pandas as pd
+
 from lenskit.data import (
     ID,
     GenericKey,
@@ -170,6 +172,10 @@ def normalize_query_input(
     if isinstance(queries, ItemListCollection):
         kt = queries.key_type
         queries = TestRequestAdapter(queries)
+    elif isinstance(queries, Mapping):
+        raise TypeError("mappings are no longer a supported batch input")
+    elif isinstance(queries, pd.DataFrame):
+        raise TypeError("data frames are no longer a supported batch input")
 
     n = None
     if isinstance(queries, Sized):

--- a/src/lenskit/batch/_queries.py
+++ b/src/lenskit/batch/_queries.py
@@ -6,7 +6,7 @@
 
 import warnings
 from collections.abc import Iterable, Iterator, Mapping, Sized
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple, TypedDict
 
 import pandas as pd
 
@@ -18,7 +18,34 @@ from lenskit.data import (
     QueryIDKey,
     RecQuery,
     UserIDKey,
+    key_dict,
 )
+from lenskit.diagnostics import DataWarning
+
+
+class BatchRecRequest(TypedDict, total=False):
+    """
+    Full recommendation request for evaluation, including candidate items.
+    """
+
+    query: RecQuery
+    "Recommendation query."
+    user_id: ID
+    "User ID (ignored if :attr:`query` is specified)."
+    query_id: ID
+    "Query ID (ignored if :attr:`query` is specified, defaults to user ID)."
+    items: ItemList
+    "The items to score or possibly recommend."
+    candidates: ItemList
+    """
+    Candidate items for the recommendations.  Overrides :attr:`items` for
+    top-*N* recommendation.
+    """
+    test_items: ItemList
+    """
+    Test items for the recommendation query.  Overrides :attr:`items` for
+    scoring or rating prediction.
+    """
 
 
 class BatchRequest(NamedTuple):
@@ -28,6 +55,83 @@ class BatchRequest(NamedTuple):
 
     query: RecQuery
     items: ItemList | None = None
+
+
+class TestRequestAdapter(Iterable[BatchRecRequest], Sized):
+    """
+    Wrapper for an item list collection that interprets it as a collection of
+    test requests.  Iterating over this collection will yield the requests in
+    the same order they are in the underlying item list collection.
+
+    The ``user_id`` and ``query_id`` key fields, if present are used to
+    construct the recommendation queries.  The item lists themselves are
+    interpreted as  directed by the ``items_as`` option:
+
+    ``test``
+        Items are used as test items (e.g., the items for which to predict
+        ratings), but **not** candidates.
+
+    ``candidates``
+        Items are used as candidate lists.
+
+    ``both``
+        Items are used as both test items and candidates.
+
+    ``None``
+        Items are excluded.
+
+    .. seealso::
+
+        :ref:`batch-queries`, :class:`~lenskit.batch.BatchRecRequest`
+
+    Args:
+        lists:
+            The item list collection.
+        items_as:
+            Where to put the item lists in the request.
+    Warns:
+        DataWarning:
+            If the item list collection cannot be used to construct usable
+            requests.
+    """
+
+    lists: ItemListCollection
+    item_use: Literal["test", "candidates", "both"] | None
+
+    def __init__(
+        self,
+        lists: ItemListCollection,
+        *,
+        items_as: Literal["test", "candidates", "both"] | None = "test",
+    ):
+        if "user_id" not in lists.key_fields:
+            warnings.warn(
+                "user_id is not in test data keys, requests unlikely to be usable",
+                DataWarning,
+                stacklevel=2,
+            )
+        self.lists = lists
+        self.item_use = items_as
+
+    def __len__(self):
+        return len(self.lists)
+
+    def __iter__(self) -> Iterator[BatchRecRequest]:
+        for key, items in self.lists.items():
+            kd = key_dict(key)
+            req: BatchRecRequest = {}
+            if uid := kd.get("user_id"):
+                req["query_id"] = req["user_id"] = uid
+            if qid := kd.get("query_id"):
+                req["query_id"] = qid
+            match self.item_use:
+                case "test":
+                    req["test_items"] = items
+                case "candidates":
+                    req["candidates"] = items
+                case "both":
+                    req["items"] = items
+            yield req
 
 
 def normalize_query_input(

--- a/src/lenskit/batch/_queries.py
+++ b/src/lenskit/batch/_queries.py
@@ -4,11 +4,12 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import warnings
 from collections.abc import Iterable, Iterator, Mapping, Sized
-from typing import Any, Literal, NamedTuple, TypedDict
-
-import pandas as pd
+from dataclasses import dataclass
+from typing import Literal, TypedDict
 
 from lenskit.data import (
     ID,
@@ -22,20 +23,36 @@ from lenskit.data import (
 )
 from lenskit.diagnostics import DataWarning
 
+type BatchInput = (
+    Iterable[BatchRecRequest]
+    | Iterable[RecQuery]
+    | Iterable[ID | GenericKey]
+    | ItemListCollection[GenericKey]
+)
+"""
+Allowed input types for batch inference routines.
+"""
+
 
 class BatchRecRequest(TypedDict, total=False):
     """
-    Full recommendation request for evaluation, including candidate items.
+    Full recommendation request for batch inference, including candidate items.
+
+    Stability:
+        Full
     """
 
     query: RecQuery
     "Recommendation query."
     user_id: ID
     "User ID (ignored if :attr:`query` is specified)."
-    query_id: ID
+    query_id: ID | GenericKey
     "Query ID (ignored if :attr:`query` is specified, defaults to user ID)."
     items: ItemList
-    "The items to score or possibly recommend."
+    """
+    The items to score or possibly recommend. It is usually better to supply
+    :attr:`candidates` and/or :attr:`test_items`.
+    """
     candidates: ItemList
     """
     Candidate items for the recommendations.  Overrides :attr:`items` for
@@ -48,13 +65,19 @@ class BatchRecRequest(TypedDict, total=False):
     """
 
 
-class BatchRequest(NamedTuple):
+@dataclass
+class ResolvedBatchRequest:
     """
-    A single request for the batch inference runner.
+    A single request for the batch inference runner, with fully-resolved
+    defaults.
+
+    Stability:
+        Internal
     """
 
     query: RecQuery
-    items: ItemList | None = None
+    test_items: ItemList | None = None
+    candidates: ItemList | None = None
 
 
 class TestRequestAdapter(Iterable[BatchRecRequest], Sized):
@@ -64,7 +87,8 @@ class TestRequestAdapter(Iterable[BatchRecRequest], Sized):
     the same order they are in the underlying item list collection.
 
     The ``user_id`` and ``query_id`` key fields, if present are used to
-    construct the recommendation queries.  The item lists themselves are
+    construct the recommendation queries.  If there is no ``query_id`` field,
+    then the entire key is used as a query ID.  The item lists themselves are
     interpreted as  directed by the ``items_as`` option:
 
     ``test``
@@ -93,6 +117,8 @@ class TestRequestAdapter(Iterable[BatchRecRequest], Sized):
         DataWarning:
             If the item list collection cannot be used to construct usable
             requests.
+    Stability:
+        Caller
     """
 
     lists: ItemListCollection
@@ -121,9 +147,11 @@ class TestRequestAdapter(Iterable[BatchRecRequest], Sized):
             kd = key_dict(key)
             req: BatchRecRequest = {}
             if uid := kd.get("user_id"):
-                req["query_id"] = req["user_id"] = uid
+                req["user_id"] = uid
             if qid := kd.get("query_id"):
                 req["query_id"] = qid
+            else:
+                req["query_id"] = key
             match self.item_use:
                 case "test":
                     req["test_items"] = items
@@ -135,31 +163,13 @@ class TestRequestAdapter(Iterable[BatchRecRequest], Sized):
 
 
 def normalize_query_input(
-    queries: Iterable[RecQuery]
-    | Iterable[tuple[RecQuery, ItemList]]
-    | Iterable[ID | GenericKey]
-    | ItemListCollection[GenericKey]
-    | Mapping[ID, ItemList]
-    | pd.DataFrame,
-) -> tuple[type[Any], Iterable[BatchRequest], int | None]:
-    if isinstance(queries, pd.DataFrame):
-        warnings.warn(
-            "use an item list collection instead of a DataFrame (LKW-BATCHIN)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        queries = ItemListCollection.from_df(queries)
-
-    elif isinstance(queries, Mapping):
-        warnings.warn(
-            "query mappings are ambiguous and deprecated, use query lists (LKW-BATCHIN)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        queries = ItemListCollection.from_dict(queries, "user_id")  # type: ignore
+    queries: BatchInput,
+) -> tuple[type[GenericKey], Iterable[ResolvedBatchRequest], int | None]:
+    kt = None
 
     if isinstance(queries, ItemListCollection):
-        return queries.key_type, _ilc_queries(queries), len(queries)
+        kt = queries.key_type
+        queries = TestRequestAdapter(queries)
 
     n = None
     if isinstance(queries, Sized):
@@ -171,10 +181,12 @@ def normalize_query_input(
     except StopIteration:
         return tuple, [], 0
 
-    fbr = _make_br(q_first)
-    if fbr.query.query_id is not None:
+    q_first = _resolve_batch_request(q_first)
+    if isinstance(q_first.query.query_id, tuple):
+        kt = type(q_first.query.query_id)
+    elif q_first.query.query_id is not None:
         kt = QueryIDKey
-    elif fbr.query.user_id is not None:
+    elif q_first.query.user_id is not None:
         kt = UserIDKey
     else:
         raise ValueError("query must have one of query_id, user_id")
@@ -182,43 +194,37 @@ def normalize_query_input(
     return kt, _iter_queries(q_first, q_iter), n
 
 
-def _ilc_queries(queries: ItemListCollection):
-    for q, items in queries.items():
-        query = RecQuery(
-            user_id=getattr(q, "user_id", None),
-            query_id=getattr(q, "query_id", None),
-        )
-        yield BatchRequest(query, items)
-
-
 def _iter_queries(
-    first: RecQuery | tuple[RecQuery, ItemList] | ID | GenericKey,
-    rest: Iterator[RecQuery | tuple[RecQuery, ItemList] | ID | GenericKey],
-) -> Iterable[BatchRequest]:
-    yield _make_br(first)
+    first: ResolvedBatchRequest,
+    rest: Iterable[BatchRecRequest] | Iterable[RecQuery] | Iterable[ID | GenericKey],
+) -> Iterable[ResolvedBatchRequest]:
+    yield first
     for item in rest:
-        yield _make_br(item)
+        yield _resolve_batch_request(item)
 
 
-def _make_br(q: RecQuery | tuple[RecQuery, ItemList] | ID | GenericKey) -> BatchRequest:
+def _resolve_batch_request(q: RecQuery | ID | GenericKey | BatchRecRequest) -> ResolvedBatchRequest:
     if isinstance(q, RecQuery):
-        return BatchRequest(q)
+        return ResolvedBatchRequest(query=q)
     elif isinstance(q, tuple):
-        if isinstance(q[0], RecQuery):
-            q, items = q
-            return BatchRequest(q, items)  # type: ignore
-        elif hasattr(q, "user_id"):
-            # we have a named tuple with user IDs
-            q = RecQuery(user_id=getattr(q, "user_id"))
-            return BatchRequest(q)
-        else:
-            warnings.warn(
-                "bare tuples are ambiguous and will be unsupported in 2026 (LKW-BATCHIN)",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            q = RecQuery(user_id=q)  # type: ignore
-            return BatchRequest(q)
+        user_id = getattr(q, "user_id", None)
+        query_id = getattr(q, "query_id", q)
+        return ResolvedBatchRequest(RecQuery(user_id=user_id, query_id=query_id))
+    elif isinstance(q, Mapping):
+        query = q.get("query", None)
+        if query is None:
+            query = RecQuery(user_id=q.get("user_id"), query_id=q.get("query_id"))
+
+        rq = ResolvedBatchRequest(query=query)
+        if (items := q.get("candidates")) is not None:
+            rq.candidates = items
+        if (items := q.get("test_items")) is not None:
+            rq.test_items = items
+        if (items := q.get("items")) is not None:
+            if rq.candidates is None:
+                rq.candidates = items
+            if rq.test_items is None:
+                rq.test_items = items
+        return rq
     else:
-        q = RecQuery(user_id=q)
-        return BatchRequest(q)
+        return ResolvedBatchRequest(RecQuery(user_id=q))

--- a/src/lenskit/batch/_ray.py
+++ b/src/lenskit/batch/_ray.py
@@ -18,7 +18,7 @@ from lenskit.parallel import get_parallel_config
 from lenskit.parallel.ray import TaskLimiter, ensure_cluster
 from lenskit.pipeline import Pipeline, ProfileSink
 
-from ._queries import BatchRequest
+from ._queries import ResolvedBatchRequest
 from ._results import BatchResultRow
 from ._runner import InvocationSpec, run_pipeline
 
@@ -29,7 +29,7 @@ def ray_results(
     pipeline: Pipeline,
     profiler: ProfileSink | None,
     invocations: list[InvocationSpec],
-    queries: Iterable[BatchRequest],
+    queries: Iterable[ResolvedBatchRequest],
     n_jobs: int,
     batch_size: int,
 ) -> Generator[BatchResultRow]:
@@ -58,6 +58,6 @@ def _run_batch(
     pipeline: Pipeline,
     invocations: list[InvocationSpec],
     profiler: ProfileSink | None,
-    requests: Sequence[BatchRequest],
+    requests: Sequence[ResolvedBatchRequest],
 ) -> list[BatchResultRow]:
     return [run_pipeline(pipeline, invocations, profiler, req) for req in requests]

--- a/src/lenskit/batch/_results.py
+++ b/src/lenskit/batch/_results.py
@@ -11,6 +11,9 @@ from typing import Sequence
 from lenskit.data import GenericKey, ItemListCollection
 
 type BatchResultRow = tuple[GenericKey, dict[str, object]]
+"""
+Results for a single query in the batch recommendations.
+"""
 
 
 class BatchResults:

--- a/src/lenskit/batch/_runner.py
+++ b/src/lenskit/batch/_runner.py
@@ -30,14 +30,14 @@ from lenskit.logging import Stopwatch, get_logger, item_progress
 from lenskit.parallel import get_parallel_config, is_free_threaded
 from lenskit.pipeline import Pipeline, PipelineProfiler, ProfileSink
 
-from ._queries import BatchRequest, normalize_query_input
+from ._queries import ResolvedBatchRequest, normalize_query_input
 from ._results import BatchResultRow, BatchResults
 
 _log = get_logger(__name__)
 
-ItemSource: TypeAlias = None | Literal["test-items"]
+ItemSource: TypeAlias = None | Literal["test-items", "candidates"]
 """
-Types of items that can be returned.
+Source for the ``items`` input to the recommendation pipeline.
 """
 
 
@@ -51,9 +51,15 @@ class InvocationSpec:
     name: str
     "A name for this invocation."
     components: dict[str, str]
-    "The names of pipeline components to measure and return, mapped to their output names."
+    """
+    The names of pipeline components to measure and return, mapped to their
+    output names.
+    """
     items: ItemSource = None
-    "The target or candidate items (if any) to provide to the recommender."
+    """
+    The target or candidate items (if any) to provide to the recommender (as the
+    ``items`` input).
+    """
     extra_inputs: dict[str, Any] = field(default_factory=dict)
     "Additional inputs to pass to the pipeline."
 
@@ -253,7 +259,10 @@ class BatchPipelineRunner:
         return results
 
     def _run_results(
-        self, pipeline: Pipeline, profiler: ProfileSink | None, queries: Iterable[BatchRequest]
+        self,
+        pipeline: Pipeline,
+        profiler: ProfileSink | None,
+        queries: Iterable[ResolvedBatchRequest],
     ) -> Generator[BatchResultRow]:
         if self.use_ray:
             from ._ray import ray_results
@@ -277,7 +286,7 @@ class BatchPipelineRunner:
         self,
         pipeline: Pipeline,
         profiler: ProfileSink | None,
-        queries: Iterable[BatchRequest],
+        queries: Iterable[ResolvedBatchRequest],
     ) -> Generator[BatchResultRow]:
         for query in queries:
             yield run_pipeline(pipeline, self.invocations, profiler, query)
@@ -286,7 +295,7 @@ class BatchPipelineRunner:
         self,
         pipeline: Pipeline,
         profiler: ProfileSink | None,
-        queries: Iterable[BatchRequest],
+        queries: Iterable[ResolvedBatchRequest],
     ) -> Generator[BatchResultRow]:
         assert isinstance(self.n_jobs, int)
         func = partial(run_pipeline, pipeline, self.invocations, profiler)
@@ -305,13 +314,14 @@ def run_pipeline(
     pipeline: Pipeline,
     invocations: list[InvocationSpec],
     profiler: ProfileSink | None,
-    req: BatchRequest,
+    req: ResolvedBatchRequest,
 ) -> BatchResultRow:
-    query, test_items = req
-    if query.query_id is not None:
-        key = QueryIDKey(query.query_id)
-    elif query.user_id is not None:
-        key = UserIDKey(query.user_id)
+    if isinstance(req.query.query_id, tuple):
+        key = req.query.query_id
+    elif req.query.query_id is not None:
+        key = QueryIDKey(req.query.query_id)
+    elif req.query.user_id is not None:
+        key = UserIDKey(req.query.user_id)
     else:
         raise RuntimeError("query must have one of query_id, user_id")
 
@@ -319,10 +329,12 @@ def run_pipeline(
 
     _log.debug("running pipeline", name=pipeline.name, key=key)
     for inv in invocations:
-        inputs: dict[str, Any] = {"query": query}
+        inputs: dict[str, Any] = {"query": req.query}
         match inv.items:
-            case "test-items" if test_items is not None:
-                inputs["items"] = test_items
+            case "test-items" if req.test_items is not None:
+                inputs["items"] = req.test_items
+            case "candidates" if req.candidates is not None:
+                inputs["items"] = req.candidates
 
         inputs.update(inv.extra_inputs)
 

--- a/src/lenskit/batch/_runner.py
+++ b/src/lenskit/batch/_runner.py
@@ -7,30 +7,22 @@
 from __future__ import annotations
 
 import sys
-import warnings
 from collections.abc import Generator, Iterable, Sized
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, Literal, Mapping, TypeAlias, overload
-
-import pandas as pd
+from typing import Any, Literal, TypeAlias
 
 from lenskit.data import (
-    ID,
-    GenericKey,
-    ItemList,
-    ItemListCollection,
     QueryIDKey,
-    RecQuery,
     UserIDKey,
 )
 from lenskit.logging import Stopwatch, get_logger, item_progress
 from lenskit.parallel import get_parallel_config, is_free_threaded
 from lenskit.pipeline import Pipeline, PipelineProfiler, ProfileSink
 
-from ._queries import ResolvedBatchRequest, normalize_query_input
+from ._queries import BatchInput, ResolvedBatchRequest, normalize_query_input
 from ._results import BatchResultRow, BatchResults
 
 _log = get_logger(__name__)
@@ -161,43 +153,10 @@ class BatchPipelineRunner:
         """
         self.add_invocation(InvocationSpec("recommend", {component: output}, extra_inputs=extra))
 
-    @overload
     def run(
         self,
         pipeline: Pipeline,
-        queries: Iterable[RecQuery]
-        | Iterable[tuple[RecQuery, ItemList]]
-        | Iterable[ID | GenericKey]
-        | ItemListCollection[GenericKey]
-        | Mapping[ID, ItemList]
-        | pd.DataFrame,
-    ) -> BatchResults: ...
-    @overload
-    def run(
-        self,
-        pipeline: Pipeline,
-        *,
-        test_data: Iterable[ID | GenericKey]
-        | ItemListCollection[GenericKey]
-        | Mapping[ID, ItemList]
-        | pd.DataFrame,
-    ) -> BatchResults: ...
-    def run(
-        self,
-        pipeline: Pipeline,
-        queries: Iterable[RecQuery]
-        | Iterable[tuple[RecQuery, ItemList]]
-        | Iterable[ID | GenericKey]
-        | ItemListCollection[GenericKey]
-        | Mapping[ID, ItemList]
-        | pd.DataFrame
-        | None = None,
-        *,
-        test_data: Iterable[ID | GenericKey]
-        | ItemListCollection[GenericKey]
-        | Mapping[ID, ItemList]
-        | pd.DataFrame
-        | None = None,
+        queries: BatchInput,
     ) -> BatchResults:
         """
         Run the pipeline and return its results.
@@ -215,16 +174,9 @@ class BatchPipelineRunner:
                 for details on the various input formats.
 
         Returns:
-            The results, as a nested dictionary.  The outer dictionary maps
-            component output names to inner dictionaries of result data.
+            The batch results, mapping output names to item list collections of
+            outputs.
         """
-        if test_data is not None:  # pragma: nocover
-            if queries is not None:
-                raise RuntimeError("cannot specify both queries and test_data=")
-            queries = test_data
-            warnings.warn(
-                "the test_data parameter is renamed to queries", DeprecationWarning, stacklevel=2
-            )
 
         if queries is None:  # pragma: nocover
             raise RuntimeError("no queries specified")

--- a/src/lenskit/data/_collection/_keys.py
+++ b/src/lenskit/data/_collection/_keys.py
@@ -21,7 +21,9 @@ from ..types import ID
 
 type GenericKey = tuple[ID, ...]
 """
-A generic collection key with no bounds or type information.
+A generic collection key with no bounds or type information.  Key types must
+also be *named* tuples (the Python type system does not allow us to express
+this).
 """
 
 K = TypeVar("K", bound=tuple, default=GenericKey)

--- a/src/lenskit/data/_query.py
+++ b/src/lenskit/data/_query.py
@@ -83,7 +83,7 @@ class RecQuery:
     The list of items to return from :meth:`query_items`.
     """
 
-    query_id: ID | None = None
+    query_id: ID | tuple[ID, ...] | None = None
     """
     An identifier for this query.
 

--- a/src/lenskit/data/_query.py
+++ b/src/lenskit/data/_query.py
@@ -12,7 +12,7 @@ Recommendation queries.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import Literal
 
 import numpy as np
 
@@ -22,6 +22,11 @@ from .types import ID
 type QueryItemSource = Literal["history", "session", "context"]
 """
 Valid sources for query items.
+"""
+
+type QueryInput = RecQuery | ID | ItemList | None
+"""
+Types that can be converted to a query by :meth:`RecQuery.create`.
 """
 
 
@@ -177,9 +182,3 @@ class RecQuery:
                 return self.history_items
             case _:  # pragma: nocover
                 raise ValueError(f"unsupported item source {source}")
-
-
-QueryInput: TypeAlias = RecQuery | ID | ItemList | None
-"""
-Types that can be converted to a query by :meth:`RecQuery.create`.
-"""

--- a/src/lenskit/data/_query.py
+++ b/src/lenskit/data/_query.py
@@ -8,9 +8,9 @@
 Recommendation queries.
 """
 
+# pyright: strict
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
@@ -78,16 +78,6 @@ class RecQuery:
     The list of items to return from :meth:`query_items`.
     """
 
-    user_items: ItemList | None = None
-    """
-    Deprecated alias for :attr:`history_items`.
-
-    .. deprecated:: 2025.6
-
-        Use :attr:`history_items` instead.  This property will be removed in
-        LensKit 2026.1.
-    """
-
     query_id: ID | None = None
     """
     An identifier for this query.
@@ -95,13 +85,6 @@ class RecQuery:
     Query identifiers are used for things like mapping batch recommendation
     outputs to their inputs.
     """
-
-    def __post_init__(self):
-        if self.user_items is None:
-            self.user_items = self.history_items
-        elif self.history_items is None:
-            warnings.warn("user_items is deprecated, use history_items", DeprecationWarning, 2)
-            self.history_items = self.user_items
 
     @classmethod
     def create(cls, data: QueryInput) -> RecQuery:

--- a/src/lenskit/funksvd.py
+++ b/src/lenskit/funksvd.py
@@ -216,7 +216,7 @@ class FunkSVDScorer(Trainable, Component[ItemList]):
 
         scores = np.full((len(items),), np.nan, dtype=np.float64)
         scores[item_mask] = i_feats @ u_feat
-        biases, _ub = self.bias.compute_for_items(items, user_id, query.user_items)
+        biases, _ub = self.bias.compute_for_items(items, user_id, query.history_items)
         scores += biases
 
         return ItemList(items, scores=scores)

--- a/src/lenskit/knn/slim.py
+++ b/src/lenskit/knn/slim.py
@@ -115,7 +115,7 @@ class SLIMScorer(Component, Trainable):
         self.items = data.items
 
     def __call__(self, query: RecQuery, items: ItemList) -> ItemList:
-        u_items = query.user_items
+        u_items = query.query_items
         if u_items is None:
             warnings.warn("no user history available", DataWarning)
             return ItemList(items, scores=np.nan)

--- a/src/lenskit/knn/user.py
+++ b/src/lenskit/knn/user.py
@@ -256,7 +256,7 @@ class UserKNNScorer(Component[ItemList], Trainable):
 
         index = self.users.number(query.user_id, missing=None)
 
-        if query.user_items is None:
+        if query.query_items is None:
             if index is None:
                 _log.warning("user %s has no ratings and none provided", query.user_id)
                 return None
@@ -269,16 +269,16 @@ class UserKNNScorer(Component[ItemList], Trainable):
             else:
                 umean = 0
             return UserRatings(index, row, umean)
-        elif len(query.user_items) == 0:
+        elif len(query.query_items) == 0:
             return None
         else:
             _log.debug("using provided item history")
             ratings = np.zeros(len(self.items), dtype=np.float32)
-            ui_nos = query.user_items.numbers(missing="negative", vocabulary=self.items)
+            ui_nos = query.query_items.numbers(missing="negative", vocabulary=self.items)
             ui_mask = ui_nos >= 0
 
             if self.config.explicit:
-                urv = query.user_items.field("rating")
+                urv = query.query_items.field("rating")
                 if urv is None:
                     _log.warning("user %s has items but no ratings", query.user_id)
                     return None

--- a/src/lenskit/pipeline/_builder.py
+++ b/src/lenskit/pipeline/_builder.py
@@ -225,8 +225,10 @@ class PipelineBuilder:
                 rts.add(type(None))
             elif isinstance(t, UnionType):
                 rts |= set(typing.get_args(t))
-            else:
+            elif isinstance(t, type):
                 rts.add(t)
+            else:
+                raise TypeError(f"unsupported type form: {t}")
 
         node = InputNode[Any](name, types=rts)
         self._nodes[name] = node

--- a/src/lenskit/pipeline/_builder.py
+++ b/src/lenskit/pipeline/_builder.py
@@ -21,7 +21,7 @@ from types import UnionType
 from typing import TypeAliasType
 from uuid import NAMESPACE_URL, uuid5
 
-from typing_extensions import Any, Literal, cast, overload
+from typing_extensions import Any, Literal, TypeForm, cast, overload
 
 from lenskit.config import load_config_data
 from lenskit.diagnostics import PipelineError, PipelineWarning
@@ -188,9 +188,12 @@ class PipelineBuilder:
         else:
             return self.node(self._default)
 
-    def create_input[T](
-        self, name: str, *types: type[T] | UnionType | TypeAliasType | None
-    ) -> Node[T]:
+    @overload
+    def create_input[T](self, name: str, *types: TypeForm[T] | None) -> Node[T]: ...
+    # TODO: remove second overload when typecheckers are sane
+    @overload
+    def create_input(self, name: str, *types: Any) -> Node[Any]: ...
+    def create_input[T](self, name: str, *types: TypeForm[T] | None) -> Node[T]:
         """
         Create an input node for the pipeline.  Pipelines expect their inputs to
         be provided when they are run.

--- a/src/lenskit/pipeline/_builder.py
+++ b/src/lenskit/pipeline/_builder.py
@@ -18,6 +18,7 @@ from graphlib import CycleError, TopologicalSorter
 from os import PathLike
 from pathlib import Path
 from types import UnionType
+from typing import TypeAliasType
 from uuid import NAMESPACE_URL, uuid5
 
 from typing_extensions import Any, Literal, cast, overload
@@ -187,7 +188,9 @@ class PipelineBuilder:
         else:
             return self.node(self._default)
 
-    def create_input[T](self, name: str, *types: type[T] | UnionType | None) -> Node[T]:
+    def create_input[T](
+        self, name: str, *types: type[T] | UnionType | TypeAliasType | None
+    ) -> Node[T]:
         """
         Create an input node for the pipeline.  Pipelines expect their inputs to
         be provided when they are run.
@@ -213,6 +216,8 @@ class PipelineBuilder:
 
         rts: set[type[T | None]] = set()
         for t in types:
+            if isinstance(t, TypeAliasType):
+                t = t.__value__
             if t is None:
                 rts.add(type(None))
             elif isinstance(t, UnionType):

--- a/src/lenskit/pipeline/_types.py
+++ b/src/lenskit/pipeline/_types.py
@@ -13,6 +13,7 @@ from importlib import import_module
 from types import FunctionType, GenericAlias, NoneType, UnionType
 from typing import (
     Any,
+    TypeAliasType,
     TypeVar,
     Union,
     _GenericAlias,  # type: ignore # noqa: PLC2701
@@ -24,7 +25,7 @@ import numpy as np
 
 from lenskit.diagnostics import PipelineWarning, TypecheckWarning
 
-type TypeExpr = type | UnionType
+type TypeExpr = type | UnionType | TypeAliasType
 """
 Type for (resolved) type expressions.
 
@@ -75,6 +76,10 @@ def is_compatible_type(typ: type, *targets: TypeExpr) -> bool:
         all of the targets, and ``True`` otherwise.
     """
     for target in targets:
+        # resolve type aliases
+        if isinstance(target, TypeAliasType):
+            target = target.__value__
+
         # try a straight subclass check first, but gracefully handle incompatible types
         try:
             if issubclass(typ, target):
@@ -125,6 +130,10 @@ def is_compatible_data(obj: object, *targets: TypeExpr) -> bool:
         all of the targets, and ``True`` otherwise.
     """
     for target in targets:
+        # resolve type aliases
+        if isinstance(target, TypeAliasType):
+            target = target.__value__
+
         # try a straight subclass check first, but gracefully handle incompatible types
         try:
             if isinstance(obj, target):

--- a/src/lenskit/sklearn/svd.py
+++ b/src/lenskit/sklearn/svd.py
@@ -125,7 +125,7 @@ class BiasedSVDScorer(Component[ItemList], Trainable):
         scores = np.full(len(items), np.nan)
         scores[iidx >= 0] = Xsel
 
-        biases, _ub = self.bias.compute_for_items(items, query.user_id, query.user_items)
+        biases, _ub = self.bias.compute_for_items(items, query.user_id, query.query_items)
         scores += biases
 
         return ItemList(items, scores=scores)

--- a/src/lenskit/splitting/_split.py
+++ b/src/lenskit/splitting/_split.py
@@ -6,21 +6,27 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
-from typing import Generic, Literal, TypeAlias, TypeVar
+from typing import Literal, TypeAlias
 
 import pandas as pd
 
+from lenskit.batch import TestRequestAdapter
 from lenskit.data import Dataset, ItemListCollection
+from lenskit.diagnostics import DataWarning
 
 SplitTable: TypeAlias = Literal["matrix"]
-TK = TypeVar("TK", bound=tuple)
 
 
 @dataclass
-class TTSplit(Generic[TK]):
+class TTSplit:
     """
     A train-test set from splitting or other sources.
+
+    .. versionchanged:: 2026.1
+
+        Added the :attr:`test_requests` property.
 
     Stability:
         Caller
@@ -31,7 +37,7 @@ class TTSplit(Generic[TK]):
     The training data.
     """
 
-    test: ItemListCollection[TK]
+    test: ItemListCollection
     """
     The test data.
     """
@@ -61,3 +67,24 @@ class TTSplit(Generic[TK]):
         Get the training data as a data frame.
         """
         return self.train.interaction_matrix(format="pandas", field="all")
+
+    @property
+    def test_requests(self) -> TestRequestAdapter:
+        """
+        Get the test data as a sequence of batch recommendation requests.
+
+        .. seealso::
+
+            :ref:`batch-queries`
+
+        Returns:
+            An collection that iterates over recommendation requests derived
+            from the test data.
+        """
+        if "user_id" not in self.test.key_fields:
+            warnings.warn(
+                "user_id is not in test data keys, requests unlikely to be usable",
+                DataWarning,
+                stacklevel=2,
+            )
+        return TestRequestAdapter(self.test)

--- a/src/lenskit/testing/_components.py
+++ b/src/lenskit/testing/_components.py
@@ -240,7 +240,7 @@ class ScorerTests(TrainingTests):
 
         item_nums = rng.choice(ml_ds.item_count, 100, replace=False)
         items = ItemList(item_nums=item_nums, vocabulary=ml_ds.items)
-        q = RecQuery(user_id=u, user_items=u_row)
+        q = RecQuery(user_id=u, history_items=u_row)
         scored = self.invoke_scorer(trained_pipeline, query=q, items=items)
         assert np.all(scored.numbers() == item_nums)
         assert np.all(scored.ids() == items.ids())
@@ -256,7 +256,7 @@ class ScorerTests(TrainingTests):
 
         item_nums = rng.choice(ml_ds.item_count, 100, replace=False)
         items = ItemList(item_nums=item_nums, vocabulary=ml_ds.items)
-        q = RecQuery(user_items=u_row)
+        q = RecQuery(history_items=u_row)
         scored = self.invoke_scorer(trained_pipeline, query=q, items=items)
         assert np.all(scored.numbers() == item_nums)
         assert np.all(scored.ids() == items.ids())

--- a/src/lenskit/tuning/_search.py
+++ b/src/lenskit/tuning/_search.py
@@ -23,7 +23,7 @@ from ray.tune.search.hyperopt import HyperOptSearch
 from ray.tune.search.optuna import OptunaSearch
 
 from lenskit.config import TuneSettings, lenskit_config
-from lenskit.data import Dataset, GenericKey, ItemListCollection
+from lenskit.data import Dataset, ItemListCollection
 from lenskit.logging import get_logger
 from lenskit.parallel import get_parallel_config
 from lenskit.parallel.ray import ensure_cluster
@@ -58,7 +58,7 @@ class PipelineTuner:
     random_seed: np.random.SeedSequence
     iterative: bool
 
-    data: TTSplit[GenericKey]
+    data: TTSplit
     harness: Any
     tuner: ray.tune.Tuner
     """

--- a/tests/basic/test_history.py
+++ b/tests/basic/test_history.py
@@ -33,9 +33,9 @@ def test_lookup_user_id(ml_ds):
 
     assert isinstance(query, RecQuery)
     assert query.user_id == user
-    assert query.user_items is not None
-    assert len(query.user_items) == len(ds_row)
-    assert np.all(query.user_items.ids() == ds_row.ids())
+    assert query.history_items is not None
+    assert len(query.history_items) == len(ds_row)
+    assert np.all(query.history_items.ids() == ds_row.ids())
 
 
 def test_lookup_no_override(ml_ds):
@@ -50,9 +50,9 @@ def test_lookup_no_override(ml_ds):
 
     assert isinstance(query, RecQuery)
     assert query.user_id == user
-    assert query.user_items is not None
-    assert len(query.user_items) == len(ds_row) - 2
-    assert np.all(query.user_items.ids() == ds_row[:-2].ids())
+    assert query.history_items is not None
+    assert len(query.history_items) == len(ds_row) - 2
+    assert np.all(query.history_items.ids() == ds_row[:-2].ids())
 
 
 def test_lookup_items_only(ml_ds: Dataset):
@@ -66,9 +66,9 @@ def test_lookup_items_only(ml_ds: Dataset):
 
     assert isinstance(query, RecQuery)
     assert query.user_id is None
-    assert query.user_items is not None
-    assert len(query.user_items) == len(ds_row) - 5
-    assert np.all(query.user_items.ids() == ds_row[:-5].ids())
+    assert query.history_items is not None
+    assert len(query.history_items) == len(ds_row) - 5
+    assert np.all(query.history_items.ids() == ds_row[:-5].ids())
 
 
 def test_lookup_pickle(ml_ds: Dataset):
@@ -87,9 +87,9 @@ def test_lookup_pickle(ml_ds: Dataset):
     l2_row = l2(100)
 
     assert l_row.user_id == 100
-    assert np.all(l_row.user_items.ids() == ds_row.ids())
+    assert np.all(l_row.history_items.ids() == ds_row.ids())
     assert l2_row.user_id == 100
-    assert np.all(l2_row.user_items.ids() == ds_row.ids())
+    assert np.all(l2_row.history_items.ids() == ds_row.ids())
 
 
 def test_known_rating_defaults(ml_ds: Dataset):

--- a/tests/batch/test_batch_pipeline.py
+++ b/tests/batch/test_batch_pipeline.py
@@ -10,7 +10,7 @@ from typing import Generator, NamedTuple
 import numpy as np
 import pandas as pd
 
-from pytest import approx, fixture, mark, skip, warns
+from pytest import approx, fixture, mark, raises, skip, warns
 
 from lenskit.basic import BiasScorer, PopScorer
 from lenskit.batch import BatchPipelineRunner, predict, recommend, score
@@ -52,7 +52,7 @@ def ml_split(ml_100k: pd.DataFrame) -> Generator[TTSplit, None, None]:
 
 
 def test_predict_single(mlb: MLB):
-    res = predict(mlb.pipeline, {1: ItemList([31])})
+    res = predict(mlb.pipeline, [{"user_id": 1, "items": ItemList([31])}])
 
     assert len(res) == 1
     uid, result = next(iter(res))
@@ -67,7 +67,7 @@ def test_predict_single(mlb: MLB):
 
 
 def test_score_single(mlb: MLB):
-    res = score(mlb.pipeline, {1: ItemList([31])})
+    res = score(mlb.pipeline, [{"user_id": 1, "items": ItemList([31])}])
 
     assert len(res) == 1
     uid, result = next(iter(res))
@@ -176,16 +176,5 @@ def test_bias_df(ml_split: TTSplit):
     runner = BatchPipelineRunner()
     runner.recommend()
 
-    with warns(DataWarning):
-        results = runner.run(pipeline, ml_split.test.to_df())
-
-    recs = results.output("recommendations")
-    ra = RunAnalysis()
-    ra.add_metric(NDCG())
-    ra.add_metric(RBP())
-    rec_acc = ra.measure(recs, ml_split.test)
-    ras = rec_acc.list_summary()
-    print(ras)
-
-    assert ras.loc["RBP", "mean"] > 0
-    assert ras.loc["NDCG", "mean"] > 0
+    with raises(TypeError):
+        _results = runner.run(pipeline, ml_split.test.to_df())

--- a/tests/batch/test_batch_pipeline.py
+++ b/tests/batch/test_batch_pipeline.py
@@ -112,7 +112,7 @@ def test_bias_batch(ml_split: TTSplit, ncpus: int | None):
     runner.recommend()
     runner.predict()
 
-    results = runner.run(pipeline, ml_split.test)
+    results = runner.run(pipeline, ml_split.test_requests)
 
     preds = results.output("predictions")
 
@@ -153,7 +153,7 @@ def test_pop_batch_recommend(ml_split: TTSplit, ncpus: int | None):
     runner = BatchPipelineRunner(n_jobs=ncpus, use_ray=use_ray)
     runner.recommend()
 
-    results = runner.run(pipeline, ml_split.test)
+    results = runner.run(pipeline, ml_split.test_requests)
 
     recs = results.output("recommendations")
     ra = RunAnalysis()

--- a/tests/data/test_query.py
+++ b/tests/data/test_query.py
@@ -16,7 +16,7 @@ def test_empty():
     query = RecQuery()
     assert query.user_id is None
     assert query.history_items is None
-    assert query.user_items is None
+    assert query.history_items is None
     assert query.session_items is None
     assert query.context_items is None
 
@@ -26,19 +26,7 @@ def test_history_items():
     query = RecQuery.create(items)
     assert query.user_id is None
     assert query.history_items == items
-    assert query.user_items == items
-    assert query.session_items is None
-    assert query.context_items is None
-    assert query.query_items == items
-
-
-def test_deprecated_user_items():
-    items = ItemList(ITEMS, vocabulary=VOCAB)
-    with warns(DeprecationWarning):
-        query = RecQuery(user_items=items)
-    assert query.user_id is None
     assert query.history_items == items
-    assert query.user_items == items
     assert query.session_items is None
     assert query.context_items is None
     assert query.query_items == items
@@ -49,7 +37,7 @@ def test_session_items():
     query = RecQuery(session_items=items)
     assert query.user_id is None
     assert query.history_items is None
-    assert query.user_items is None
+    assert query.history_items is None
     assert query.session_items == items
     assert query.context_items is None
     assert query.query_items == items
@@ -60,7 +48,7 @@ def test_context_items():
     query = RecQuery(context_items=items)
     assert query.user_id is None
     assert query.history_items is None
-    assert query.user_items is None
+    assert query.history_items is None
     assert query.session_items is None
     assert query.context_items == items
     assert query.query_items == items
@@ -77,7 +65,7 @@ def test_context_items_override():
     )
     assert query.user_id is None
     assert query.history_items == h_il
-    assert query.user_items == h_il
+    assert query.history_items == h_il
     assert query.session_items == s_il
     assert query.context_items == c_il
     assert query.query_items == c_il
@@ -92,7 +80,7 @@ def test_session_items_override():
     )
     assert query.user_id is None
     assert query.history_items == h_il
-    assert query.user_items == h_il
+    assert query.history_items == h_il
     assert query.session_items == s_il
     assert query.context_items is None
     assert query.query_items == s_il
@@ -110,7 +98,7 @@ def test_combined_query_items():
     )
     assert query.user_id is None
     assert query.history_items == h_il
-    assert query.user_items == h_il
+    assert query.history_items == h_il
     assert query.session_items == s_il
     assert query.context_items == c_il
     assert query.query_items is not None

--- a/tests/integration/test_pipeline_basics.py
+++ b/tests/integration/test_pipeline_basics.py
@@ -48,7 +48,7 @@ def test_history_correct(rng: np.random.Generator, ml_ds: Dataset, random_pipe: 
         query = random_pipe.run("history-lookup", query=uid)
         assert isinstance(query, RecQuery)
         assert query.user_id == uid
-        user_items = query.user_items
+        user_items = query.history_items
         assert isinstance(user_items, ItemList)
         assert len(user_items) == len(train_items)
         assert set(user_items.ids()) == set(train_items.ids())

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -16,6 +16,8 @@ from lenskit.pipeline import PipelineBuilder, PipelineError
 from lenskit.pipeline._types import TypecheckWarning
 from lenskit.pipeline.nodes import InputNode, Node
 
+type TK = int | str
+
 
 def test_init_empty():
     pipe = PipelineBuilder()
@@ -33,6 +35,23 @@ def test_create_input():
 
     assert len(pipe.nodes()) == 1
     assert pipe.node("user") is src
+
+
+def test_create_input_type_alias():
+    "create an input node"
+    pipe = PipelineBuilder()
+    src = pipe.create_input("user", TK)
+    assert_type(src, Node[int | str])
+    assert isinstance(src, InputNode)
+    assert src.name == "user"
+    assert src.types == set([int, str])
+
+    assert len(pipe.nodes()) == 1
+    assert pipe.node("user") is src
+
+    pipe = pipe.build()
+    assert len(pipe.nodes()) == 1
+    assert pipe.node("user") == src
 
 
 def test_lookup_optional():

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -5,10 +5,11 @@
 # SPDX-License-Identifier: MIT
 
 # pyright: strict
+from typing import Any
 from uuid import UUID
 
 import numpy as np
-from typing_extensions import assert_type
+from typing_extensions import TypeForm, assert_type, reveal_type
 
 from pytest import mark, raises, warns
 

--- a/tests/pipeline/test_types.py
+++ b/tests/pipeline/test_types.py
@@ -22,7 +22,7 @@ from numpy.typing import ArrayLike, NDArray
 
 from pytest import mark, warns
 
-from lenskit.data import Dataset, MatrixRelationshipSet, RelationshipSet
+from lenskit.data import MatrixRelationshipSet, QueryInput, RecQuery, RelationshipSet
 from lenskit.pipeline._types import (
     TypecheckWarning,
     import_path_string,
@@ -208,3 +208,13 @@ def test_is_instance_proto():
 
 def test_is_subclass_proto():
     assert is_instance_or_subclass(list, Sequence)
+
+
+def test_query_subtype():
+    assert is_compatible_type(RecQuery, QueryInput)
+
+
+def test_query_valid():
+    query = RecQuery(47)
+    assert is_compatible_data(query, RecQuery)
+    assert is_compatible_data(query, QueryInput)


### PR DESCRIPTION
This updates the batch inference interfaces to make them clearer and reduce implicit behavior.

- [x] Create explicit input type for advanced batch inference requests
- [x] Separate test from candidate items in requests
- [x] Update documentation for new input types
- [x] Fix tests for new input types
- [x] Implement adapter for item list collections
- [x] Review return types and their documentation
- [x] Update release notes
- [x] Fix any test breakage

Closes #958. Closes #1052.