### PR TITLE
Improve Optuna tune running

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -24,6 +24,7 @@ Third release in 2026, with more feature updates and bug fixes.
   (:py:mod:`lenskit.data.sources.steam`, :pr:`1111`).
 - Support simultaneous multithreaded running in accelerator tasks (:issue:`1124`, :pr:`1125`).
 - Fix Torch compilation support bugs (:pr:`1113`).
+- Optuna fixes for random seeds, continuing when a trial fails, collecting results (:pr:`1132`, :pr:`1134`).
 
 .. _2026.2.1:
 

--- a/pipelines/als-explicit-search.toml
+++ b/pipelines/als-explicit-search.toml
@@ -1,0 +1,11 @@
+[search]
+max_points = 30
+metric = "RMSE"
+
+[space.scorer]
+embedding_size_exp = { type = "int", min = 3, max = 8 }
+regularization.user = { type = "float", min = 1e-4, max = 1, scale = "log" }
+regularization.item = { type = "float", min = 1e-4, max = 1, scale = "log" }
+
+[pipeline]
+file = "als-explicit.toml"

--- a/src/lenskit/cli/tune.py
+++ b/src/lenskit/cli/tune.py
@@ -20,6 +20,7 @@ from humanize import precisedelta
 
 from lenskit.logging import get_logger, stdout_console
 from lenskit.tuning import PipelineTuner, TuningSpec
+from lenskit.tuning.spec import ErrorAction
 
 _log = get_logger(__name__)
 
@@ -65,6 +66,11 @@ _log = get_logger(__name__)
 @click.option(
     "--save-pipeline", type=Path, metavar="FILE", help="Save best pipeline configuration to FILE"
 )
