### PR TITLE
Remove types from pipeline nodes and simplify input types

### DIFF
--- a/src/lenskit/pipeline/_builder.py
+++ b/src/lenskit/pipeline/_builder.py
@@ -18,7 +18,7 @@ from graphlib import CycleError, TopologicalSorter
 from os import PathLike
 from pathlib import Path
 from types import UnionType
-from typing import TypeAliasType
+from typing import TypeAliasType, Union
 from uuid import NAMESPACE_URL, uuid5
 
 from typing_extensions import Any, Literal, TypeForm, cast, overload
@@ -31,7 +31,7 @@ from . import config
 from ._cache import PipelineCache
 from ._hooks import ComponentInputHook, HookEntry, RunHooks
 from ._impl import Pipeline
-from ._types import TypecheckWarning, import_path_string, is_instance_or_subclass
+from ._types import import_path_string, is_instance_or_subclass
 from .components import (
     Component,
     ComponentConstructor,
@@ -189,11 +189,11 @@ class PipelineBuilder:
             return self.node(self._default)
 
     @overload
-    def create_input[T](self, name: str, *types: TypeForm[T] | None) -> Node[T]: ...
-    # TODO: remove second overload when typecheckers are sane
+    def create_input[T](self, name: str, *types: TypeForm[T]) -> Node[T]: ...
+    # TODO: remove second overload when typecheckers properly implement TypeForm
     @overload
     def create_input(self, name: str, *types: Any) -> Node[Any]: ...
-    def create_input[T](self, name: str, *types: TypeForm[T] | None) -> Node[T]:
+    def create_input[T](self, name: str, *types: TypeForm[T] | None) -> Node[Any]:
         """
         Create an input node for the pipeline.  Pipelines expect their inputs to
         be provided when they are run.
@@ -217,20 +217,27 @@ class PipelineBuilder:
         check_name(name, what="input")
         self._check_available_name(name)
 
-        rts: set[type[T | None]] = set()
+        tys: set[type[Any]] = set()
         for t in types:
             if isinstance(t, TypeAliasType):
                 t = t.__value__
             if t is None:
-                rts.add(type(None))
+                tys.add(type(None))
             elif isinstance(t, UnionType):
-                rts |= set(typing.get_args(t))
+                tys |= set(typing.get_args(t))
             elif isinstance(t, type):
-                rts.add(t)
+                tys.add(t)
             else:
                 raise TypeError(f"unsupported type form: {t}")
 
-        node = InputNode[Any](name, types=rts)
+        ty: type[Any] | UnionType
+        if len(tys) == 1:
+            (ty,) = tys
+        elif tys:
+            ty = Union[*tys]
+        else:
+            ty = Any
+        node = InputNode[Any](name, type=ty)
         self._nodes[name] = node
         return node
 
@@ -247,7 +254,7 @@ class PipelineBuilder:
             name = str(uuid5(NAMESPACE_LITERAL_DATA, lit.model_dump_json()))
         else:
             check_name(name)
-        node = LiteralNode(name, value, types=set([type(value)]))
+        node = LiteralNode(name, value)
         self._nodes[name] = node
         return node
 
@@ -380,8 +387,6 @@ class PipelineBuilder:
                 )
 
         node = ComponentNode[T].create(name, comp, config)
-        if node.types is None:
-            warnings.warn(f"cannot determine return type of component {comp}", TypecheckWarning)
         self._nodes[name] = node
 
         self.connect(node, **inputs)
@@ -532,10 +537,8 @@ class PipelineBuilder:
 
         for node in self.nodes():
             match node:
-                case InputNode(name, types=types):
-                    if types is None:
-                        types = set[type]()
-                    clone.create_input(name, *types)
+                case InputNode(name, type=ty):
+                    clone.create_input(name, ty)
                 case LiteralNode(name, value):
                     clone._nodes[name] = LiteralNode(name, value)
                 case ComponentConstructorNode(name, comp, config):

--- a/src/lenskit/pipeline/_runner.py
+++ b/src/lenskit/pipeline/_runner.py
@@ -11,6 +11,7 @@ Pipeline runner logic.
 # pyright: strict
 # pyright: reportPrivateUsage=false
 from dataclasses import dataclass
+from types import UnionType
 from typing import Any, Literal
 
 import structlog
@@ -95,20 +96,20 @@ class PipelineRunner:
         match node:
             case LiteralNode(name, value):
                 self.state[name] = value
-            case InputNode(name, types=types):
-                self._inject_input(name, types, required)
+            case InputNode(name, type=ty):
+                self._inject_input(name, ty, required)
             case ComponentInstanceNode():
                 self._run_component(node, required)
             case _:  # pragma: nocover
                 raise PipelineError(f"invalid node {node}")
 
-    def _inject_input(self, name: str, types: set[type] | None, required: bool) -> None:
+    def _inject_input(self, name: str, ty: type[Any] | UnionType, required: bool) -> None:
         val = self.inputs.get(name, None)
-        if val is None and required and types and not is_compatible_data(None, *types):
+        if val is None and required and not is_compatible_data(None, ty):
             raise PipelineError(f"input {name} not specified")
 
-        if val is not None and types and not is_compatible_data(val, *types):
-            raise TypeError(f"invalid data for input {name} (expected {types}, got {type(val)})")
+        if val is not None and not is_compatible_data(val, ty):
+            raise TypeError(f"invalid data for input {name} (expected {ty}, got {type(val)})")
 
         trace(self.log, "injecting input", name=name, value=val)
         self.state[name] = val

--- a/src/lenskit/pipeline/_types.py
+++ b/src/lenskit/pipeline/_types.py
@@ -80,6 +80,8 @@ def is_compatible_type(typ: type, *targets: TypeExpr) -> bool:
         # resolve type aliases
         if isinstance(target, TypeAliasType):
             target = target.__value__
+        if target == Any:
+            return True
 
         # try a straight subclass check first, but gracefully handle incompatible types
         try:
@@ -134,6 +136,8 @@ def is_compatible_data(obj: object, *targets: TypeExpr) -> bool:
         # resolve type aliases
         if isinstance(target, TypeAliasType):
             target = target.__value__
+        if target == Any:
+            return True
 
         # try a straight subclass check first, but gracefully handle incompatible types
         try:

--- a/src/lenskit/pipeline/_types.py
+++ b/src/lenskit/pipeline/_types.py
@@ -22,6 +22,7 @@ from typing import (
 )
 
 import numpy as np
+from typing_extensions import TypeForm
 
 from lenskit.diagnostics import PipelineWarning, TypecheckWarning
 
@@ -243,3 +244,8 @@ def import_path_string(tstr: str) -> Any:
 
         mod = import_module(mod_name)
         return getattr(mod, typ_name)
+
+
+def is_union_type(ty: TypeForm[Any]):
+    # TODO: update to 'isinstance' after Python 3.14 unification of types
+    return get_origin(ty) is Union or get_origin(ty) is UnionType

--- a/src/lenskit/pipeline/config.py
+++ b/src/lenskit/pipeline/config.py
@@ -18,7 +18,7 @@ import warnings
 from collections import OrderedDict
 from hashlib import sha256
 from types import FunctionType
-from typing import Annotated, Literal, Mapping
+from typing import Annotated, Literal, Mapping, get_args
 
 from annotated_types import Predicate
 from deepmerge import always_merger
@@ -28,7 +28,7 @@ from typing_extensions import Any, Self
 from lenskit.diagnostics import PipelineError, PipelineWarning
 
 from ._hooks import HookEntry
-from ._types import make_importable_path
+from ._types import is_union_type, make_importable_path
 from .components import Component
 from .nodes import ComponentConstructorNode, ComponentInstanceNode, ComponentNode, InputNode
 
@@ -180,10 +180,15 @@ class PipelineInput(BaseModel):
 
     @classmethod
     def from_node(cls, node: InputNode[Any]) -> Self:
-        if node.types is not None:
-            types = {make_importable_path(t) for t in node.types}
-        else:
+        if node.type == Any:
             types = None
+        elif is_union_type(node.type):
+            types = set(get_args(node.type))
+        else:
+            types = {node.type}
+
+        if types is not None:
+            types = {make_importable_path(t) for t in types}
 
         return cls(name=node.name, types=types)
 

--- a/src/lenskit/pipeline/nodes.py
+++ b/src/lenskit/pipeline/nodes.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Mapping
+from types import UnionType
 from typing import Any, cast
 
 from pydantic import JsonValue
@@ -27,13 +28,16 @@ from .components import (
     ComponentInput,
     PipelineFunction,
     component_inputs,
-    component_return_type,
 )
 
 
 class Node[T]:
     """
     Representation of a single node in a :class:`Pipeline`.
+
+    .. versionchanged:: 2026.1
+
+        Removed the ``types`` attribute.
 
     Stability:
         Caller
@@ -43,12 +47,9 @@ class Node[T]:
 
     name: str
     "The name of this node."
-    types: set[type] | None
-    "The set of valid data types of this node, or None for no typechecking."
 
-    def __init__(self, name: str, *, types: set[type] | None = None):
+    def __init__(self, name: str):
         self.name = name
-        self.types = types
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.name}>"
@@ -61,6 +62,18 @@ class InputNode[T](Node[T]):
     Stability:
         Internal
     """
+
+    type: type[T] | UnionType
+    """
+    The data type of this input.
+    """
+
+    def __init__(self, name: str, *, type: type[T] | UnionType | None = None):
+        super().__init__(name)
+        if type is None:
+            self.type = Any  # type: ignore
+        else:
+            self.type = type
 
 
 class LiteralNode[T](Node[T]):
@@ -75,8 +88,8 @@ class LiteralNode[T](Node[T]):
     value: T
     "The value associated with this node"
 
-    def __init__(self, name: str, value: T, *, types: set[type] | None = None):
-        super().__init__(name, types=types)
+    def __init__(self, name: str, value: T):
+        super().__init__(name)
         self.value = value
 
 
@@ -88,9 +101,6 @@ class ComponentNode[T](Node[T]):
     Stability:
         Internal
     """
