### PR TITLE
Support Arrow tables as inputs for adding item attributes

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -19,6 +19,8 @@ Third release in 2026, with more feature updates and bug fixes.
 
 - Fixed graded NDCG when input item lists are empty and do not have the grade
   field (:issue:`1095`, :pr:`1096`).
+- Added support for PyArrow tables to
+  :meth:`lenksit.data.DatsetBuilder.add_scalar_attribute` (:pr:`1109`).
 
 .. _2026.2.0:
 

--- a/src/lenskit/data/_builder.py
+++ b/src/lenskit/data/_builder.py
@@ -817,6 +817,11 @@ class DatasetBuilder:
                     entities = entities[id_col].values
                 else:
                     entities = entities.index.values
+            elif isinstance(entities, pa.Table):
+                values = entities.column(name)
+                entities = entities.column(id_col)
+            else:  # pragma: nocover
+                raise TypeError(f"cannot extract values from {type(entities)}")
 
         e_tbl = self._tables[cls]
         if e_tbl is None:  # pragma: nocover

--- a/tests/data/test_builder_attributes.py
+++ b/tests/data/test_builder_attributes.py
@@ -11,7 +11,7 @@ import pyarrow as pa
 import torch
 from scipy.sparse import csr_array
 
-from pytest import approx, mark, raises, skip, warns
+from pytest import approx, fixture, mark, raises, skip, warns
 
 from lenskit.data import DatasetBuilder, from_interactions_df
 from lenskit.data.matrix import SparseRowArray
@@ -22,38 +22,18 @@ from lenskit.testing import ml_test_dir
 FRUITS = ["apple", "banana", "orange", "lemon", "mango"]
 
 
-def test_item_scalar_series():
-    dsb = DatasetBuilder()
-
+@fixture(scope="function")
+def items_df():
     items = pd.read_csv(ml_test_dir / "movies.csv")
     items = items.rename(columns={"movieId": "item_id"}).set_index("item_id")
