### PR TITLE
Fix inverted logic on Torch compilation

### DIFF
--- a/src/lenskit/flexmf/_training.py
+++ b/src/lenskit/flexmf/_training.py
@@ -150,14 +150,7 @@ class FlexMFTrainerBase(ModelTrainer, Generic[Comp, Cfg]):
         Invoke the model, using the compiled version if available.
         """
         if self._compiled_model is not None:
-            from torch.dynamo._exc import TorchDynamoException  # noqa: PLC2701
-
-            try:
-                return self._compiled_model(*args, **kwargs)
-            except TorchDynamoException as e:
-                self.log.warning("calling compiled model failed, falling back: %s", e)
-                self._compiled_model = None
-                return self.call_model(*args, **kwargs)
+            return self._compiled_model(*args, **kwargs)
         else:
             return self.model(*args, **kwargs)
 

--- a/src/lenskit/training.py
+++ b/src/lenskit/training.py
@@ -204,7 +204,7 @@ class TrainingOptions:
             # FIXME: re-enable when Triton supports free-threading.
             _log.info("Disabling Torch compilation by default on free-threaded Python")
 
-        if not self.env_flag("LK_TORCH_COMPILE", default=ft):
+        if not self.env_flag("LK_TORCH_COMPILE", default=not ft):
             _log.debug("Torch compilation not enabled")
             return False
 


### PR DESCRIPTION
The Torch compilation switch had inverted default logic on free-threaded Python, which this PR fixes.