### PR TITLE
Make summary Markdown optional in data import

### DIFF
--- a/src/lenskit/cli/data/convert.py
+++ b/src/lenskit/cli/data/convert.py
@@ -21,9 +21,17 @@ _log = get_logger(__name__)
 @click.option(
     "--item-lists", is_flag=True, help="Convert to an ItemListCollection instead of Dataset."
 )
+@click.option(
+    "--summary/--no-summary",
+    "summary",
+    default=True,
+    help="Include a summary Markdown file in the exported dataset.",
+)
 @click.argument("src", type=Path, nargs=-1, required=True)
 @click.argument("dst", type=Path, required=True)
-def convert(format: str | None, src: list[Path], dst: Path, item_lists: bool = False):
+def convert(
+    format: str | None, summary: bool, src: list[Path], dst: Path, item_lists: bool = False
+):
     """
     Convert data into the LensKit native format.
 
@@ -71,4 +79,4 @@ def convert(format: str | None, src: list[Path], dst: Path, item_lists: bool = F
         ilc.save_parquet(dst)
     else:
         log.info("saving data in native format")
-        data.save(dst)
+        data.save(dst, summary=summary)

--- a/src/lenskit/data/_container.py
+++ b/src/lenskit/data/_container.py
@@ -69,7 +69,7 @@ class DataContainer:
         self.__dict__.update(state)
         self.tables = {name: _resolve_compat_table(tbl) for name, tbl in state["tables"].items()}
 
-    def save(self, path: str | PathLike[str]):
+    def save(self, path: str | PathLike[str], *, summary: bool = True):
         """
         Save the data to disk.
         """
@@ -94,8 +94,9 @@ class DataContainer:
             log.debug("writing table", table=name, rows=table.num_rows)
             write_table(table, path / f"{name}.parquet", compression="zstd")
 
-        log.debug("writing summary file")
-        save_stats(self, path / "summary.md")
+        if summary:
+            log.debug("writing summary file")
+            save_stats(self, path / "summary.md")
 
     @classmethod
     def load(cls, path: str | PathLike[str]):

--- a/src/lenskit/data/_dataset.py
+++ b/src/lenskit/data/_dataset.py
@@ -110,7 +110,7 @@ class Dataset:
         container = DataContainer.load(path)
         return cls(container)
 
-    def save(self, path: str | PathLike[str]):
+    def save(self, path: str | PathLike[str], *, summary: bool = True):
         """
         Save the data set in the LensKit native format.
 
@@ -119,7 +119,7 @@ class Dataset:
                 The path in which to save the data set (will be created as a
                 directory).
         """
-        self._data.save(path)
+        self._data.save(path, summary=summary)
 
     @property
     def name(self) -> str | None:


### PR DESCRIPTION
This modifies dataset saving to make the `summary.md` file optional.