### PR TITLE
Add TrainingOptions.torch_compilation_enabled and disable by default on free-threaded Python

### DIFF
--- a/src/lenskit/flexmf/_training.py
+++ b/src/lenskit/flexmf/_training.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import math
-import platform
 from abc import abstractmethod
 from collections.abc import Callable, Generator, Sequence
 from dataclasses import dataclass, field, replace
@@ -25,11 +24,6 @@ from lenskit.parallel.config import ensure_parallel_init
 from lenskit.training import ModelTrainer, TrainingOptions
 
 from ._model import FlexMFModel
-
-try:
-    from torch._dynamo.exc import TorchDynamoException
-except ImportError:
-    TorchDynamoException = None
 
 # hide base import to avoid circular imports
 if TYPE_CHECKING:
@@ -121,31 +115,19 @@ class FlexMFTrainerBase(ModelTrainer, Generic[Comp, Cfg]):
         self.component.model = self.model.to(self.device)
         self.model.train(True)
 
-        if options.env_flag("LK_TORCH_COMPILE", default=True):
-            if platform.system() not in ("Linux", "Darwin"):
-                _log.warn(
-                    "compiled models are only usable on Linux and macOS, using uncompiled model",
-                    err_code="LKW-TCOMP",
-                )
-            elif torch.__version__ < "2.8":
-                _log.warn(
-                    "compiled models require Torch >=2.8, using uncompiled model",
-                    err_code="LKW-TCOMP",
-                )
-            else:
-                _log.debug("compiling FlexMF model")
-                try:
-                    self._compiled_model = torch.compile(self.model)
-                except RuntimeError as e:
-                    (msg,) = e.args
-                    if msg.startswith("torch.compile"):
-                        _log.warn(
-                            "Torch compilation failed, using uncompiled model",
-                            exc_info=e,
-                            err_code="LKW-TCOMP",
-                        )
-                    else:
-                        raise e
+        if options.torch_compilation_enabled():
+            try:
+                self._compiled_model = torch.compile(self.model)
+            except RuntimeError as e:
+                (msg,) = e.args
+                if msg.startswith("torch.compile"):
+                    _log.warn(
+                        "Torch compilation failed, using uncompiled model",
+                        exc_info=e,
+                        err_code="LKW-TCOMP",
+                    )
+                else:
+                    raise e
 
         self.setup_optimizer()
 
@@ -168,7 +150,8 @@ class FlexMFTrainerBase(ModelTrainer, Generic[Comp, Cfg]):
         Invoke the model, using the compiled version if available.
         """
         if self._compiled_model is not None:
-            assert TorchDynamoException is not None
+            from torch.dynamo._exc import TorchDynamoException  # noqa: PLC2701
+
             try:
                 return self._compiled_model(*args, **kwargs)
             except TorchDynamoException as e:

--- a/src/lenskit/training.py
+++ b/src/lenskit/training.py
@@ -12,6 +12,7 @@ Interfaces and support for model training.
 from __future__ import annotations
 
 import os
+import platform
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -23,6 +24,7 @@ from typing_extensions import TypeVar
 
 from lenskit.data import Dataset, ItemList
 from lenskit.logging import get_logger, item_progress
+from lenskit.parallel import is_free_threaded
 from lenskit.pipeline._types import make_importable_path
 from lenskit.pipeline.components import Component
 from lenskit.random import RNGInput, random_generator
@@ -190,6 +192,40 @@ class TrainingOptions:
             return False
         else:
             raise ValueError(f"unrecognized boolean value {name}={val}")
+
+    def torch_compilation_enabled(self) -> bool:
+        """
+        Query whether models should attempt to use :func:`torch.compile`.
+        """
+        import torch
+
+        ft = is_free_threaded(require_active=True)
+        if ft:
+            # FIXME: re-enable when Triton supports free-threading.
+            _log.info("Disabling Torch compilation by default on free-threaded Python")
+
+        if not self.env_flag("LK_TORCH_COMPILE", default=ft):
+            _log.debug("Torch compilation not enabled")
+            return False
+
+        if platform.system() not in ("Linux", "Darwin"):
+            _log.warn(
+                "compiled models are only usable on Linux and macOS, using uncompiled model",
+                err_code="LKW-TCOMP",
+            )
+            return False
+
+        if torch.__version__ < "2.8":
+            _log.warn(
+                "compiled models require Torch >=2.8, using uncompiled model",
+                err_code="LKW-TCOMP",
+            )
+            return False
+
+        if ft:
+            _log.warn("Torch compilation currently disables free-threading")
+
+        return True
 
 
 @runtime_checkable


### PR DESCRIPTION
Triton currently does not support free-threaded Python, so importing it on free-threaded Python disables free-threading.

This adds `TrainingOptions.torch_compilation_enabled` to provide a single place for models to query whether Torch compilation should be enabled, disables it by default on free-threaded Python, and updates FlexMF to use this method.