### PR TITLE
Add .list() and .value() methods to entity attributes

### DIFF
--- a/src/accel/indirect/hashing/content_string.rs
+++ b/src/accel/indirect/hashing/content_string.rs
@@ -10,8 +10,10 @@ use arrow::array::{
     make_array, Array, ArrayData, AsArray, GenericStringArray, OffsetSizeTrait, StringBuilder,
     StringViewArray,
 };
+use arrow::compute::cast;
 use arrow::pyarrow::PyArrowType;
 use arrow_schema::DataType;
+use log::*;
 use pyo3::exceptions::PyTypeError;
 use pyo3::types::PyAnyMethods;
 use rustc_hash::FxHasher;
@@ -71,10 +73,12 @@ impl<OS: OffsetSizeTrait> IndirectHashContent for StringContentArray<OS> {
                 DataType::Utf8View => Box::new(arr.as_string_view().clone()),
                 DataType::LargeUtf8 => Box::new(arr.as_string::<i64>().clone()),
                 t => {
-                    return Err(PyTypeError::new_err(format!(
-                        "unsupported array type {:?}",
-                        t
-                    )))
+                    trace!("converting search array from {}", t);
+                    let arr = cast(&arr, &DataType::Utf8)
+                        .map_err(|e| PyTypeError::new_err(format!("error casting arrays: {}", e)))?
+                        .as_string::<i32>()
+                        .clone();
+                    Box::new(arr)
                 }
             }
         } else {

--- a/src/lenskit/data/_attributes.py
+++ b/src/lenskit/data/_attributes.py
@@ -190,6 +190,22 @@ class EntityAttribute(ABC):
         """
         return self._spec.layout == AttrLayout.SPARSE
 
+    def value(self) -> Any:
+        """
+        If the attribute is for a single entity, get its value as a Python object.
+        """
+        n = len(self)
+        if n == 1:
+            return self.list()[0]
+        else:
+            raise ValueError(f"value() not defined for {n} values")
+
+    def list(self) -> list[Any]:
+        """
+        Get the attribute values as a Python list.
+        """
+        return self.arrow().to_pylist()
+
     def pandas(
         self, *, missing: Literal["null", "omit"] = "null"
     ) -> pd.Series | pd.DataFrame:  # pragma: nocover

--- a/src/lenskit/data/_items.py
+++ b/src/lenskit/data/_items.py
@@ -1140,6 +1140,9 @@ class ItemList:
     def __len__(self):
         return self._len
 
+    def __bool__(self):
+        return self._len > 0
+
     def __getitem__(self, sel: ILIndexer) -> ItemList:
         """
         Subset the item list.

--- a/src/lenskit/data/_vocab.py
+++ b/src/lenskit/data/_vocab.py
@@ -167,7 +167,7 @@ class Vocabulary:
         if pa.types.is_null(self._array.type):
             nums = pa.nulls(len(terms), type=pa.int32())
         else:
-            term_arr = pa.array(terms, type=self._array.type)  # type: ignore
+            term_arr = pa.array(terms)  # type: ignore
             nums = self._index.get_indexes(term_arr)  # type: ignore
 
         trace(self._log, "resolved %d IDs, %d invalid", len(terms), nums.null_count)

--- a/tests/data/test_attribute.py
+++ b/tests/data/test_attribute.py
@@ -1,0 +1,40 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2026 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+
+from pytest import raises
+
+from lenskit.data import Dataset, DatasetBuilder
+
+
+def test_attribute_single_value():
+    items = pd.DataFrame({"item_id": [42], "name": ["HACKEM MUCHE"]})
+    dsb = DatasetBuilder()
+    dsb.add_entities("item", items)
+    data = dsb.build()
+    assert data.item_count == 1
+
+    assert data.entities("item").attribute("name").value() == "HACKEM MUCHE"
+    assert data.entities("item").attribute("name").list() == ["HACKEM MUCHE"]
+
+
+def test_attribute_pydata():
+    items = pd.DataFrame({"item_id": [42, 67], "name": ["HACKEM MUCHE", "READ ME"]})
+    dsb = DatasetBuilder()
+    dsb.add_entities("item", items)
+    data = dsb.build()
+    assert data.item_count == 2
+
+    assert data.entities("item").attribute("name").list() == ["HACKEM MUCHE", "READ ME"]
+    assert data.entities("item").select(ids=[67]).attribute("name").list() == ["READ ME"]
+    assert data.entities("item").select(ids=[42]).attribute("name").arrow().to_pylist() == [
+        "HACKEM MUCHE"
+    ]
+
+    with raises(ValueError):
+        assert data.entities("item").attribute("name").value()
+    assert data.entities("item").select(ids=[42]).attribute("name").value() == "HACKEM MUCHE"


### PR DESCRIPTION
This adds `.list()` and `.value()` methods to entity attributes, to improve convenience of easy access.

Also fixes some type-casting bugs with vocabulary ID types.