### PR TITLE
Add top-level search defaults and make stopping behavior configurable

### DIFF
--- a/src/lenskit/cli/tune.py
+++ b/src/lenskit/cli/tune.py
@@ -20,7 +20,7 @@ from humanize import precisedelta
 
 from lenskit.logging import get_logger, stdout_console
 from lenskit.schemas.tuning import ErrorAction
-from lenskit.tuning import PipelineTuner, TuningSpec
+from lenskit.tuning import TuningSpec
 
 _log = get_logger(__name__)
 
@@ -128,6 +128,8 @@ def tune(
 
         controller = RayPipelineTuner(spec, out)
     else:
+        from lenskit.tuning import PipelineTuner
+
         controller = PipelineTuner(spec, out)
 
     if job_limit is not None:

--- a/src/lenskit/schemas/settings.py
+++ b/src/lenskit/schemas/settings.py
@@ -88,14 +88,9 @@ class TuneSettings(BaseModel):
     """
     Multiplier for tuning job GPU requirements.  This is to coarsely adapt GPU
     requirements from configuration files to the local machine.  If a tuning
-    specificataion requires 1 GPU, but your machine has enough capacity to run
+    specification requires 1 GPU, but your machine has enough capacity to run
     two jobs in parallel on a single GPU, you can set this to 0.5 to modify the
     tuning jobs to require 0.5 GPUs each.
-    """
-
-    max_points: int | None = None
-    """
-    Maximum number of search points for hyperparameter tuning.
     """
 
 

--- a/src/lenskit/schemas/settings.py
+++ b/src/lenskit/schemas/settings.py
@@ -17,6 +17,8 @@ from annotated_types import Gt, Le
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from .tuning import SearchConfig
+
 
 class PowerQueries(TypedDict, total=False):
     """
@@ -91,6 +93,11 @@ class TuneSettings(BaseModel):
     specification requires 1 GPU, but your machine has enough capacity to run
     two jobs in parallel on a single GPU, you can set this to 0.5 to modify the
     tuning jobs to require 0.5 GPUs each.
+    """
+
+    defaults: SearchConfig | None = None
+    """
+    Default settings for hyperparameter search.
     """
 
 

--- a/src/lenskit/schemas/tuning.py
+++ b/src/lenskit/schemas/tuning.py
@@ -12,9 +12,8 @@ from typing import Mapping
 from pydantic import BaseModel, Field, model_validator
 from typing_extensions import Annotated, Literal
 
-from lenskit.config import lenskit_config
-from lenskit.pipeline.config import PipelineConfig
-from lenskit.schemas import load_model_data
+from ._load import load_model_data
+from .pipeline import PipelineConfig
 
 type ErrorAction = Literal["abort", "continue"]
 """
@@ -116,15 +115,10 @@ class SearchConfig(BaseModel):
         """
         Get the number of search points to use.
         """
-        cfg = lenskit_config()
-
         points = self.default_points
 
         if self.max_points is not None and points > self.max_points:
             points = self.max_points
-
-        if cfg.tuning.max_points is not None and points > cfg.tuning.max_points:
-            points = cfg.tuning.max_points
 
         return points
 

--- a/src/lenskit/schemas/tuning.py
+++ b/src/lenskit/schemas/tuning.py
@@ -22,6 +22,12 @@ Action to take when a trial fails.
 """
 
 
+class IterativeConfig(BaseModel):
+    """
+    Options for iterative search.
+    """
+
+
 class SearchConfig(BaseModel):
     """
     Configuration options for the hyperparameter search.
@@ -31,6 +37,7 @@ class SearchConfig(BaseModel):
     """
     The search method to use.
     """
+
     max_points: int | None = None
     """
     The maximum number of points to try.
@@ -39,22 +46,21 @@ class SearchConfig(BaseModel):
     """
     The default number of search points, if not limited by a maximum configuration.
     """
-    max_epochs: int = 100
+    error_action: ErrorAction = "continue"
     """
-    The maximum number of epochs to use in iterative training.
+    What to do when one of the search trials fails.
     """
-    min_epochs: int = 3
-    """
-    The minimum number of epochs for iterative training.
-    """
+
     metric: str | None = None
     """
     The metric to use.
     """
+
     list_length: int | None = None
     """
     The length of recommendation lists to use.
     """
+
     num_cpus: int | Literal["threads", "backend-threads", "all-threads"] = "threads"
     """
     The number of CPUs to request from Ray Tune.
@@ -63,13 +69,30 @@ class SearchConfig(BaseModel):
     """
     The number of GPUs to requrest from Ray Tune.
     """
+
+    max_epochs: int = 100
+    """
+    The maximum number of epochs to use in iterative training.
+    """
+
+    min_epochs: int = 3
+    """
+    The minimum number of epochs for iterative training.
+    """
+
+    plateau_check_iters: int = 3
+    """
+    The number of iterations to check for the plateau stopper.
+    """
+
+    plateau_min_rel_improvement: float = 0.01
+    """
+    The minimum relative improvement to continue the trial.
+    """
+
     checkpoint_iters: int = 2
     """
-    The frequency for saving checkpoints.
-    """
-    error_action: ErrorAction = "continue"
-    """
-    What to do when one of the search trials fails.
+    The frequency for saving checkpoints (only supported by Ray).
     """
 
     def resolved_direction(self) -> Literal["min", "max"]:
@@ -104,6 +127,24 @@ class SearchConfig(BaseModel):
             points = cfg.tuning.max_points
 
         return points
+
+    def merge(self, other: SearchConfig) -> SearchConfig:
+        """
+        Produce a new configuration by merging another configuration into this one.
+
+        Args:
+            other:
+                The other configuration to merge.
+        Returns:
+            The combination of ``self`` and ``other``, where values from ``other``
+            are preferred in case of conflict.
+        """
+        ours = self.model_dump()
+        theirs = other.model_dump(
+            exclude_unset=True, exclude_defaults=True, exclude_computed_fields=True
+        )
+        combined = ours | theirs
+        return self.model_validate(combined)
 
 
 class TuningSpec(BaseModel, extra="forbid"):

--- a/src/lenskit/schemas/tuning.py
+++ b/src/lenskit/schemas/tuning.py
@@ -154,6 +154,13 @@ class TuningSpec(BaseModel, extra="forbid"):
 
     @classmethod
     def load(cls, path: Path) -> TuningSpec:
+        """
+        Load the tuning specification from the file.
+
+        .. note::
+
+            This load does **not** merge the global defaults.
+        """
         cfg = load_model_data(path, cls)
         cfg.file_path = path
         return cfg

--- a/src/lenskit/schemas/tuning.py
+++ b/src/lenskit/schemas/tuning.py
@@ -79,6 +79,12 @@ class SearchConfig(BaseModel):
     The minimum number of epochs for iterative training.
     """
 
+    median_min_trials: int = 5
+    """
+    The minimum number of trials at an epoch for the median pruner to
+    consider pruning.
+    """
+
     plateau_check_iters: int = 3
     """
     The number of iterations to check for the plateau stopper.

--- a/src/lenskit/tuning/__init__.py
+++ b/src/lenskit/tuning/__init__.py
@@ -8,28 +8,16 @@
 Tune parameters using Ray Tune.
 """
 
-from lenskit.schemas.tuning import TuningSpec
+import lazy_loader as lazy
 
-from ._base import BasePipelineTuner
-
-try:
-    from ._optuna import PipelineTuner
-except ImportError:
-
-    class PipelineTuner(BasePipelineTuner):
-        def run(self):
-            raise RuntimeError("Optuna is not available")
-
-
-try:
-    from ._ray import RayPipelineTuner, RayTuneResults
-except ImportError:
-    pass
-
-__all__ = [
-    "TuningSpec",
-    "PipelineTuner",
-    "BasePipelineTuner",
-    "RayPipelineTuner",
-    "RayTuneResults",
-]
+__getattr__, __dir__, __all__ = lazy.attach(
+    __name__,
+    submodules=[
+        "spec",
+    ],
+    submod_attrs={
+        "_base": ["BasePipelineTuner", "TuningSpec"],
+        "_optuna": ["PipelineTuner"],
+        "_ray": ["RayPipelineTuner", "RayTuneResults"],
+    },
+)

--- a/src/lenskit/tuning/__init__.pyi
+++ b/src/lenskit/tuning/__init__.pyi
@@ -1,0 +1,13 @@
+from lenskit.schemas.tuning import TuningSpec
+
+from ._base import BasePipelineTuner
+from ._optuna import PipelineTuner
+from ._ray import RayPipelineTuner, RayTuneResults
+
+__all__ = [
+    "TuningSpec",
+    "PipelineTuner",
+    "BasePipelineTuner",
+    "RayPipelineTuner",
+    "RayTuneResults",
+]

--- a/src/lenskit/tuning/_base.py
+++ b/src/lenskit/tuning/_base.py
@@ -65,6 +65,8 @@ class BasePipelineTuner(ABC):
 
         self.spec = spec.model_copy(deep=True)
         self.spec.pipeline = pb.build_config()
+        if self.settings.defaults is not None:
+            self.spec.search = self.settings.defaults.merge(self.spec.search)
         self.random_seed = spawn_seed(rng)
 
         self.log = _log.bind(model=pb.name)

--- a/src/lenskit/tuning/_base.py
+++ b/src/lenskit/tuning/_base.py
@@ -163,6 +163,12 @@ class TuneResults(ABC):
         Get the number of completed trials in this search.
         """
 
+    def num_failed(self) -> int:
+        """
+        Get the number of failed trials in this search.
+        """
+        return 0
+
     @abstractmethod
     def trials(self) -> Iterable[dict[str, JsonValue]]:
         """

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -392,8 +392,11 @@ class OptunaTuneResults(TuneResults):
     study: Study
     iterative: bool
 
-    def num_trials(self):
-        return len(self.study.trials)
+    def num_trials(self) -> int:
+        return len([t for t in self.study.trials if t.state != TrialState.FAIL])
+
+    def num_failed(self) -> int:
+        return len([t for t in self.study.trials if t.state == TrialState.FAIL])
 
     @override
     def trials(self) -> Iterable[dict[str, JsonValue]]:

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -55,7 +55,7 @@ class PipelineTuner(BasePipelineTuner):
         study = optuna.create_study(
             sampler=optuna.samplers.TPESampler(seed=int_seed(self.random_seed)),
             storage=JournalStorage(JournalFileBackend(fspath(self.out_dir / "optuna.log"))),
-            pruner=CompositePruner(),
+            pruner=CompositePruner(self.spec.search),
             direction=StudyDirection.MINIMIZE if self.mode == "min" else StudyDirection.MAXIMIZE,
         )
 

--- a/src/lenskit/tuning/_optuna.py
+++ b/src/lenskit/tuning/_optuna.py
@@ -33,7 +33,7 @@ from lenskit.pipeline import Pipeline, PipelineBuilder
 from lenskit.pipeline.components import Component, Placeholder
 from lenskit.pipeline.nodes import ComponentConstructorNode, ComponentInstanceNode
 from lenskit.random import int_seed, make_seed
-from lenskit.schemas.tuning import SearchParam, SearchSpace, TuningSpec
+from lenskit.schemas.tuning import SearchConfig, SearchParam, SearchSpace, TuningSpec
 from lenskit.training import ModelTrainer, TrainingOptions, UsesTrainer
 
 from ._base import BasePipelineTuner, TuneResults
@@ -475,10 +475,15 @@ class CompositePruner(BasePruner):
     stops.
     """
 
+    config: SearchConfig
     median: BasePruner
 
-    def __init__(self):
-        self.median = MedianPruner(n_min_trials=3, n_warmup_steps=3)
+    def __init__(self, config: SearchConfig):
+        self.config = config
+        self.median = MedianPruner(
+            n_min_trials=config.median_min_trials,
+            n_warmup_steps=config.min_epochs,
+        )
 
     def prune(self, study, trial):
         step = trial.last_step
@@ -492,7 +497,10 @@ class CompositePruner(BasePruner):
             return False
 
         plateau = PlateauStopRule(
-            mode="min" if study.direction == StudyDirection.MINIMIZE else "max"
+            mode="min" if study.direction == StudyDirection.MINIMIZE else "max",
+            min_improvement=self.config.plateau_min_rel_improvement,
+            min_iters=self.config.min_epochs,
+            check_iters=self.config.plateau_check_iters,
         )
         metrics = [
             trial.intermediate_values[i] for i in range(step + 1) if i in trial.intermediate_values

--- a/src/lenskit/tuning/_ray/search.py
+++ b/src/lenskit/tuning/_ray/search.py
@@ -152,20 +152,19 @@ class RayPipelineTuner(BasePipelineTuner):
         stopper = None
         cp_config = None
         if self.iterative:
-            # FIXME: make this configurable
             min_iter = self.spec.search.min_epochs
             scheduler = ray.tune.schedulers.MedianStoppingRule(
                 time_attr="training_iteration",
                 grace_period=min_iter,
-                min_time_slice=3,
-                min_samples_required=3,
+                min_time_slice=min_iter,
+                min_samples_required=self.spec.search.median_min_trials,
             )
             stopper = RelativePlateauStopper(
                 metric=self.metric,
                 mode=self.mode,
                 grace_period=min_iter,
-                check_iters=min(min_iter, 3),
-                min_improvement=0.005,
+                check_iters=min(min_iter, self.spec.search.plateau_check_iters),
+                min_improvement=self.spec.search.plateau_min_rel_improvement,
             )
 
             cp_freq = self.spec.search.checkpoint_iters

--- a/tests/tuning/test_tuner_setup.py
+++ b/tests/tuning/test_tuner_setup.py
@@ -18,7 +18,7 @@ def test_tuner_spec():
     assert spec.component_name == "scorer"
 
 
-def test_tuner_spec():
+def test_tuner_merge_defaults():
     try:
         from lenskit.tuning import PipelineTuner
     except ImportError:

--- a/tests/tuning/test_tuner_setup.py
+++ b/tests/tuning/test_tuner_setup.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from pytest import skip
 
+from lenskit.config import LenskitSettings, reconfigure
 from lenskit.schemas.tuning import TuningSpec
 
 
@@ -15,6 +16,24 @@ def test_tuner_spec():
     spec = TuningSpec.load(Path("pipelines/iknn-explicit-search.toml"))
     assert len(spec.space) == 1
     assert spec.component_name == "scorer"
+
+
+def test_tuner_spec():
+    try:
+        from lenskit.tuning import PipelineTuner
+    except ImportError:
+        skip("optuna not available")
+
+    with reconfigure(
+        LenskitSettings.model_validate(
+            {"tuning": {"defaults": {"max_points": 42, "max_epochs": 15}}}
+        )
+    ):
+        spec = TuningSpec.load(Path("pipelines/als-implicit-search.toml"))
+        tuner = PipelineTuner(spec)
+
+        assert tuner.spec.search.max_points == 30
+        assert tuner.spec.search.max_epochs == 15
 
 
 def test_ray_tuner_space():

--- a/tests/tuning/test_tuning_specs.py
+++ b/tests/tuning/test_tuning_specs.py
@@ -8,7 +8,15 @@ from pydantic import ValidationError
 
 from pytest import raises
 
-from lenskit.schemas.tuning import SearchParam
+from lenskit.schemas.tuning import SearchConfig, SearchParam
+
+
+def test_merge_configs():
+    first = SearchConfig(max_epochs=42)
+    second = SearchConfig(min_epochs=17)
+    both = first.merge(second)
+    assert both.max_epochs == 42
+    assert both.min_epochs == 17
 
 
 def test_require_range():


### PR DESCRIPTION
This PR adds configurability to the tuner's stopping behavior, for both Optuna and Ray. It also adds `tuning.defaults` to the main configuration schema to allow overall defaults to be changed in the configuration file.