### PR TITLE
Cast item lists to common schema when converting to Arrow

### DIFF
--- a/src/lenskit/data/_collection/_base.py
+++ b/src/lenskit/data/_collection/_base.py
@@ -453,11 +453,16 @@ class ItemListCollection(ABC, Generic[KL_co]):  # ruff: ignore[non-pep695-generi
         else:
             schema = pa.schema(columns)
 
+        il_type = pa.struct(list(schema))  # type: ignore
+        item_type = pa.list_(il_type)
+
         for batch in batched(self.items(), batch_size):
             keys = pa.Table.from_pylist([key_dict(k) for (k, _il) in batch])
-            item_type = pa.list_(pa.struct(list(schema)))  # type: ignore
+
             col_elts = [
-                il.to_arrow(ids=True, numbers=False, type="array", columns=schema.names)
+                il.to_arrow(ids=True, numbers=False, type="array", columns=schema.names).cast(
+                    il_type
+                )
                 for (_k, il) in batch
             ]
             col = pa.array(col_elts, item_type)

--- a/tests/data/test_collection.py
+++ b/tests/data/test_collection.py
@@ -299,6 +299,21 @@ def test_to_arrow():
     assert names == ["item_id", "score"]
 
 
+def test_to_arrow_with_null():
+    ilc = ItemListCollection.from_dict(
+        {
+            72: ItemList(["a"], scores=[1], widgets=[3]),
+            82: ItemList(["a", "b", "c"], scores=[3, 4, 10], widgets=[2, 2, 2]),
+            85: ItemList(ItemList(["a"], scores=[1]), widgets=None),
+        },
+        key="user_id",
+    )
+    tbl = ilc.to_arrow()
+    ic = tbl.column("items")
+    assert "widgets" in ic.type.value_type.names
+    assert pa.types.is_integer(ic.type.value_type.field("widgets").type)
+
+
 def test_to_arrow_flat():
     ilc = ItemListCollection.from_dict(
         {72: ItemList(["a"], scores=[1]), 82: ItemList(["a", "b", "c"], scores=[3, 4, 10])},


### PR DESCRIPTION
If item lists in a collection have different schemas, they would fail when being converted to Arrow. This change adds a test for the bug this causes, and an explicit cast to convert data to a common schema.

Closes #1164.