### PR TITLE
Refactor pipeline configuration generation to be in nodes

### DIFF
--- a/codebook.toml
+++ b/codebook.toml
@@ -11,4 +11,5 @@ words = [
   "TPE",
   "hyperparameters",
   "lenskit",
+  "seealso",
 ]

--- a/hk.pkl
+++ b/hk.pkl
@@ -11,9 +11,11 @@ local linters = new Mapping<String, Step> {
   ["trailing-whitespace"] = Builtins.trailing_whitespace
   // ["check-merge-conflict"] = Builtins.check_merge_conflict
   ["check-toml"] = Builtins.taplo
+  ["ruff"] = Builtins.ruff
 }
 
 local formatters = new Mapping<String, Step> {
+  ["format-python"] = Builtins.ruff_format
   ["format-rust"] = Builtins.rustfmt
   ["format-yaml"] = Builtins.yamlfmt
   // ["format-toml"] = Builtins.taplo_format

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -10,6 +10,7 @@ pkl = "latest"
 taplo = "latest"
 dprint = "latest"
 yamlfmt = "latest"
+ruff = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["rust"]

--- a/mise/mise.lock
+++ b/mise/mise.lock
@@ -146,6 +146,45 @@ checksum = "sha256:61c40e940d5e61a0c54cc6bdef6ff26d44f02aeccd19fa0407125dc617dba
 url = "https://github.com/apple/pkl/releases/download/0.32.0/pkl-windows-amd64.exe"
 url_api = "https://api.github.com/repos/apple/pkl/releases/assets/470498222"
 
+[[tools.ruff]]
+version = "0.15.21"
+backend = "aqua:astral-sh/ruff"
+
+[tools.ruff."platforms.linux-arm64"]
+checksum = "sha256:2ec7c0077431f96f74c3c72aea6505e902bc2ff47127653c8de1389ee30a3cb3"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.21/ruff-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/471700003"
+
+[tools.ruff."platforms.linux-arm64-musl"]
+checksum = "sha256:2ec7c0077431f96f74c3c72aea6505e902bc2ff47127653c8de1389ee30a3cb3"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.21/ruff-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/471700003"
+
+[tools.ruff."platforms.linux-x64"]
+checksum = "sha256:7e157ff9a2e13676118c587e6db0ec02d040e415b21014346d230e64789c0e78"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.21/ruff-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/471700081"
+
+[tools.ruff."platforms.linux-x64-musl"]
+checksum = "sha256:7e157ff9a2e13676118c587e6db0ec02d040e415b21014346d230e64789c0e78"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.21/ruff-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/471700081"
+
+[tools.ruff."platforms.macos-arm64"]
+checksum = "sha256:0452f9d5da6e8051d332cf21ae82a608d8e2cfeec5a71a46ffa9e50adbb2381d"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.21/ruff-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/471699864"
+
+[tools.ruff."platforms.macos-x64"]
+checksum = "sha256:7e6ff3bd585b5b7c47634c957ac84fb5806d3c7ab4ef0e5ec1c53ce272f489da"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.21/ruff-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/471700061"
+
+[tools.ruff."platforms.windows-x64"]
+checksum = "sha256:035c59abfd7bd1102e0b656f5771e6ae7a712a45ef54b5ab575541c7ff7d1eb0"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.21/ruff-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/471700068"
+
 [[tools.rust]]
 version = "stable"
 backend = "core:rust"

--- a/src/lenskit/config/__init__.py
+++ b/src/lenskit/config/__init__.py
@@ -11,7 +11,7 @@ LensKit general configuration
 from __future__ import annotations
 
 import warnings
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from pathlib import Path
@@ -142,7 +142,7 @@ def reconfigure(
     cfg_dir: Path | LenskitSettings | None = None,
     *,
     settings_cls=LenskitSettings,
-) -> Generator[LenskitSettings]:
+):
     """
     Temporarily reconfigure LensKit, overriding the existing configuration.
 
@@ -162,7 +162,7 @@ def reconfigure(
     Stability:
         Internal
     """
