### PR TITLE
Support parameterized pipeline input types

### DIFF
--- a/src/lenskit/pipeline/_builder.py
+++ b/src/lenskit/pipeline/_builder.py
@@ -17,8 +17,8 @@ from copy import deepcopy
 from graphlib import CycleError, TopologicalSorter
 from os import PathLike
 from pathlib import Path
-from types import UnionType
-from typing import TypeAliasType, Union
+from types import GenericAlias, UnionType
+from typing import TypeAliasType, Union, get_origin
 from uuid import NAMESPACE_URL, uuid5
 
 from typing_extensions import Any, Literal, TypeForm, cast, overload
@@ -227,6 +227,8 @@ class PipelineBuilder:
                 tys |= set(typing.get_args(t))
             elif isinstance(t, type):
                 tys.add(t)
+            elif isinstance(t, GenericAlias):
+                tys.add(get_origin(t))
             else:
                 raise TypeError(f"unsupported type form: {t}")
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -54,6 +54,26 @@ def test_create_input_type_alias():
     assert len(pipe.nodes()) == 1
     assert pipe.node("user") == src
 
+    cfg = pipe.config
+    assert cfg.inputs[0].types == {"int", "str"}
+
+
+def test_create_input_list():
+    "create an input node"
+    pipe = PipelineBuilder()
+    src = pipe.create_input("features", list[str])
+    assert_type(src, Node[list[str]])
+    assert isinstance(src, InputNode)
+    assert src.name == "features"
+    assert src.type == list  # noqa: E721
+    # assert src.type == list[str]
+
+    assert len(pipe.nodes()) == 1
+    assert pipe.node("features") is src
+
+    cfg = pipe.build_config()
+    assert cfg.inputs[0].types == {"list"}
+
 
 def test_lookup_optional():
     "lookup a node without failing"


### PR DESCRIPTION
This adds initial support (through generic erasure) for parameterized pipeline input types like `list[str]`, needed for POPROX.

Closes #1101.