### PR TITLE
Add tests for Optuna pow2 search space

### DIFF
--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -118,8 +118,8 @@ class PipelineTuner(BasePipelineTuner):
                 return self._run_trial(study)
 
         trial = study.ask()
-        config = self._ask_config(trial)
         self.log = self.log.bind(trial_num=trial.number)
+        config = self._ask_config(trial)
 
         with Task(
             label=f"trial {trial.number} to tune {self.pipeline.meta.name}",
@@ -255,7 +255,9 @@ class PipelineTuner(BasePipelineTuner):
     def _ask_config(self, trial: Trial):
         # we have exactly one
         for space in self.spec.space.values():
-            return _ask_space(trial, space)
+            cfg = _ask_space(trial, space)
+            self.log.info("obtained search point", cfg=cfg)
+            return cfg
 
 
 def _ask_space(trial: Trial, space: SearchSpace, *, prefix: str = ""):

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -283,6 +283,8 @@ def _ask_space(trial: Trial, space: SearchSpace, *, prefix: str = ""):
             out[name] = trial.suggest_categorical(prefix + name, [False, True])
         elif spec.type == "choice":
             out[name] = trial.suggest_categorical(prefix + name, spec.choices)
+        else:  # pragma: nocover
+            raise ValueError(f"unsupported configuration {space}")
 
     return out
 

--- a/src/lenskit/tuning/spec.py
+++ b/src/lenskit/tuning/spec.py
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
-from typing import Mapping
 
 from pathlib import Path
+from typing import Mapping
 
 from pydantic import BaseModel, Field, model_validator
 from typing_extensions import Annotated, Literal

--- a/src/lenskit/tuning/spec.py
+++ b/src/lenskit/tuning/spec.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
+from typing import Mapping
 
 from pathlib import Path
 
@@ -219,7 +220,7 @@ class SearchParam(BaseModel):
         return self
 
 
-type SearchSpace = dict[str, SearchParam | SearchSpace]
+type SearchSpace = Mapping[str, SearchParam | SearchSpace]
 """
 Specification of the (possibly nested) hyperparameter search space for a
 component.

--- a/tests/tuning/test_optuna_space.py
+++ b/tests/tuning/test_optuna_space.py
@@ -6,10 +6,11 @@
 
 from pytest import importorskip
 
-from lenskit.tuning._optuna import _ask_space
-from lenskit.tuning.spec import SearchParam
+from lenskit.tuning.spec import SearchParam  # noqa: E402
 
 optuna = importorskip("optuna")
+
+from lenskit.tuning._optuna import _ask_space  # noqa: E402
 
 NTRIALS = 1000
 

--- a/tests/tuning/test_optuna_space.py
+++ b/tests/tuning/test_optuna_space.py
@@ -4,13 +4,12 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-import optuna
-
 from pytest import importorskip
 
-importorskip("optuna")
 from lenskit.tuning._optuna import _ask_space
 from lenskit.tuning.spec import SearchParam
+
+optuna = importorskip("optuna")
 
 NTRIALS = 1000
 

--- a/tests/tuning/test_optuna_space.py
+++ b/tests/tuning/test_optuna_space.py
@@ -4,18 +4,21 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
+import math
+
 from pytest import importorskip
 
-from lenskit.tuning.spec import SearchParam  # noqa: E402
+from lenskit.tuning.spec import SearchParam
 
 optuna = importorskip("optuna")
 
-from lenskit.tuning._optuna import _ask_space  # noqa: E402
 
 NTRIALS = 1000
 
 
 def test_log2_space():
+    from lenskit.tuning._optuna import _ask_space
+
     space = {"n": SearchParam(type="int", scale="pow2", min=8, max=1024)}
     study = optuna.create_study()
 
@@ -27,3 +30,5 @@ def test_log2_space():
             assert isinstance(x, int)
             assert x >= 8
             assert x <= 1024
+            base = math.log2(x)
+            assert int(base) == base

--- a/tests/tuning/test_optuna_space.py
+++ b/tests/tuning/test_optuna_space.py
@@ -1,0 +1,29 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2026 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+import optuna
+
+from pytest import importorskip
+
+importorskip("optuna")
+from lenskit.tuning._optuna import _ask_space
+from lenskit.tuning.spec import SearchParam
+
+NTRIALS = 1000
+
+
+def test_log2_space():
+    space = {"n": SearchParam(type="int", scale="pow2", min=8, max=1024)}
+    study = optuna.create_study()
+
+    for _t in range(NTRIALS):
+        trial = study.ask()
+        for p in range(10):
+            pt = _ask_space(trial, space)
+            x = pt["n"]
+            assert isinstance(x, int)
+            assert x >= 8
+            assert x <= 1024


### PR DESCRIPTION
This adds tests for the `pow2` search space, and tightens up some Optuna typing and error reporting.