### PR TITLE
Make RecQuery keyword-only and add query time

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -82,6 +82,8 @@ Breaking Changes
   :class:`~lenskit.basic.TrainingItemsCandidateSelector` (:issue:`935`).
 - Several input types to batch inference are no longer supported, to reduce
   ambiguity and implicit behavior (:issue:`958`, :pr:`1074`).
+- Revised :class:`~lenskit.data.RecQuery` to only accept keyword arguments, and
+  removed the legacy ``user_items`` attribute.
 
 .. _prefix.dev: https://prefix.dev/channels/lenskit/
 

--- a/src/lenskit/data/_query.py
+++ b/src/lenskit/data/_query.py
@@ -30,12 +30,16 @@ Types that can be converted to a query by :meth:`RecQuery.create`.
 """
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RecQuery:
     """
     Representation of a the data available for a recommendation query.  This is
     generally the available inputs for a recommendation request *except* the set
     of candidate items.
+
+    .. versionchanged:: 2026.1
+
+        Made arguments keyword-only, and removed the historical ``user_items`` attribute.
 
     .. todo::
 
@@ -48,6 +52,14 @@ class RecQuery:
 
     Stability:
         Caller
+    """
+
+    query_id: ID | tuple[ID, ...] | None = None
+    """
+    An identifier for this query.
+
+    Query identifiers are used for things like mapping batch recommendation
+    outputs to their inputs.
     """
 
     user_id: ID | None = None
@@ -81,14 +93,6 @@ class RecQuery:
     query_source: QueryItemSource | set[QueryItemSource] | None = None
     """
     The list of items to return from :meth:`query_items`.
-    """
-
-    query_id: ID | tuple[ID, ...] | None = None
-    """
-    An identifier for this query.
-
-    Query identifiers are used for things like mapping batch recommendation
-    outputs to their inputs.
     """
 
     @classmethod

--- a/src/lenskit/data/_query.py
+++ b/src/lenskit/data/_query.py
@@ -12,6 +12,7 @@ Recommendation queries.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Literal
 
 import numpy as np
@@ -60,6 +61,17 @@ class RecQuery:
 
     Query identifiers are used for things like mapping batch recommendation
     outputs to their inputs.
+    """
+
+    query_time: datetime | None = None
+    """
+    The time at which the query is issued.
+
+    .. note::
+
+        No LensKit models or data processing code currently makes use of this,
+        but it is included for to support future time-aware modeling and replays
+        of historical data.
     """
 
     user_id: ID | None = None

--- a/tests/basic/test_candidates.py
+++ b/tests/basic/test_candidates.py
@@ -55,7 +55,7 @@ def test_training_selector_session(ml_ds: Dataset):
     row = ml_ds.user_row(100)
     session = ItemList(item_nums=np.arange(0, 10, 2), vocabulary=ml_ds.items)
     assert row is not None
-    cands = sel(query=RecQuery(100, history_items=row, session_items=session))
+    cands = sel(query=RecQuery(user_id=100, history_items=row, session_items=session))
 
     assert len(cands) <= ml_ds.item_count
     assert len(cands) == len(set(ml_ds.items.ids()) - set(session.ids()))
@@ -68,7 +68,7 @@ def test_training_selector_multi(ml_ds: Dataset):
     row = ml_ds.user_row(100)
     session = ItemList(item_nums=np.arange(0, 10, 2), vocabulary=ml_ds.items)
     assert row is not None
-    cands = sel(query=RecQuery(100, history_items=row, session_items=session))
+    cands = sel(query=RecQuery(user_id=100, history_items=row, session_items=session))
 
     assert len(cands) <= ml_ds.item_count
     assert len(cands) == len(set(ml_ds.items.ids()) - set(session.ids()) - set(row.ids()))

--- a/tests/basic/test_history.py
+++ b/tests/basic/test_history.py
@@ -45,7 +45,7 @@ def test_lookup_no_override(ml_ds):
 
     user = ml_ds.users.id(100)
     ds_row = ml_ds.user_row(user)
-    query = RecQuery(user, ds_row[:-2])
+    query = RecQuery(user_id=user, history_items=ds_row[:-2])
     query = lookup(query)
 
     assert isinstance(query, RecQuery)

--- a/tests/models/test_als_explicit.py
+++ b/tests/models/test_als_explicit.py
@@ -88,7 +88,7 @@ def test_als_predict_basic_for_new_ratings():
     assert algo.bias is not None
     assert algo.bias.global_bias == approx(simple_df.rating.mean())
 
-    query = RecQuery(15, ItemList(item_ids=[1, 2], rating=[4.0, 5.0]))
+    query = RecQuery(user_id=15, history_items=ItemList(item_ids=[1, 2], rating=[4.0, 5.0]))
     preds = algo(query, items=ItemList([3]))
 
     assert len(preds) == 1
