### PR TITLE
Don't panic when ALS solve fails

### DIFF
--- a/src/accel/als/explicit.rs
+++ b/src/accel/als/explicit.rs
@@ -10,13 +10,14 @@ use arrow::{
 };
 use ndarray::{Array1, ArrayBase, ArrayView2, Axis, ViewRepr};
 use numpy::{Ix1, PyArray2, PyArrayMethods};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{exceptions::PyRuntimeError, prelude::*, IntoPyObjectExt};
 use rayon::prelude::*;
+use thiserror::Error;
 
 use rayon_cancel::CancelAdapter;
 
 use crate::{
-    als::solve::POSV,
+    als::solve::{SolveError, POSV},
     parallel::maybe_fuse,
     sparse::{CSRMatrix, CSR},
     tasks::{AccelTask, AccelTaskImpl, IterCancel},
@@ -63,17 +64,17 @@ impl AccelTaskImpl for ExplicitTrainTask {
         let adapter = CancelAdapter::new(iter);
         task.set_cancel(IterCancel::from_adapter(&adapter));
 
-        let frob: f32 = py.detach(move || {
-            adapter
+        let frob: PyResult<f32> = py.detach(move || {
+            Ok(adapter
                 .map(|(i, row)| {
-                    let f = train_row_solve(&self.solver, &self.matrix, i, row, &other, self.reg);
-                    f
+                    train_row_solve(&self.solver, &self.matrix, i, row, &other, self.reg)
                 })
-                .sum::<f32>()
-                .sqrt()
+                .try_reduce(|| 0.0f32, |v1, v2| Ok(v1 + v2))
+                .map_err(|e| PyRuntimeError::new_err(format!("ALS solve error: {}", e)))?
+                .sqrt())
         });
 
-        frob.into_bound_py_any(py)
+        frob?.into_bound_py_any(py)
     }
 }
 
@@ -84,13 +85,13 @@ fn train_row_solve(
     mut row_data: ArrayBase<ViewRepr<&mut f32>, Ix1>,
     other: &ArrayView2<f32>,
     reg: f32,
-) -> f32 {
+) -> Result<f32, SolveError> {
     let cols = matrix.row_cols(row_num);
     let vals = matrix.row_vals(row_num);
 
     if cols.len() == 0 {
         row_data.fill(0.0);
-        return 0.0;
+        return Ok(0.0);
     }
 
     let cols: Vec<_> = cols.iter().map(|c| *c as usize).collect();
@@ -110,10 +111,10 @@ fn train_row_solve(
     let v = mt.dot(&vals);
     assert_eq!(v.shape(), &[nd]);
 
-    let soln = solver.solve(&mut mtm, &v).expect("LAPACK error");
+    let soln = solver.solve(&mut mtm, &v)?;
 
     let deltas = &soln - &row_data;
     row_data.assign(&soln);
 
-    deltas.dot(&deltas)
+    Ok(deltas.dot(&deltas))
 }

--- a/src/accel/als/implicit.rs
+++ b/src/accel/als/implicit.rs
@@ -10,14 +10,14 @@ use arrow::{
 };
 use ndarray::{Array1, ArrayBase, ArrayView2, Axis, ViewRepr};
 use numpy::{Ix1, PyArray2, PyArrayMethods};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{exceptions::PyRuntimeError, prelude::*, IntoPyObjectExt};
 use rayon::prelude::*;
 
 use log::*;
 use rayon_cancel::CancelAdapter;
 
 use crate::{
-    als::solve::POSV,
+    als::solve::{SolveError, POSV},
     parallel::maybe_fuse,
     sparse::{CSRMatrix, CSR},
     tasks::{AccelTask, AccelTaskImpl, IterCancel},
@@ -72,17 +72,15 @@ impl AccelTaskImpl for ImplicitTrainTask {
         let adapter = CancelAdapter::new(iter);
         task.set_cancel(IterCancel::from_adapter(&adapter));
 
-        let frob = py.detach(move || {
-            adapter
-                .map(|(i, row)| {
-                    let f = train_row_solve(&self.solver, &self.matrix, i, row, &other, &otor);
-                    f
-                })
-                .sum::<f32>()
-                .sqrt()
+        let frob: PyResult<f32> = py.detach(move || {
+            Ok(adapter
+                .map(|(i, row)| train_row_solve(&self.solver, &self.matrix, i, row, &other, &otor))
+                .try_reduce(|| 0.0f32, |v1, v2| Ok(v1 + v2))
+                .map_err(|e| PyRuntimeError::new_err(format!("ALS solve error: {}", e)))?
+                .sqrt())
         });
 
-        frob.into_bound_py_any(py)
+        frob?.into_bound_py_any(py)
     }
 }
 
@@ -93,13 +91,13 @@ fn train_row_solve(
     mut row_data: ArrayBase<ViewRepr<&mut f32>, Ix1>,
     other: &ArrayView2<f32>,
     otor: &ArrayView2<f32>,
-) -> f32 {
+) -> Result<f32, SolveError> {
     let cols = matrix.row_cols(row_num);
     let vals = matrix.row_vals(row_num);
 
     if cols.len() == 0 {
         row_data.fill(0.0);
-        return 0.0;
+        return Ok(0.0);
     }
 
     let cols: Vec<_> = cols.iter().map(|c| *c as usize).collect();
@@ -118,10 +116,10 @@ fn train_row_solve(
     vals += 1.0;
     let y = mt.dot(&vals);
 
-    let soln = solver.solve(&mut a, &y).expect("LAPACK error");
+    let soln = solver.solve(&mut a, &y)?;
 
     let deltas = &soln - &row_data;
     row_data.assign(&soln);
 
-    deltas.dot(&deltas)
+    Ok(deltas.dot(&deltas))
 }

--- a/src/accel/tasks/mod.rs
+++ b/src/accel/tasks/mod.rs
@@ -6,9 +6,9 @@
 
 //! Support for monitored accelerator tasks.
 
-use std::sync::Mutex;
+use std::{panic::catch_unwind, sync::Mutex};
 
-use pyo3::{prelude::*, types::PyNone, IntoPyObjectExt};
+use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyNone, IntoPyObjectExt};
 mod atomic;
 mod progress;
 

--- a/src/lenskit/parallel/_task.py
+++ b/src/lenskit/parallel/_task.py
@@ -42,10 +42,12 @@ def run_accel_task[R](task: AccelTask[R], *, progress: Progress | None = None) -
                 result = thread.wait_for_result()
 
             match result:
-                case Exception():
+                case BaseException():
                     raise RuntimeError("accelerator task failed with exception") from result
                 case Some(v):
                     return v
+                case _:  # pragma: nocover
+                    raise TypeError("unexpected accelerator task result")
 
     except KeyboardInterrupt as e:
         _log.debug("received KeyboardInterrupt, cancelling background task")
@@ -108,7 +110,7 @@ class AccelTaskThread[R](threading.Thread):
 
     _task: AccelTask[R]
     _condition: threading.Condition
-    _result: Some[R] | Exception | None = None
+    _result: Some[R] | BaseException | None = None
     _accel_context: Context
 
     def __init__(self, task: AccelTask[R]):
@@ -124,18 +126,18 @@ class AccelTaskThread[R](threading.Thread):
             res = self._accel_context.run(self._task.invoke, pool=NestedPool.active_accel_pool())
             res = Some(res)
             _log.debug("accelerator task finished", task=self._task)
-        except Exception as e:
+        except BaseException as e:
             _log.error("accelerator task failed", task=self._task, exc_info=e)
             res = e
 
         self._set_result(res)
 
-    def _set_result(self, result: Some[R] | Exception):
+    def _set_result(self, result: Some[R] | BaseException):
         with self._condition:
             self._result = result
             self._condition.notify_all()
 
-    def wait_for_result(self, *, timeout: float | None = None) -> Some[R] | Exception | None:
+    def wait_for_result(self, *, timeout: float | None = None) -> Some[R] | BaseException | None:
         with self._condition:
             if self._result is not None:
                 return self._result

--- a/src/lenskit/parallel/_task.py
+++ b/src/lenskit/parallel/_task.py
@@ -46,6 +46,8 @@ def run_accel_task[R](task: AccelTask[R], *, progress: Progress | None = None) -
                     raise RuntimeError("accelerator task failed with exception") from result
                 case Some(v):
                     return v
+                case None:
+                    pass  # continue the loop
                 case _:  # pragma: nocover
                     raise TypeError("unexpected accelerator task result")
 


### PR DESCRIPTION
This removes the `expect` / panic when ALS solve fails, instead propagating the error back to Python so it can be properly caught. `PanicException` does not extend `Exception`, so the error handling was failing.

It also updates the AccelTask stuff to propagate `BaseException` from the worker thread, not just `Exception`, so that panics properly propagate.