+@click.option(
+    "--on-error",
+    type=click.Choice(["abort", "continue"], case_sensitive=False),
+    help="What to do when a trial fails.",
+)
 @click.argument("SEARCH_SPEC", type=Path)
 @click.argument("OUT", type=Path)
 def tune(
@@ -72,6 +78,7 @@ def tune(
     search_spec: Path,
     out: Path,
     method: Literal["random", "hyperopt", "tpe"] | None,
+    on_error: ErrorAction | None,
     use_ray: bool,
     max_points: int | None,
     job_limit: int | None,
@@ -97,6 +104,8 @@ def tune(
         spec.search.metric = metric
     if method is not None:
         spec.search.method = method
+    if on_error is not None:
+        spec.search.error_action = on_error
 
     out.mkdir(exist_ok=True, parents=True)
 

--- a/src/lenskit/tuning/_base.py
+++ b/src/lenskit/tuning/_base.py
@@ -108,10 +108,7 @@ class BasePipelineTuner(ABC):
 
     @property
     def mode(self) -> Literal["min", "max"]:
-        if self.spec.search.metric == "RMSE":
-            return "min"
-        else:
-            return "max"
+        return self.spec.search.resolved_direction()
 
     @property
     def pipeline(self) -> PipelineConfig:

--- a/src/lenskit/tuning/_measure.py
+++ b/src/lenskit/tuning/_measure.py
@@ -13,6 +13,7 @@ from lenskit.data import GenericKey, ItemList, ItemListCollection, key_dict
 from lenskit.logging import Task, get_logger, item_progress
 from lenskit.metrics import (
     DCG,
+    MAE,
     NDCG,
     RBP,
     RMSE,
@@ -80,11 +81,14 @@ def measure_recs(
     metrics["RBP"] = measure_list(RBP, recs, test)
     metrics["DCG"] = measure_list(DCG, recs, test)
     metrics["NDCG"] = measure_list(NDCG, recs, test)
+    metrics["NDCG@10"] = measure_list(NDCG, recs, test, n=10)
     metrics["RecipRank"] = measure_list(RecipRank, recs, test)
-    metrics["Hit10"] = measure_list(Hit, recs, test, n=10)
+    metrics["Hit"] = measure_list(Hit, recs, test)
+    metrics["Hit@10"] = measure_list(Hit, recs, test, n=10)
 
     if preds is not None:
         log.debug("measuring rating predictions")
         metrics["RMSE"] = measure_list(RMSE, preds, test)
+        metrics["MAE"] = measure_list(MAE, preds, test)
 
     return metrics

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -31,7 +31,7 @@ from lenskit.parallel import NestedPool
 from lenskit.pipeline import Pipeline, PipelineBuilder
 from lenskit.pipeline.components import Component, Placeholder
 from lenskit.pipeline.nodes import ComponentConstructorNode, ComponentInstanceNode
-from lenskit.random import make_seed
+from lenskit.random import int_seed, make_seed
 from lenskit.training import ModelTrainer, TrainingOptions, UsesTrainer
 
 from ._base import BasePipelineTuner, TuneResults
@@ -52,6 +52,7 @@ class PipelineTuner(BasePipelineTuner):
     def run(self) -> OptunaTuneResults:
         self.out_dir.mkdir(exist_ok=True, parents=True)
         study = optuna.create_study(
+            sampler=optuna.samplers.TPESampler(seed=int_seed(self.random_seed)),
             storage=JournalStorage(JournalFileBackend(fspath(self.out_dir / "optuna.log"))),
             pruner=CompositePruner(),
             direction=StudyDirection.MINIMIZE if self.mode == "min" else StudyDirection.MAXIMIZE,

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -316,7 +316,7 @@ class OptunaTuneResults(TuneResults):
                     cfg["epochs"] = np.argmax(vals).item() + 1
                 case StudyDirection.MINIMIZE:
                     cfg["epochs"] = np.argmin(vals).item() + 1
-                case _:
+                case _:  # pragma: nocover
                     raise RuntimeError("unexpected study direction")
 
         return cfg

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -98,7 +98,9 @@ class PipelineTuner(BasePipelineTuner):
                         for t in done:
                             if exc := t.exception():
                                 _log.error("tuning trial failed", exc_info=exc)
-                                raise exc
+                                if self.spec.search.error_action == "abort":
+                                    pool.shutdown(False, cancel_futures=True)
+                                    raise exc
 
                             pb.update()
             else:

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -308,7 +308,14 @@ class OptunaTuneResults(TuneResults):
         cfg = unflatten_dict(best.params)
         if self.iterative:
             vals = [best.intermediate_values.get(i) for i in range(best.last_step + 1)]
-            cfg["epochs"] = np.argmax(vals).item()
+            match self.study.direction:
+                case StudyDirection.MAXIMIZE:
+                    cfg["epochs"] = np.argmax(vals).item() + 1
+                case StudyDirection.MINIMIZE:
+                    cfg["epochs"] = np.argmin(vals).item() + 1
+                case _:
+                    raise RuntimeError("unexpected study direction")
+
         return cfg
 
     def best_result(self) -> dict[str, JsonValue]:

--- a/src/lenskit/tuning/spec.py
+++ b/src/lenskit/tuning/spec.py
@@ -61,6 +61,15 @@ class SearchConfig(BaseModel):
     The frequency for saving checkpoints.
     """
 
+    def resolved_direction(self) -> Literal["min", "max"]:
+        """
+        Get the metric optimization direction.
+        """
+        if self.metric in ("RMSE", "MAE"):
+            return "min"
+        else:
+            return "max"
+
     def update_max_points(self, n: int | None):
         """
         Limit the search points to a new maximum, if it exceeds the current maximum.

--- a/src/lenskit/tuning/spec.py
+++ b/src/lenskit/tuning/spec.py
@@ -14,6 +14,11 @@ from typing_extensions import Annotated, Literal
 from lenskit.config import lenskit_config, load_config_data
 from lenskit.pipeline.config import PipelineConfig
 
+type ErrorAction = Literal["abort", "continue"]
+"""
+Action to take when a trial fails.
+"""
+
 
 class SearchConfig(BaseModel):
     """
@@ -59,6 +64,10 @@ class SearchConfig(BaseModel):
     checkpoint_iters: int = 2
     """
     The frequency for saving checkpoints.
+    """
+    error_action: ErrorAction = "continue"
+    """
+    What to do when one of the search trials fails.
     """
 
     def resolved_direction(self) -> Literal["min", "max"]:

--- a/tests/tuning/__init__.py
+++ b/tests/tuning/__init__.py
@@ -1,7 +1,0 @@
-# This file is part of LensKit.
-# Copyright (C) 2018-2023 Boise State University.
-# Copyright (C) 2023-2026 Drexel University.
-# Licensed under the MIT license, see LICENSE.md for details.
-# SPDX-License-Identifier: MIT
-
-from pytest import importorskip

--- a/tests/tuning/test_iterative_tuning.py
+++ b/tests/tuning/test_iterative_tuning.py
@@ -36,8 +36,10 @@ def tuner_class(request):
 
 @mark.slow
 @mark.realdata
-def test_tune_als(ml_100k, tmpdir, tuner_class):
-    spec = TuningSpec.load(Path("pipelines/als-implicit-search.toml"))
+@mark.parametrize("version", ["implicit", "explicit"])
+def test_tune_als(ml_100k, tmpdir, tuner_class, version: str):
+    "test optimizing an iterative model"
+    spec = TuningSpec.load(Path(f"pipelines/als-{version}-search.toml"))
     spec.search.method = "random"
     spec.search.max_points = 10
     spec.search.max_epochs = 5


### PR DESCRIPTION
A couple of improvements to how Optuna tuning jobs run:

- Tuning can continue when one trial fails (not yet supported in Ray)
- Random seeds are properly passed to the Optuna sampler