### PR TITLE
Explicitly handle time zones in time-filtering builders

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -17,8 +17,17 @@ rough corners polished off the interfaces, and hopefully fewer bugs.
 
 Third release in 2026, with more feature updates and bug fixes.
 
+.. important::
+
+    This release updates :meth:`lenskit.data.DatasetBuilder.filter_interactions` to
+    explicitly and consistently handle time zones, independent of the local time zone.
+    In some cases, such as filtering by a numeric timestamp, the previous code was
+    (incorrectly) time-zone-dependent.
+
 - Fixed bug in FlexMF's ``"misranked"`` sampler (for WARP), where it did
   not correctly continue sampling (:pr:`1121`).
+- Made time zone handling in :meth:`lenskit.data.DatasetBuilder.filter_interactions` explicit (:pr:`1162`).  This may affect
+  filter results by a few hours, because previous behavior was unspecified and time-zone-dependent.
 - Reworked type checking logic in the pipeline to fix type bugs with NumPy 2.5, and hopefully reduce brittleness (:pr:`1120`).
 - Added initial support for importing Steam user/item data
   (:py:mod:`lenskit.data.sources.steam`, :pr:`1111`).

--- a/src/lenskit/data/_builder.py
+++ b/src/lenskit/data/_builder.py
@@ -1213,10 +1213,15 @@ def _empty_rel_table(types: list[str]) -> pa.Table:
 def _conform_time(time: int | float | str | dt.datetime, col_type: pa.DataType):
     if isinstance(time, str):
         time = dt.datetime.fromisoformat(time)
+    elif not isinstance(time, dt.datetime):
+        time = dt.datetime.fromtimestamp(time, tz=dt.UTC)
 
     if pa.types.is_timestamp(col_type):
-        if not isinstance(time, dt.datetime):
-            return dt.datetime.fromtimestamp(time)
+        if col_type.tz is None:
+            # we assume time-zone-free data is UTC
+            return time.replace(tzinfo=None)
+        else:
+            return time
     elif isinstance(time, dt.datetime):
         return time.timestamp()
 

--- a/src/lenskit/data/_builder.py
+++ b/src/lenskit/data/_builder.py
@@ -629,6 +629,11 @@ class DatasetBuilder:
         """
         Filter interactions based on timestamp or to remove particular entities.
 
+        .. versionchanged:: 2026.3
+
+            Time stamp filtering is now consistent and independent of the local
+            time zone (unless naïve date/times are passed).
+
         Args:
             cls:
                 The interaction class to filter.
@@ -645,6 +650,19 @@ class DatasetBuilder:
         tbl = self._tables[cls]
         if tbl is None:  # pragma: nocover
             raise ValueError(f"interaction class {cls} is empty")
+
+        if isinstance(min_time, dt.datetime) and min_time.tzinfo is None:  # pragma: nocover
+            warnings.warn(
+                "minimum time is naïve, result may be time-zone-dependent",
+                DataWarning,
+                stacklevel=2,
+            )
+        if isinstance(max_time, dt.datetime) and max_time.tzinfo is None:  # pragma: nocover
+            warnings.warn(
+                "maximum time is naïve, result may be time-zone-dependent",
+                DataWarning,
+                stacklevel=2,
+            )
 
         if min_time is not None or max_time is not None:
             if "timestamp" not in tbl.column_names:

--- a/tests/data/test_builder_filter.py
+++ b/tests/data/test_builder_filter.py
@@ -7,6 +7,7 @@
 # pyright: basic
 from __future__ import annotations
 
+import datetime as dt
 from dataclasses import dataclass
 from datetime import datetime
 from itertools import product
@@ -19,6 +20,7 @@ import pyarrow as pa
 from pytest import approx, mark, raises, warns
 
 from lenskit.data import Dataset, DatasetBuilder
+from lenskit.data._builder import _conform_time
 from lenskit.data.schema import AllowableTroolean
 from lenskit.diagnostics import DataError, DataWarning
 
@@ -225,3 +227,28 @@ def test_filter_ratings_readd(rng, ml_ds: Dataset):
 
     ds2 = dsb2.build()
     assert ds2.interaction_count == ml_ds.interaction_count
+
+
+def test_conform_str_nodate():
+    qt = _conform_time("2026-07-07", pa.timestamp("s"))
+    assert isinstance(qt, datetime)
+    assert qt.year == 2026
+    assert qt.day == 7
+
+
+def test_conform_int():
+    # this TS is 11:00 AM EST, Dec. 31, 2025 - it should be in 2025
+    qt = _conform_time(1767196800, pa.timestamp("s"))
+    assert isinstance(qt, datetime)
+    assert qt.year == 2025
+    assert qt.month == 12
+    assert qt.day == 31
+
+
+def test_conform_boundary():
+    # this TS is 11:00 PM EST, Dec. 31, 2025 - it should be in 2026 UTC
+    qt = _conform_time(1767240000, pa.timestamp("s"))
+    assert isinstance(qt, datetime)
+    assert qt.year == 2026
+    assert qt.month == 1
+    assert qt.day == 1


### PR DESCRIPTION
This updates the `DatasetBuilder` logic to explicitly handle time zones when filtering by timestamp, to ensure handling is unambiguous.