-    settings = configure(cfg_dir, settings_cls, _set_global=False)  # ty:ignore[no-matching-overload]
+    settings = configure(cfg_dir, settings_cls=settings_cls, _set_global=False)  # ty:ignore[no-matching-overload]
     token = _context_settings.set(settings)
     try:
         yield settings

--- a/src/lenskit/config/__init__.py
+++ b/src/lenskit/config/__init__.py
@@ -11,7 +11,6 @@ LensKit general configuration
 from __future__ import annotations
 
 import warnings
-from collections.abc import Generator, Iterator
 from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from pathlib import Path

--- a/src/lenskit/config/__init__.py
+++ b/src/lenskit/config/__init__.py
@@ -11,6 +11,9 @@ LensKit general configuration
 from __future__ import annotations
 
 import warnings
+from collections.abc import Generator
+from contextlib import AbstractContextManager, contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 
 from pydantic_settings import TomlConfigSettingsSource
@@ -48,6 +51,7 @@ __all__ = [
 SettingsClass = TypeVar("SettingsClass", bound="LenskitSettings", default="LenskitSettings")
 _log = get_logger(__name__)
 _settings: LenskitSettings | None = None
+_context_settings: ContextVar[LenskitSettings | None] = ContextVar("lenskit.settings", default=None)
 
 
 def lenskit_config() -> LenskitSettings:
@@ -58,12 +62,15 @@ def lenskit_config() -> LenskitSettings:
     """
     global _settings
 
-    if _settings is None:
+    settings = _context_settings.get()
+    if settings is None:
+        settings = _settings
+
+    if settings is None:
         settings = LenskitSettings()
         settings.finish_setup()
-        return settings
-    else:
-        return _settings
+
+    return settings
 
 
 @overload
@@ -85,7 +92,7 @@ def configure(
 
     LensKit does **not** automatically read configuration files — if this
     function is never called, then configuration will entirely be done through
-    defaults and environment varibles.
+    defaults and environment variables.
 
     This function will automatically configure the global RNG, if a seed is
     specified.  It does **not** configure logging.
@@ -122,9 +129,48 @@ def configure(
     return settings
 
 
-def _load_settings[SettingsClass](
-    cfg_dir: Path | None, settings_cls: type[SettingsClass]
-) -> SettingsClass:
+@overload
+def reconfigure(cfg_dir: Path | None = None) -> AbstractContextManager[LenskitSettings]: ...
+@overload
+def reconfigure(
+    cfg_dir: Path | None = None, *, settings_cls: type[SettingsClass]
+) -> AbstractContextManager[LenskitSettings]: ...
+@overload
+def reconfigure(settings: LenskitSettings, /) -> AbstractContextManager[LenskitSettings]: ...
+@contextmanager
+def reconfigure(
+    cfg_dir: Path | LenskitSettings | None = None,
+    *,
+    settings_cls=LenskitSettings,
+) -> Generator[LenskitSettings]:
+    """
+    Temporarily reconfigure LensKit, overriding the existing configuration.
+
+    .. note::
+
+        This overwrites the active :class:`LenskitSettings`, but does *not*
+        reconfigure parallelism or other globally-configured state.  It is
+        mostly useful for tests to inject a controlled LensKit settings to
+        test how other code responds to those settings.
+
+    .. seealso:: :func:`configure`
+
+    Returns:
+        A context manager that will restore the previous settings state when
+        exited.
+
+    Stability:
+        Internal
+    """
+    settings = configure(cfg_dir, settings_cls, _set_global=False)  # ty:ignore[no-matching-overload]
+    token = _context_settings.set(settings)
+    try:
+        yield settings
+    finally:
+        _context_settings.reset(token)
+
+
+def _load_settings[C](cfg_dir: Path | None, settings_cls: type[C]) -> C:
     # define a subclass so we can specify the configuration location
     toml_files = ["lenskit.toml", "lenskit.local.toml"]
     if cfg_dir is not None:

--- a/src/lenskit/pipeline/_builder.py
+++ b/src/lenskit/pipeline/_builder.py
@@ -39,7 +39,7 @@ from .components import (
     fallback_on_none,
     is_component_class,
 )
-from .config import UNSET_CODE, PipelineConfig, PipelineHook, check_name
+from .config import UNSET_CODE, PipelineConfig, check_name
 from .nodes import (
     ComponentConstructorNode,
     ComponentInstanceNode,
@@ -622,7 +622,7 @@ class PipelineBuilder:
 
         cfg.hooks.run = {}
         for name, hooks in self._run_hooks.items():
-            cfg.hooks.run[name] = [PipelineHook.from_entry(e) for e in hooks]
+            cfg.hooks.run[name] = [e.to_config() for e in hooks]
 
         if include_hash:
             cfg.meta.hash = config.hash_config(cfg)

--- a/src/lenskit/pipeline/_builder.py
+++ b/src/lenskit/pipeline/_builder.py
@@ -605,11 +605,11 @@ class PipelineBuilder:
         for node in self.nodes():
             match node:
                 case InputNode():
-                    cfg.inputs.append(config.PipelineInput.from_node(node))
+                    cfg.inputs.append(node.to_config())
                 case LiteralNode(name, value):
                     cfg.literals[name] = config.PipelineLiteral.represent(value)
                 case ComponentNode(name):
-                    c_cfg = config.PipelineComponent.from_node(node)
+                    c_cfg = node.to_config()
                     c_cfg.inputs = dict(sorted(edges.get(name, {}).items(), key=lambda kv: kv[0]))
                     cfg.components[name] = c_cfg
                 case _:  # pragma: nocover

--- a/src/lenskit/pipeline/_hooks/__init__.py
+++ b/src/lenskit/pipeline/_hooks/__init__.py
@@ -10,7 +10,9 @@ Definition of pipeline hook protocols.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
+from types import FunctionType
 
 from typing_extensions import (
     Any,
@@ -19,7 +21,10 @@ from typing_extensions import (
     TypedDict,
 )
 
+from lenskit.diagnostics import PipelineWarning
+
 from ..components import Component, ComponentInput, PipelineFunction
+from ..config import PipelineHook
 from ..nodes import ComponentInstanceNode
 
 type GenericHook = Callable[..., Any]
@@ -39,6 +44,12 @@ class HookEntry[Hook: GenericHook](NamedTuple):
 
     function: Hook
     priority: int = 1
+
+    def to_config(self) -> PipelineHook:
+        if not isinstance(self.function, FunctionType):
+            warnings.warn(f"hook {self.function} is not a function", PipelineWarning)
+        function = f"{self.function.__module__}:{self.function.__qualname__}"  # type: ignore
+        return PipelineHook(function=function, priority=self.priority)
 
 
 class ComponentInputHook(Protocol):

--- a/src/lenskit/pipeline/config.py
+++ b/src/lenskit/pipeline/config.py
@@ -16,18 +16,13 @@ import pickle
 import re
 from collections import OrderedDict
 from hashlib import sha256
-from types import FunctionType
-from typing import Annotated, Literal, Mapping, get_args
+from typing import Annotated, Literal, Mapping
 
 from annotated_types import Predicate
-from pydantic import AliasChoices, BaseModel, Field, JsonValue, TypeAdapter, ValidationError
+from pydantic import AliasChoices, BaseModel, Field, JsonValue, ValidationError
 from typing_extensions import Any, Self
 
 from lenskit.diagnostics import PipelineError
-
-from ._types import is_union_type, make_importable_path
-from .components import Component
-from .nodes import ComponentConstructorNode, ComponentInstanceNode, ComponentNode, InputNode
 
 VALID_NAME = re.compile(r"^[\w.@%!*?-]+$", re.UNICODE)
 UNSET_CODE = "!UNSET"
@@ -195,20 +190,6 @@ class PipelineInput(BaseModel):
     types: set[str] | None
     "The list of types for this input."
 
-    @classmethod
-    def from_node(cls, node: InputNode[Any]) -> Self:
-        if node.type == Any:
-            types = None
-        elif is_union_type(node.type):
-            types = set(get_args(node.type))
-        else:
-            types = {node.type}
-
-        if types is not None:
-            types = {make_importable_path(t) for t in types}
-
-        return cls(name=node.name, types=types)
-
 
 class PipelineComponent(BaseModel):
     """
@@ -232,29 +213,6 @@ class PipelineComponent(BaseModel):
     The component's input wirings, mapping input names to node names.  For
     certain meta-nodes, it is specified as a list instead of a dict.
     """
-
-    @classmethod
-    def from_node(cls, node: ComponentNode[Any]) -> Self:
-        match node:
-            case ComponentInstanceNode(_name, comp):
-                config = None
-                if isinstance(comp, FunctionType):
-                    ctype = comp
-                else:
-                    ctype = comp.__class__
-                    if isinstance(comp, Component):
-                        config = comp.dump_config()
-            case ComponentConstructorNode(_name, ctype, config):
-                if isinstance(ctype, type) and issubclass(ctype, Component):
-                    config = TypeAdapter[Any](ctype.config_class()).dump_python(config, mode="json")
-                else:
-                    config = None
-            case _:  # pragma: nocover
-                raise TypeError("unexpected node type")
-
-        code = make_importable_path(ctype)  # type: ignore
-
-        return cls(code=code, config=config)
 
 
 class PipelineLiteral(BaseModel):

--- a/src/lenskit/pipeline/config.py
+++ b/src/lenskit/pipeline/config.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import base64
 import pickle
 import re
-import warnings
 from collections import OrderedDict
 from hashlib import sha256
 from types import FunctionType
@@ -24,9 +23,8 @@ from annotated_types import Predicate
 from pydantic import AliasChoices, BaseModel, Field, JsonValue, TypeAdapter, ValidationError
 from typing_extensions import Any, Self
 
-from lenskit.diagnostics import PipelineError, PipelineWarning
+from lenskit.diagnostics import PipelineError
 
-from ._hooks import HookEntry
 from ._types import is_union_type, make_importable_path
 from .components import Component
 from .nodes import ComponentConstructorNode, ComponentInstanceNode, ComponentNode, InputNode
@@ -59,13 +57,6 @@ class PipelineHook(BaseModel):
 
     function: str
     priority: Annotated[int, Predicate(lambda x: x != 0)] = 1
-
-    @classmethod
-    def from_entry(cls, hook: HookEntry[Any]):
-        if not isinstance(hook.function, FunctionType):  # type: ignore
-            warnings.warn(f"hook {hook.function} is not a function", PipelineWarning)
-        function = f"{hook.function.__module__}:{hook.function.__qualname__}"
-        return cls(function=function, priority=hook.priority)
 
 
 class PipelineHooks(BaseModel):

--- a/src/lenskit/pipeline/nodes.py
+++ b/src/lenskit/pipeline/nodes.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Mapping
-from types import UnionType
-from typing import Any, cast
+from types import FunctionType, UnionType
+from typing import Any, cast, get_args
 
-from pydantic import JsonValue
+from pydantic import BaseModel, JsonValue, TypeAdapter
 
+from ._types import is_union_type, make_importable_path
 from .components import (
     Component,
     ComponentConstructor,
@@ -29,6 +30,7 @@ from .components import (
     PipelineFunction,
     component_inputs,
 )
+from .config import PipelineComponent, PipelineInput
 
 
 class Node[T]:
@@ -54,6 +56,9 @@ class Node[T]:
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.name}>"
 
+    def to_config(self) -> BaseModel:
+        raise TypeError(f"node {self.__class__.__name__} has no config")
+
 
 class InputNode[T](Node[T]):
     """
@@ -74,6 +79,19 @@ class InputNode[T](Node[T]):
             self.type = Any  # type: ignore
         else:
             self.type = type
+
+    def to_config(self) -> PipelineInput:
+        if self.type == Any:
+            types = None
+        elif is_union_type(self.type):  # ty:ignore[invalid-argument-type]
+            types = set(get_args(self.type))
+        else:
+            types = {self.type}
+
+        if types is not None:
+            types = {make_importable_path(t) for t in types}
+
+        return PipelineInput(name=self.name, types=types)
 
 
 class LiteralNode[T](Node[T]):
@@ -123,6 +141,10 @@ class ComponentNode[T](Node[T]):
     def inputs(self) -> dict[str, ComponentInput]:  # pragma: nocover
         raise NotImplementedError()
 
+    # method to refine the return type
+    def to_config(self) -> PipelineComponent:
+        raise NotImplementedError()
+
 
 class ComponentConstructorNode[T](ComponentNode[T]):
     __match_args__ = ("name", "constructor", "config")
@@ -139,6 +161,18 @@ class ComponentConstructorNode[T](ComponentNode[T]):
     @property
     def inputs(self):
         return component_inputs(self.constructor)
+
+    def to_config(self) -> PipelineComponent:
+        if isinstance(self.constructor, type) and issubclass(self.constructor, Component):
+            config = TypeAdapter[Any](self.constructor.config_class()).dump_python(
+                self.config, mode="json"
+            )
+        else:
+            config = None
+
+        code = make_importable_path(self.constructor)  # type: ignore
+
+        return PipelineComponent(code=code, config=config)
 
 
 class ComponentInstanceNode[T](ComponentNode[T]):
@@ -157,3 +191,16 @@ class ComponentInstanceNode[T](ComponentNode[T]):
     @property
     def inputs(self):
         return component_inputs(self.component, _warn_level=2)
+
+    def to_config(self) -> PipelineComponent:
+        config = None
+        if isinstance(self.component, FunctionType):
+            ctype = self.component
+        else:
+            ctype = self.component.__class__
+            if isinstance(self.component, Component):
+                config = self.component.dump_config()
+
+        code = make_importable_path(ctype)
+
+        return PipelineComponent(code=code, config=config)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 
-from lenskit.config import LenskitSettings, configure, lenskit_config
+from lenskit.config import LenskitSettings, configure, lenskit_config, reconfigure
 
 
 def test_default_config():
@@ -20,3 +20,16 @@ def test_load_toml():
     assert cfg is not None
     assert cfg.random.seed == 42
     assert set(cfg.machines.keys()) == {"local", "shared"}
+
+
+def test_reconfigure():
+    base = lenskit_config()
+
+    with reconfigure(cfg_dir=Path(__file__).parent):
+        n2 = lenskit_config()
+        assert n2 is not base
+        assert n2.random.seed == 42
+        assert n2.random.seed != base.random.seed
+
+    outside = lenskit_config()
+    assert outside == base

--- a/tests/pipeline/test_config_node.py
+++ b/tests/pipeline/test_config_node.py
@@ -11,7 +11,7 @@ from lenskit.pipeline.nodes import InputNode
 def test_untyped_input():
     node = InputNode("scroll")
 
-    cfg = PipelineInput.from_node(node)
+    cfg = node.to_config()
     print(cfg)
     assert cfg.name == "scroll"
     assert cfg.types is None
@@ -20,7 +20,7 @@ def test_untyped_input():
 def test_input_with_type():
     node = InputNode("scroll", type=str)
 
-    cfg = PipelineInput.from_node(node)
+    cfg = node.to_config()
     print(cfg)
     assert cfg.name == "scroll"
     assert cfg.types == {"str"}
@@ -29,7 +29,7 @@ def test_input_with_type():
 def test_input_with_none():
     node = InputNode("scroll", type=str | None)
 
-    cfg = PipelineInput.from_node(node)
+    cfg = node.to_config()
     print(cfg)
     assert cfg.name == "scroll"
     assert cfg.types == {"None", "str"}
@@ -38,7 +38,7 @@ def test_input_with_none():
 def test_input_with_generic():
     node = InputNode("scroll", type=list[str])
 
-    cfg = PipelineInput.from_node(node)
+    cfg = node.to_config()
     print(cfg)
     assert cfg.name == "scroll"
     assert cfg.types == {"list"}


### PR DESCRIPTION
This refactors pipeline configuration logic so that nodes generate their configurations instead of configurations generating themselves from nodes, to prepare to move the configuration schema.