-
-    def __init__(self, name: str):
-        super().__init__(name)
 
     @staticmethod
     def create[CFG](
@@ -125,8 +135,6 @@ class ComponentConstructorNode[T](ComponentNode[T]):
         super().__init__(name)
         self.constructor = constructor
         self.config = config
-        if rt := component_return_type(constructor):
-            self.types = {rt}
 
     @property
     def inputs(self):
@@ -145,8 +153,6 @@ class ComponentInstanceNode[T](ComponentNode[T]):
     ):
         super().__init__(name)
         self.component = component
-        if rt := component_return_type(component):
-            self.types = {rt}
 
     @property
     def inputs(self):

--- a/tests/pipeline/test_config_node.py
+++ b/tests/pipeline/test_config_node.py
@@ -18,7 +18,7 @@ def test_untyped_input():
 
 
 def test_input_with_type():
-    node = InputNode("scroll", types={str})
+    node = InputNode("scroll", type=str)
 
     cfg = PipelineInput.from_node(node)
     print(cfg)
@@ -27,7 +27,7 @@ def test_input_with_type():
 
 
 def test_input_with_none():
-    node = InputNode("scroll", types={str, type(None)})
+    node = InputNode("scroll", type=str | None)
 
     cfg = PipelineInput.from_node(node)
     print(cfg)
