### PR TITLE
Update default embedding sizes to 64

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -30,6 +30,8 @@ Breaking Changes
   :meth:`~lenskit.training.Trainable.is_trained`.
 - Pipeline components and inputs now have restrictions on their names, and cannot
   have names beginning with ``_``.  See :ref:`pipeline-names` for details.
+- Default embedding sizes for all embedding-based models (matrix factorizers, etc.)
+  have changed to be 64 instead of 50 (:issue:`846`).
 - Pipeline configurations serialized with previous versions **cannot** be
   re-loaded in LensKit 2026, due to moves of module paths.  Import path
   canonicalization (:issue:`948`) reduces the risk of such breakage in future

--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -30,8 +30,10 @@ Breaking Changes
   :meth:`~lenskit.training.Trainable.is_trained`.
 - Pipeline components and inputs now have restrictions on their names, and cannot
   have names beginning with ``_``.  See :ref:`pipeline-names` for details.
-- Default embedding sizes for all embedding-based models (matrix factorizers, etc.)
-  have changed to be 64 instead of 50 (:issue:`846`).
+- Default embedding sizes for all embedding-based models (matrix factorizers,
+  etc.) have changed to be 64 instead of 50, with the exception of
+  :mod:`lenskit.implicit`, which continues to default to Implicit's defaults
+  (:issue:`846`).
 - Pipeline configurations serialized with previous versions **cannot** be
   re-loaded in LensKit 2026, due to moves of module paths.  Import path
   canonicalization (:issue:`948`) reduces the risk of such breakage in future

--- a/src/lenskit/als/_common.py
+++ b/src/lenskit/als/_common.py
@@ -38,7 +38,7 @@ class ALSConfig(EmbeddingSizeMixin, BaseModel):
     """
 
     embedding_size: PositiveInt = Field(
-        default=50, validation_alias=AliasChoices("embedding_size", "features")
+        default=64, validation_alias=AliasChoices("embedding_size", "features")
     )
     """
     The dimension of user and item embeddings (number of latent features to

--- a/src/lenskit/funksvd.py
+++ b/src/lenskit/funksvd.py
@@ -35,7 +35,7 @@ class FunkSVDConfig(EmbeddingSizeMixin, BaseModel):
     "Configuration for :class:`FunkSVDScorer`."
 
     embedding_size: PositiveInt = Field(
-        default=50, validation_alias=AliasChoices("embedding_size", "features")
+        default=64, validation_alias=AliasChoices("embedding_size", "features")
     )
     """
     Number of latent features.

--- a/src/lenskit/hpf.py
+++ b/src/lenskit/hpf.py
@@ -39,7 +39,7 @@ class HPFConfig(BaseModel, extra="allow"):
     """
 
     embedding_size: int = Field(
-        default=50, validation_alias=AliasChoices("embedding_size", "features")
+        default=64, validation_alias=AliasChoices("embedding_size", "features")
     )
     """
     The dimension of user and item embeddings (number of latent features to

--- a/src/lenskit/sklearn/nmf.py
+++ b/src/lenskit/sklearn/nmf.py
@@ -39,7 +39,7 @@ class NMFConfig(EmbeddingSizeMixin, BaseModel, extra="forbid"):
     beta_loss: Literal["frobenius", "kullback-leibler", "itakura-saito"] = "frobenius"
     max_iter: PositiveInt = Field(default=200, validation_alias=AliasChoices("max_iter", "epochs"))
     embedding_size: PositiveInt | None = Field(
-        default=None, validation_alias=AliasChoices("embedding_size", "n_components")
+        default=64, validation_alias=AliasChoices("embedding_size", "n_components")
     )
     alpha_W: float = 0.0
     alpha_H: float | Literal["same"] = "same"

--- a/src/lenskit/sklearn/svd.py
+++ b/src/lenskit/sklearn/svd.py
@@ -31,7 +31,7 @@ _log = get_logger(__name__)
 
 class BiasedSVDConfig(EmbeddingSizeMixin, BaseModel):
     embedding_size: int = Field(
-        default=50, validation_alias=AliasChoices("embedding_size", "features")
+        default=64, validation_alias=AliasChoices("embedding_size", "features")
     )
     """
     The dimension of user and item embeddings (number of latent features to

--- a/tests/models/test_als_explicit.py
+++ b/tests/models/test_als_explicit.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from pytest import approx, mark, skip
 
-from lenskit.als import BiasedMFScorer
+from lenskit.als import BiasedMFConfig, BiasedMFScorer
 from lenskit.data import Dataset, ItemList, RecQuery, from_interactions_df, load_movielens_df
 from lenskit.metrics import quick_measure_model
 from lenskit.testing import BasicComponentTests, ScorerTests
@@ -37,6 +37,12 @@ class TestExplicitALS(BasicComponentTests, ScorerTests):
         assert np.all(copy.item_embeddings == orig.item_embeddings)
         assert np.all(copy.items.index == orig.items.index)
         assert np.all(copy.users.index == orig.users.index)
+
+
+def test_als_config():
+    cfg = BiasedMFConfig(embedding_size_exp=10, epochs=5)
+    assert cfg.embedding_size == 1024
+    assert cfg.epochs == 5
 
 
 def test_als_basic_build():

--- a/tests/models/test_als_implicit.py
+++ b/tests/models/test_als_implicit.py
@@ -40,7 +40,7 @@ class TestImplicitALS(BasicComponentTests, ScorerTests):
 
 def test_config_defaults():
     cfg = ImplicitMFConfig()
-    assert cfg.embedding_size == 50
+    assert cfg.embedding_size == 64
 
 
 def test_config_es_alias():


### PR DESCRIPTION
This updates the default embedding size for all embedding-based models to 64, so we have power-of-2 models.