@@ -110,7 +110,7 @@ def test_als_predict_basic_for_new_user_with_new_ratings():
     preds = preds.scores("pandas", index="ids")
     assert preds is not None
 
-    query = RecQuery(-1, ItemList(item_ids=[1, 2], rating=[4.0, 5.0]))
+    query = RecQuery(user_id=-1, history_items=ItemList(item_ids=[1, 2], rating=[4.0, 5.0]))
 
     new_preds = algo(query=query, items=ItemList([i]))
     new_preds = new_preds.scores("pandas", index="ids")
@@ -143,7 +143,7 @@ def test_als_predict_for_new_users_with_new_ratings(rng, ml_ds: Dataset):
 
         _log.debug("user_features from fit: " + str(algo.user_embeddings[algo.users.number(u), :]))
 
-        query = RecQuery(-1, user_data)
+        query = RecQuery(user_id=-1, history_items=user_data)
         new_preds = algo(query=query, items=ItemList(items))
         assert np.all(new_preds.ids() == items)
 
@@ -208,7 +208,7 @@ def test_als_predict_no_user_features_basic(rng: np.random.Generator, ml_ds: Dat
 
     _log.debug("user_features from fit: " + str(algo.user_embeddings[algo.users.number(u), :]))
 
-    query = RecQuery(-1, user_data)
+    query = RecQuery(user_id=-1, history_items=user_data)
     new_preds = algo_no_user_features(query, items=ItemList(items))
 
     _log.debug("preds: " + str(preds.scores()))

--- a/tests/models/test_als_implicit.py
+++ b/tests/models/test_als_implicit.py
@@ -115,7 +115,7 @@ def test_als_predict_basic_for_new_ratings():
     algo = ImplicitMFScorer(features=20, epochs=10)
     algo.train(simple_ds)
 
-    query = RecQuery(15, ItemList([1, 2]))
+    query = RecQuery(user_id=15, history_items=ItemList([1, 2]))
     preds = algo(query, ItemList([3]))
 
     assert len(preds) == 1
@@ -141,7 +141,7 @@ def test_als_predict_basic_for_new_user_with_new_ratings():
     preds = preds.scores("pandas", index="ids")
     assert preds is not None
 
-    query = RecQuery(1, ItemList([1, 2], rating=[4.0, 5.0]))
+    query = RecQuery(user_id=1, history_items=ItemList([1, 2], rating=[4.0, 5.0]))
     new_preds = algo(query, ItemList([i]))
     new_preds = new_preds.scores("pandas", index="ids")
     assert new_preds is not None
@@ -195,7 +195,7 @@ def test_als_predict_for_new_users_with_new_ratings(rng: np.random.Generator, ml
 
         _log.debug("training data reconstruction:\n%s", nr_info)
 
-        query = RecQuery(-1, user_data)
+        query = RecQuery(history_items=user_data)
         new_preds = algo(query, items)
         new_preds = new_preds.scores("pandas", index="ids")
         assert new_preds is not None
@@ -241,7 +241,7 @@ def test_als_recs_topn_for_new_users_with_new_ratings(
         _log.debug("user_features from fit: " + str(algo.user_embeddings[upos, :]))
 
         # get the user's rating series
-        query = RecQuery(-1, user_data)
+        query = RecQuery(history_items=user_data)
 
         new_recs = pipe.run("recommender", query=query)
         assert isinstance(new_recs, ItemList)
@@ -303,7 +303,7 @@ def test_als_predict_no_user_features_basic(ml_ratings: pd.DataFrame, ml_ds: Dat
 
     algo_no_user_features = ImplicitMFScorer(features=5, epochs=10, user_embeddings=False)
     algo_no_user_features.train(ml_ds)
-    query = RecQuery(u, user_data)
+    query = RecQuery(user_id=u, history_items=user_data)
     preds_no_user_features = algo_no_user_features(query, ItemList(items))
     preds_no_user_features = preds_no_user_features.scores("pandas", index="ids")
     assert preds_no_user_features is not None

--- a/tests/models/test_knn_user_user.py
+++ b/tests/models/test_knn_user_user.py
@@ -158,7 +158,7 @@ def test_uu_predict_live_ratings(ml_ratings):
 
     ratings = ItemList.from_df(ml_ratings[ml_ratings.user_id == 4][["item_id", "rating"]])
 
-    query = RecQuery(20381, ratings)
+    query = RecQuery(user_id=20381, history_items=ratings)
     preds = algo(
         query=query,
         items=ItemList([1016, 2091]),

--- a/tests/pipeline/test_types.py
+++ b/tests/pipeline/test_types.py
@@ -223,6 +223,6 @@ def test_query_subtype():
 
 
 def test_query_valid():
-    query = RecQuery(47)
+    query = RecQuery(user_id=47)
     assert is_compatible_data(query, RecQuery)
     assert is_compatible_data(query, QueryInput)


### PR DESCRIPTION
This updates `RecQuery` to be keyword-only for clarity, and adds the `query_time` option.

Closes #955.