@@ -36,7 +36,7 @@ def test_input_with_none():
 
 
 def test_input_with_generic():
-    node = InputNode("scroll", types={list[str]})
+    node = InputNode("scroll", type=list[str])
 
     cfg = PipelineInput.from_node(node)
     print(cfg)

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -5,11 +5,10 @@
 # SPDX-License-Identifier: MIT
 
 # pyright: strict
-from typing import Any
 from uuid import UUID
 
 import numpy as np
-from typing_extensions import TypeForm, assert_type, reveal_type
+from typing_extensions import assert_type
 
 from pytest import mark, raises, warns
 
@@ -32,7 +31,7 @@ def test_create_input():
     assert_type(src, Node[int | str])
     assert isinstance(src, InputNode)
     assert src.name == "user"
-    assert src.types == set([int, str])
+    assert src.type == int | str
 
     assert len(pipe.nodes()) == 1
     assert pipe.node("user") is src
@@ -45,7 +44,7 @@ def test_create_input_type_alias():
     assert_type(src, Node[int | str])
     assert isinstance(src, InputNode)
     assert src.name == "user"
-    assert src.types == set([int, str])
+    assert src.type == int | str
 
     assert len(pipe.nodes()) == 1
     assert pipe.node("user") is src
@@ -164,7 +163,7 @@ def test_component_type():
 
     node = pipe.add_component("return", incr, msg=msg)
     assert node.name == "return"
-    assert node.types == set([str])
+    # assert node.type == set([str])
 
 
 def test_single_input():
@@ -627,8 +626,9 @@ def test_pipeline_component_default():
     def add(x, y):  # type: ignore
         return x + y  # type: ignore
 
-    with warns(TypecheckWarning):
-        pipe.add_component("add", add, x=np.arange(10), y=a)  # type: ignore
+    # TODO: test typecheck warnings again
+    # with warns(TypecheckWarning):
+    pipe.add_component("add", add, x=np.arange(10), y=a)  # type: ignore
     pipe.default_component("add")
 
     cfg = pipe.build_config()

--- a/tests/pipeline/test_save_load.py
+++ b/tests/pipeline/test_save_load.py
@@ -88,7 +88,7 @@ def test_round_trip_input():
     i2 = p2.node("user")
     assert isinstance(i2, InputNode)
     assert i2.name == "user"
-    assert i2.types == {int, str}
+    assert i2.type == int | str
 
 
 def test_round_trip_optional_input():
@@ -103,7 +103,7 @@ def test_round_trip_optional_input():
     i2 = p2.node("user")
     assert isinstance(i2, InputNode)
     assert i2.name == "user"
-    assert i2.types == {int, str, NoneType}
+    assert i2.type == int | str | None
 
 
 def test_config_single_node():

--- a/tests/pipeline/test_types.py
+++ b/tests/pipeline/test_types.py
@@ -114,6 +114,14 @@ def test_numpy_scalar_typecheck2():
     assert is_compatible_data(np.int32(4270), np.integer[Any] | int)
 
 
+def test_compatible_any():
+    assert is_compatible_data(50, Any)
+
+
+def test_compatible_type_any():
+    assert is_compatible_type(int, Any)
+
+
 @mark.skip("broke with NumPy 2.4")
 def test_pandas_typecheck():
     assert is_compatible_data(pd.Series(["a", "b"]), ArrayLike)


### PR DESCRIPTION
This removes types from most pipeline node types, and updates the `InputNode` to use a single type (which may be a union). This reduces some proactive type-checking but also reduces many warnings, and we will re-add better pipeline type-checking as a separate effort.

Closes #1077.