### PR TITLE
flexmf: rewrite misranked (for WARP) sampling loop

### DIFF
--- a/src/lenskit/flexmf/_implicit.py
+++ b/src/lenskit/flexmf/_implicit.py
@@ -14,6 +14,7 @@ import numpy as np
 import torch
 from pydantic import NonNegativeInt, PositiveFloat, PositiveInt, model_validator
 from torch.nn import functional as F
+from typing_extensions import override
 
 from lenskit.data import Dataset
 from lenskit.logging import get_logger
@@ -22,6 +23,7 @@ from ._base import FlexMFConfigBase, FlexMFScorerBase
 from ._model import FlexMFModel
 from ._training import FlexMFTrainerBase, FlexMFTrainingBatch, FlexMFTrainingData
 
+WARP_CAND_BATCH_SIZE = 10
 MAX_TRIES = 200
 ImplicitLoss: TypeAlias = Literal["logistic", "pairwise", "warp"]
 NegativeStrategy: TypeAlias = Literal["uniform", "popular", "misranked"]
@@ -290,60 +292,97 @@ class FlexMFImplicitTrainer(FlexMFTrainerBase[FlexMFImplicitScorer, FlexMFImplic
 
 
 class FlexMFWARPTrainer(FlexMFImplicitTrainer):
-    def scored_negatives(self, batch, users, pos_scores):
+    @override
+    def scored_negatives(
+        self, batch: FlexMFTrainingBatch, users: torch.Tensor, pos_scores: torch.Tensor
+    ):
         assert batch.data.interactions is not None
         assert isinstance(batch.users, np.ndarray)
+        bsize = len(users)
+        assert pos_scores.shape == (bsize, 1)
+        device = users.device
 
-        # start looking for misranked items
-        idx_range = torch.arange(len(users), device=users.device)
-        neg_scores = torch.full((len(users),), -math.inf, device=users.device)
-        neg_norms = torch.zeros(len(users), device=users.device)
+        # Pre-allocate an array of batch row indices to speed computation.
+        idx_range = torch.arange(len(users))
+        idx_dev = idx_range.to(device=users.device, non_blocking=True)
+
+        # Allocate tensors to store the final sampled negatives and their
+        # scores, and the number of tries we needed to find them.
+        neg_scores = torch.full((len(users),), -math.inf, device=device)
+        neg_norms = torch.zeros(len(users), device=device)
         neg_counts = torch.zeros(len(users))
-        neg_items = torch.empty(len(users), dtype=torch.int32, device=users.device)
-        needed = neg_counts <= 0
-        tries = 0
-        while torch.any(needed):
-            bi = tries % 10
-            tries += 1
-            if tries > MAX_TRIES:
-                self.log.debug("exceed MAX_TRIES for %d items", np.sum(needed.numpy()))
-                continue
+        neg_items = torch.empty(len(users), dtype=torch.int32, device=device)
 
-            n_dev = needed.to(users.device)
-            n_users = batch.users[needed]
+        # The main logic is to loop, sampling candidate negatives and testing
+        # them for misranks. MAX_TRIES is the maximum number of candidate
+        # negaties we will consider before giving up. We sample and score
+        # candidate negatives in batches, of size WARP_CAND_BATCH_SIZE, to
+        # reduce the CPU/GPU communication overhead.
+
+        # Data structures to track the *candidate* batch - the set of items
+        # we've found based on the users who needed negatives at the start of
+        # the candidate batch. These will not be assigned until the first time
+        # in the loop.
+        cand_mask: torch.Tensor  # training batch mask for rows w/ candidates
+        cand_range: torch.Tensor  # index range of candidate rows
+        cand_items: torch.Tensor  # candidate item numbers
+        cand_scores: torch.Tensor  # candidate item scores
+        cand_norms: torch.Tensor  # candidate item norms
+
+        # Count the number of attempted negatives.
+        tries = 0
+        # Track which training batch rows we still need negatives for.
+        needed = torch.full((bsize,), True, dtype=torch.bool)
+
+        # We will keep looping as long as some rows need negatives, and we
+        # haven't exceeded the attempt budget.
+        while tries < MAX_TRIES and torch.any(needed):
+            # Compute the index within the current batch.
+            bi = tries % WARP_CAND_BATCH_SIZE
+            tries += 1
+
+            n_dev = needed.to(device, non_blocking=True)
             if bi == 0:
-                neg_cand = torch.as_tensor(
+                # Set up candidates based on rows that need items at the start of the batch.
+                cand_mask = needed
+                cand_size = torch.sum(needed).item()
+                cand_range = torch.arange(cand_size).to(device=device, non_blocking=True)
+                cand_items = torch.as_tensor(
                     batch.data.interactions.sample_negatives(
-                        n_users,
-                        n=10,
+                        batch.users[needed],
+                        n=WARP_CAND_BATCH_SIZE,
                         weighting="uniform",
                         rng=self.rng,
                     )
-                ).to(users.device)
-                nc_scores, nc_norms = self.score(users[n_dev], neg_cand)
+                ).to(device, non_blocking=True)
+                cand_scores, cand_norms = self.score(users[n_dev], cand_items)
 
-            found = nc_scores[:, bi] > pos_scores[n_dev, 0]
-            f_idx = idx_range[n_dev][found]
-            neg_items[f_idx] = neg_cand[found, bi]
-            neg_scores[f_idx] = nc_scores[found, bi]
-            if nc_norms.shape:
-                neg_norms[f_idx] = nc_norms[found, bi]
+            # Which of the *candidate* rows represent needed negatives?
+            cand_needed = needed[cand_mask]
+            cn_dev = cand_needed.to(device=device, non_blocking=True)
 
-            nf = ~found
-            nf_idx = idx_range[n_dev][nf]
-            nf_big = nc_scores[nf, bi] > neg_scores[nf_idx]
-            nf_upd = nf_idx[nf_big]
-            # assert nf_big.shape == neg_cand.shape[:1], f"{nf_big.shape} != {neg_cand.shape}"
-            neg_items[nf_upd] = neg_cand[nf, bi][nf_big]
-            neg_scores[nf_upd] = nc_scores[nf, bi][nf_big]
-            if nc_norms.shape:
-                neg_norms[nf_upd] = nc_norms[nf, bi][nf_big]
+            # For any batch row still needing a negative, if we have a higher score,
+            # we've either found that negative, or we've found a better negative for
+            # when we give up. So update all the rows in ‘needed’ for which the candidate
+            # item score is higher.
+            act_better = cand_scores[cn_dev, bi] > neg_scores[n_dev]
+            act_cidx = cand_range[cn_dev][act_better]
+            # Compute the indices in the batch for these improvements.
+            upd_idx = idx_dev[n_dev][act_better]
+            # Apply the updates to the training batch working storage.
+            neg_counts[upd_idx] = tries
+            neg_items[upd_idx] = cand_items[act_cidx, bi]
+            neg_scores[upd_idx] = cand_scores[act_cidx, bi]
+            if cand_norms.shape:
+                neg_norms[upd_idx] = cand_norms[act_cidx, bi]
 
-            neg_counts[needed] += 1
+            # Now that we have the best negative so far, find the winners and
+            # remove don't update them in the next batch.
+            needed = neg_scores < pos_scores[:, 0]
 
-            needed = neg_counts <= 0
-
+        # Compute estimated ranks from the negative counts
         ranks = ((self.data.n_items - 1) / (neg_counts + 1)).to(torch.float64).detach()
+        # Used estimated ranks to compute sample weights for the minibatch
         # L(k) = sum i=1..k 1/i = harmonic k
         # approximate harmonic k with log
         weights = (
@@ -353,7 +392,8 @@ class FlexMFWARPTrainer(FlexMFImplicitTrainer):
             - 1 / (12 * ranks**2)
             + 1 / (120 * ranks**4)
         )
-        return neg_items, neg_scores.reshape(-1, 1), neg_norms, weights.to(pos_scores.device)
+        weights = weights.to(pos_scores.device, non_blocking=True)
+        return neg_items, neg_scores.reshape(-1, 1), neg_norms, weights
 
 
 def _loss_logistic(pos_pred, neg_pred, pos_weight, weights):

--- a/src/lenskit/flexmf/_implicit.py
+++ b/src/lenskit/flexmf/_implicit.py
@@ -333,6 +333,7 @@ class FlexMFWARPTrainer(FlexMFImplicitTrainer):
         tries = 0
         # Track which training batch rows we still need negatives for.
         needed = torch.full((bsize,), True, dtype=torch.bool)
+        n_dev = needed.to(device, non_blocking=True)
 
         # We will keep looping as long as some rows need negatives, and we
         # haven't exceeded the attempt budget.
@@ -341,7 +342,6 @@ class FlexMFWARPTrainer(FlexMFImplicitTrainer):
             bi = tries % WARP_CAND_BATCH_SIZE
             tries += 1
 
-            n_dev = needed.to(device, non_blocking=True)
             if bi == 0:
                 # Set up candidates based on rows that need items at the start of the batch.
                 cand_mask = needed
@@ -378,7 +378,8 @@ class FlexMFWARPTrainer(FlexMFImplicitTrainer):
 
             # Now that we have the best negative so far, find the winners and
             # remove don't update them in the next batch.
-            needed = neg_scores < pos_scores[:, 0]
+            n_dev = neg_scores < pos_scores[:, 0]
+            needed = n_dev.cpu()
 
         # Compute estimated ranks from the negative counts
         ranks = ((self.data.n_items - 1) / (neg_counts + 1)).to(torch.float64).detach()


### PR DESCRIPTION
The previous WARP sampling loop was incorrect - it did not correctly update the "needed" lists, and would abort the negative sampling loop too quickly.  It was difficult to figure out how to fix the bug in-place, so this rewrites the loop with more thorough comments to document how the selection loop and the batching logic works.

The problem was that the original loop determined which rows still needed items just from the number of candidates tried, which meant it aborted the loop after the first iteration and just became an expensive BPR.