-
-    dsb.add_entities("item", items.index.values)
-    dsb.add_scalar_attribute("item", "title", items["title"])
-    sa = dsb.schema.entities["item"].attributes["title"]
-    assert sa.layout == AttrLayout.SCALAR
-
-    ds = dsb.build()
-
-    df = ds.entities("item").pandas().set_index("item_id")
-    assert "title" in df.columns
-    ds_ts, orig_ts = df["title"].align(items["title"])
-    assert np.all(ds_ts == orig_ts)
-
-    assert ds.entities("item").attribute("title").is_scalar
-    df = ds.entities("item").attribute("title").pandas()
-    assert isinstance(df, pd.Series)
-    assert np.all(df == items["title"])
+    yield items
 
 
-def test_item_scalar_df():
+def test_item_scalar_series(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"})
-
-    dsb.add_entities("item", items["item_id"].values)
-    dsb.add_scalar_attribute("item", "title", items[["item_id", "title"]])
+    dsb.add_entities("item", items_df.index.values)
+    dsb.add_scalar_attribute("item", "title", items_df["title"])
     sa = dsb.schema.entities["item"].attributes["title"]
     assert sa.layout == AttrLayout.SCALAR
 
@@ -61,24 +41,22 @@ def test_item_scalar_df():
 
     df = ds.entities("item").pandas().set_index("item_id")
     assert "title" in df.columns
-    ds_ts, orig_ts = df["title"].align(items.set_index("item_id")["title"])
+    ds_ts, orig_ts = df["title"].align(items_df["title"])
     assert np.all(ds_ts == orig_ts)
 
     assert ds.entities("item").attribute("title").is_scalar
     df = ds.entities("item").attribute("title").pandas()
     assert isinstance(df, pd.Series)
-    ds_ts, orig_ts = df.align(items.set_index("item_id")["title"])
-    assert np.all(ds_ts == orig_ts)
+    assert np.all(df == items_df["title"])
 
 
-def test_item_scalar_array():
+def test_item_scalar_df(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"})
+    items_df = items_df.reset_index()
 
-    dsb.add_entities("item", items["item_id"].values)
-    dsb.add_scalar_attribute("item", "title", items["item_id"], items["title"])
+    dsb.add_entities("item", items_df["item_id"].values)
+    dsb.add_scalar_attribute("item", "title", items_df[["item_id", "title"]])
     sa = dsb.schema.entities["item"].attributes["title"]
     assert sa.layout == AttrLayout.SCALAR
 
@@ -86,24 +64,23 @@ def test_item_scalar_array():
 
     df = ds.entities("item").pandas().set_index("item_id")
     assert "title" in df.columns
-    ds_ts, orig_ts = df["title"].align(items.set_index("item_id")["title"])
+    ds_ts, orig_ts = df["title"].align(items_df.set_index("item_id")["title"])
     assert np.all(ds_ts == orig_ts)
 
     assert ds.entities("item").attribute("title").is_scalar
     df = ds.entities("item").attribute("title").pandas()
     assert isinstance(df, pd.Series)
-    ds_ts, orig_ts = df.align(items.set_index("item_id")["title"])
+    ds_ts, orig_ts = df.align(items_df.set_index("item_id")["title"])
     assert np.all(ds_ts == orig_ts)
 
 
-def test_item_scalar_series_arrays():
+def test_item_scalar_array(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"})
+    items_df = items_df.reset_index()
 
-    dsb.add_entities("item", items["item_id"].values)
-    dsb.add_scalar_attribute("item", "title", items["item_id"], items["title"])
+    dsb.add_entities("item", items_df["item_id"].values)
+    dsb.add_scalar_attribute("item", "title", items_df["item_id"], items_df["title"])
     sa = dsb.schema.entities["item"].attributes["title"]
     assert sa.layout == AttrLayout.SCALAR
 
@@ -111,13 +88,37 @@ def test_item_scalar_series_arrays():
 
     df = ds.entities("item").pandas().set_index("item_id")
     assert "title" in df.columns
-    ds_ts, orig_ts = df["title"].align(items.set_index("item_id")["title"])
+    ds_ts, orig_ts = df["title"].align(items_df.set_index("item_id")["title"])
     assert np.all(ds_ts == orig_ts)
 
     assert ds.entities("item").attribute("title").is_scalar
     df = ds.entities("item").attribute("title").pandas()
     assert isinstance(df, pd.Series)
-    ds_ts, orig_ts = df.align(items.set_index("item_id")["title"])
+    ds_ts, orig_ts = df.align(items_df.set_index("item_id")["title"])
+    assert np.all(ds_ts == orig_ts)
+
+
+def test_item_scalar_series_arrays(items_df: pd.DataFrame):
+    dsb = DatasetBuilder()
+
+    items_df = items_df.reset_index()
+
+    dsb.add_entities("item", items_df["item_id"].values)
+    dsb.add_scalar_attribute("item", "title", items_df["item_id"], items_df["title"])
+    sa = dsb.schema.entities["item"].attributes["title"]
+    assert sa.layout == AttrLayout.SCALAR
+
+    ds = dsb.build()
+
+    df = ds.entities("item").pandas().set_index("item_id")
+    assert "title" in df.columns
+    ds_ts, orig_ts = df["title"].align(items_df.set_index("item_id")["title"])
+    assert np.all(ds_ts == orig_ts)
+
+    assert ds.entities("item").attribute("title").is_scalar
+    df = ds.entities("item").attribute("title").pandas()
+    assert isinstance(df, pd.Series)
+    ds_ts, orig_ts = df.align(items_df.set_index("item_id")["title"])
     assert np.all(ds_ts == orig_ts)
 
 
@@ -157,13 +158,10 @@ def test_scalar_attribute_alignment():
 
 
 @mark.xfail(reason="attributes at insert time not yet implemented")
-def test_item_insert_scalar_df():
+def test_item_insert_scalar_df(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"})
-
-    dsb.add_entities("item", items[["item_id", "title"]])
+    dsb.add_entities("item", items_df[["item_id", "title"]])
     sa = dsb.schema.entities["item"].attributes["title"]
     assert sa.layout == AttrLayout.SCALAR
 
@@ -171,24 +169,21 @@ def test_item_insert_scalar_df():
 
     df = ds.entities("item").pandas().set_index("item_id")
     assert "title" in df.columns
-    ds_ts, orig_ts = df["title"].align(items.set_index("item_id")["title"])
+    ds_ts, orig_ts = df["title"].align(items_df.set_index("item_id")["title"])
     assert np.all(ds_ts == orig_ts)
 
     assert ds.entities("item").attribute("title").is_scalar
     df = ds.entities("item").attribute("title").pandas()
     assert isinstance(df, pd.Series)
-    ds_ts, orig_ts = df.align(items.set_index("item_id")["title"])
+    ds_ts, orig_ts = df.align(items_df.set_index("item_id")["title"])
     assert np.all(ds_ts == orig_ts)
 
 
 @mark.xfail(reason="attributes at insert time not yet implemented")
-def test_item_update_titles():
+def test_item_update_titles(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"})
-
-    dsb.add_entities("item", items)
+    dsb.add_entities("item", items_df)
 
     dsb.add_scalar_attribute(
         "item", "title", pd.Series({2: "Board Game Adventure", 110: "Briarheart"})
@@ -201,16 +196,13 @@ def test_item_update_titles():
     assert df.loc[110, "title"] == "Briarheart"
 
 
-def test_item_list_series():
+def test_item_list_series(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"}).set_index("item_id")
-
-    genres = items["genres"].str.split("|")
+    genres = items_df["genres"].str.split("|")
     g_counts = genres.apply(len)
 
-    dsb.add_entities("item", items.index.values)
+    dsb.add_entities("item", items_df.index.values)
     dsb.add_list_attribute("item", "genres", genres)
     va = dsb.schema.entities["item"].attributes["genres"]
     assert va.layout == AttrLayout.LIST
@@ -238,17 +230,14 @@ def test_item_list_series():
     assert np.all(gs == gs2)
 
 
-def test_item_list_random():
+def test_item_list_random(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"}).set_index("item_id")
-
-    genres = items["genres"].str.split("|")
+    genres = items_df["genres"].str.split("|")
 
     genres = genres.sample(n=200)
 
-    dsb.add_entities("item", items.index.values)
+    dsb.add_entities("item", items_df.index.values)
     dsb.add_list_attribute("item", "genres", genres.index.values, genres.tolist())
 
     va = dsb.schema.entities["item"].attributes["genres"]
@@ -264,16 +253,16 @@ def test_item_list_random():
     assert np.all(gcomp.apply(len) == gscomp.apply(len))
 
 
-def test_item_list_df():
+def test_item_list_df(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"})
-    items["genres"] = items["genres"].str.split("|")
-    g_counts = items.set_index("item_id")["genres"].apply(len)
+    items_df = items_df.reset_index()
 
-    dsb.add_entities("item", items["item_id"].values)
-    dsb.add_list_attribute("item", "genres", items[["item_id", "genres"]])
+    items_df["genres"] = items_df["genres"].str.split("|")
+    g_counts = items_df.set_index("item_id")["genres"].apply(len)
+
+    dsb.add_entities("item", items_df["item_id"].values)
+    dsb.add_list_attribute("item", "genres", items_df[["item_id", "genres"]])
     va = dsb.schema.entities["item"].attributes["genres"]
     assert va.layout == AttrLayout.LIST
 
@@ -283,7 +272,7 @@ def test_item_list_df():
     if isinstance(arr, pa.ChunkedArray):
         arr = arr.combine_chunks()
     assert isinstance(arr, pa.ListArray)
-    assert len(arr) == len(items)
+    assert len(arr) == len(items_df)
     assert np.all(
         arr.value_lengths().fill_null(0).to_numpy()
         == g_counts.reindex(ds.entities("item").ids()).values
@@ -291,14 +280,12 @@ def test_item_list_df():
 
 
 @mark.xfail(reason="attributes at insert time not yet implemented")
-def test_item_initial_list_df():
+def test_item_initial_list_df(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"})
-    items["genres"] = items["genres"].str.split("|")
+    items_df["genres"] = items_df["genres"].str.split("|")
 
-    dsb.add_entities("item", items)
+    dsb.add_entities("item", items_df)
     va = dsb.schema.entities["item"].attributes["genres"]
     assert va.layout == AttrLayout.LIST
 
@@ -312,7 +299,7 @@ def test_item_initial_list_df():
 
     arr = ds.entities("item").attribute("genres").arrow()
     assert isinstance(arr, pa.ListArray)
-    assert len(arr) == len(items)
+    assert len(arr) == len(items_df)
 
 
 def test_item_vector(rng: np.random.Generator, ml_ratings: pd.DataFrame):
@@ -446,33 +433,27 @@ def test_item_vector_attr_subset(rng: np.random.Generator, ml_ratings: pd.DataFr
     assert df.shape == (np.sum(q_known), 5)
 
 
-def test_add_invalid_attribute_name():
+def test_add_invalid_attribute_name(items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    items = pd.read_csv(ml_test_dir / "movies.csv")
-    items = items.rename(columns={"movieId": "item_id"}).set_index("item_id")
-
-    dsb.add_entities("item", items.index.values)
+    dsb.add_entities("item", items_df.index.values)
 
     invalid_attributes = ["_title", "title_id"]
     for attribute_name in invalid_attributes:
         with raises(ValueError, match="invalid"):
-            dsb.add_scalar_attribute("item", attribute_name, items["title"])
+            dsb.add_scalar_attribute("item", attribute_name, items_df["title"])
 
 
-def test_item_sparse_attribute(rng: np.random.Generator, ml_ratings: pd.DataFrame):
+def test_item_sparse_attribute(rng: np.random.Generator, items_df: pd.DataFrame):
     dsb = DatasetBuilder()
 
-    movies = pd.read_csv(ml_test_dir / "movies.csv")
-    movies = movies.rename(columns={"movieId": "item_id"}).set_index("item_id")
+    dsb.add_entities("item", items_df.index)
 
-    dsb.add_entities("item", movies.index)
-
-    genre_lists = movies["genres"].str.split("|")
+    genre_lists = items_df["genres"].str.split("|")
     genres = genre_lists.reset_index().explode("genres", ignore_index=True)
     gindex = pd.Index(np.unique(genres["genres"]))
 
-    ids = movies.index.values.copy()
+    ids = items_df.index.values.copy()
     rng.shuffle(ids)
     idx2 = pd.Index(ids)
     ig_rows = idx2.get_indexer_for(genres["item_id"])
@@ -506,7 +487,7 @@ def test_item_sparse_attribute(rng: np.random.Generator, ml_ratings: pd.DataFram
     arr = ds.entities("item").attribute("genres").arrow()
     assert isinstance(arr, SparseRowArray)
 
-    for movie in rng.choice(movies.index.values, 50, replace=False):
+    for movie in rng.choice(items_df.index.values, 50, replace=False):
         row = ds.items.number(movie)
         start = mat.indptr[row]
         end = mat.indptr[row + 1]

--- a/tests/data/test_builder_attributes.py
+++ b/tests/data/test_builder_attributes.py
@@ -494,3 +494,29 @@ def test_item_sparse_attribute(rng: np.random.Generator, items_df: pd.DataFrame)
         cols = mat.indices[start:end]
         mgs = gindex[cols].tolist()
         assert mgs == genre_lists.loc[movie]
+
+
+def test_item_table_attribute(items_df: pd.DataFrame):
+    dsb = DatasetBuilder()
+
+    dsb.add_entities("item", items_df.index.values)
+
+    tbl = pa.Table.from_pandas(items_df.reset_index())
+    print(tbl)
+    dsb.add_scalar_attribute("item", "title", tbl)
+
+    sa = dsb.schema.entities["item"].attributes["title"]
+    assert sa.layout == AttrLayout.SCALAR
+
+    ds = dsb.build()
+
+    df = ds.entities("item").pandas().set_index("item_id")
+    assert "title" in df.columns
+    ds_ts, orig_ts = df["title"].align(items_df["title"])
+    assert np.all(ds_ts == orig_ts)
+
+    assert ds.entities("item").attribute("title").is_scalar
+    df = ds.entities("item").attribute("title").pandas()
+    assert isinstance(df, pd.Series)
+    ds_ts, orig_ts = df.align(items_df["title"])
+    assert np.all(ds_ts == orig_ts)


### PR DESCRIPTION
This updates `DatasetBuilder.add_scalar_attribute` to support loading attributes from PyArrow tables.