### PR TITLE
Speed up Slim recommendation with sparse matrices

### DIFF
--- a/src/lenskit/knn/slim.py
+++ b/src/lenskit/knn/slim.py
@@ -133,13 +133,16 @@ class SLIMScorer(Component, Trainable):
         # get user item numbers
         u_inos = u_items.numbers(vocabulary=self.items, missing="negative")
         u_inos = u_inos[u_inos >= 0]
+        u_n = len(u_inos)
+        tot_n = len(self.items)
 
         # prepare our initial matrix
-        x = np.zeros(len(self.items))
-        x[u_inos] = 1
+        x = csr_array((np.ones(u_n, dtype=np.float32), u_inos, [0, u_n]), shape=(1, tot_n))
 
         # compute the scores
         all_scores = x @ self.weights
+        assert all_scores.shape == (1, tot_n)
+        all_scores = all_scores[0, :].toarray()
 
         # finalize result
         scores = np.full(len(items), np.nan, np.float32)

--- a/src/lenskit/knn/slim.py
+++ b/src/lenskit/knn/slim.py
@@ -142,7 +142,7 @@ class SLIMScorer(Component, Trainable):
         # compute the scores
         all_scores = x @ self.weights
         assert all_scores.shape == (1, tot_n)
-        all_scores = all_scores[0, :].toarray()
+        all_scores = all_scores.toarray()[0, :]
 
         # finalize result
         scores = np.full(len(items), np.nan, np.float32)

--- a/src/lenskit/knn/slim.py
+++ b/src/lenskit/knn/slim.py
@@ -83,6 +83,10 @@ class SLIMScorer(Component, Trainable):
     config: SLIMConfig
 
     weights: csr_array
+    """
+    The *transposed* SLIM weight matrix.  That is, :math:`w_{ij}` is the weight
+    to predict item :math:`j` using :math:`w_i`, not the other way around.
+    """
     items: Vocabulary
 
     def is_trained(self) -> bool:


### PR DESCRIPTION
This uses a sparse matrix-matrix multiply instead of dense vector-matrix multiply in SLIM inference to speed up scoring and recommendation generation by a lot (about 4.5x on ML-32M).