### PR TITLE
Fix Optuna iterative tuning epoch extraction

### DIFF
--- a/src/lenskit/tuning/_base.py
+++ b/src/lenskit/tuning/_base.py
@@ -108,10 +108,7 @@ class BasePipelineTuner(ABC):
 
     @property
     def mode(self) -> Literal["min", "max"]:
-        if self.spec.search.metric == "RMSE":
-            return "min"
-        else:
-            return "max"
+        return self.spec.search.resolved_direction()
 
     @property
     def pipeline(self) -> PipelineConfig:

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -308,7 +308,14 @@ class OptunaTuneResults(TuneResults):
         cfg = unflatten_dict(best.params)
         if self.iterative:
             vals = [best.intermediate_values.get(i) for i in range(best.last_step + 1)]
-            cfg["epochs"] = np.argmax(vals).item()
+            match self.study.direction:
+                case StudyDirection.MAXIMIZE:
+                    cfg["epochs"] = np.argmax(vals).item() + 1
+                case StudyDirection.MINIMIZE:
+                    cfg["epochs"] = np.argmin(vals).item() + 1
+                case _:
+                    raise RuntimeError("unexpected study direction")
+
         return cfg
 
     def best_result(self) -> dict[str, JsonValue]:

--- a/src/lenskit/tuning/spec.py
+++ b/src/lenskit/tuning/spec.py
@@ -61,6 +61,15 @@ class SearchConfig(BaseModel):
     The frequency for saving checkpoints.
     """
 
+    def resolved_direction(self) -> Literal["min", "max"]:
+        """
+        Get the metric optimization direction.
+        """
+        if self.metric in ("RMSE", "MAE"):
+            return "min"
+        else:
+            return "max"
+
     def update_max_points(self, n: int | None):
         """
         Limit the search points to a new maximum, if it exceeds the current maximum.


### PR DESCRIPTION
Optuna's epoch selection logic incorrectly maximized min metrics, and also had an off-by-1 in the epoch count.