### PR TITLE
Add UniqueItemCount metric

### DIFF
--- a/src/lenskit/metrics/__init__.py
+++ b/src/lenskit/metrics/__init__.py
@@ -16,7 +16,7 @@ from lenskit.data import ItemList
 from ._base import ListMetric, Metric, MetricFunction, MetricResult, MetricVal
 from ._collect import MeasurementCollector, RunMetrics
 from ._quick import quick_measure_model
-from .basic import ListLength, TestItemCount
+from .basic import ListLength, TestItemCount, UniqueItemCount
 from .bulk import RunAnalysis, RunAnalysisResult
 from .predict import MAE, RMSE
 from .ranking import (
@@ -71,6 +71,7 @@ __all__ = [
     "RunAnalysisResult",
     "RunMetrics",
     "TestItemCount",
+    "UniqueItemCount",
     "least_item_promoted",
     "quick_measure_model",
     "rank_biased_overlap",

--- a/src/lenskit/metrics/_collect.py
+++ b/src/lenskit/metrics/_collect.py
@@ -229,6 +229,7 @@ class MeasurementCollector:
         results = {}
 
         for state in self._metrics:
+            _log.debug("accumulating metric %s", state.label)
             agg = state.accumulator.accumulate()
             _add_values(results, state.label, agg)
 

--- a/src/lenskit/metrics/basic.py
+++ b/src/lenskit/metrics/basic.py
@@ -10,7 +10,7 @@ Basic set statistics.
 
 from lenskit.data import ItemList
 
-from ._base import ListMetric, Metric
+from ._base import ListMetric
 
 
 class ListLength(ListMetric):
@@ -27,7 +27,7 @@ class ListLength(ListMetric):
         return len(recs)
 
 
-class TestItemCount(Metric):
+class TestItemCount(ListMetric):
     """
     Report the number of test items.
 

--- a/src/lenskit/metrics/basic.py
+++ b/src/lenskit/metrics/basic.py
@@ -8,7 +8,12 @@
 Basic set statistics.
 """
 
-from lenskit.data import ItemList
+from typing import override
+
+from lenskit.data import ID, ItemList
+from lenskit.data.accum import Accumulator
+from lenskit.data.types import IDSequence
+from lenskit.metrics import Metric
 
 from ._base import ListMetric
 
@@ -39,3 +44,33 @@ class TestItemCount(ListMetric):
 
     def measure_list(self, recs: ItemList, test: ItemList) -> float:
         return len(test)
+
+
+class UniqueItemCount(Metric[IDSequence, int]):
+    """
+    Count the number of unique items in the recommendation lists.
+
+    Stability:
+        Caller
+    """
+
+    def measure_list(self, recs: ItemList, test: ItemList) -> IDSequence:
+        return recs.ids()
+
+    def create_accumulator(self):
+        return UniqueItemAccumulator()
+
+
+class UniqueItemAccumulator(Accumulator):
+    _ids: set[ID]
+
+    def __init__(self):
+        self._ids = set()
+
+    @override
+    def add(self, value: IDSequence) -> None:
+        self._ids.update(value)
+
+    @override
+    def accumulate(self) -> int:
+        return len(self._ids)

--- a/tests/eval/test_bulk_metrics.py
+++ b/tests/eval/test_bulk_metrics.py
@@ -10,7 +10,7 @@ from pytest import approx, raises
 
 from lenskit.data import ItemListCollection
 from lenskit.data._adapt import ITEM_COMPAT_COLUMN, USER_COMPAT_COLUMN
-from lenskit.metrics.basic import ListLength, TestItemCount
+from lenskit.metrics.basic import ListLength, TestItemCount, UniqueItemCount
 from lenskit.metrics.bulk import RunAnalysis
 from lenskit.metrics.predict import RMSE
 from lenskit.metrics.ranking import DCG, NDCG, RBP, Precision, RecipRank
@@ -41,6 +41,7 @@ def test_recs(demo_recs):
     bms = RunAnalysis()
     bms.add_metric(ListLength())
     bms.add_metric(TestItemCount())
+    bms.add_metric(UniqueItemCount())
     bms.add_metric(Precision())
     bms.add_metric(NDCG())
     bms.add_metric(DCG())
@@ -52,6 +53,9 @@ def test_recs(demo_recs):
     stats = metrics.list_summary()
     print(stats)
     for m in bms.collector.metric_names:
+        if m == "UniqueItemCount":
+            continue
+
         assert stats.loc[m, "mean"] == approx(scores[m].mean())
 
 

--- a/tests/eval/test_bulk_metrics.py
+++ b/tests/eval/test_bulk_metrics.py
@@ -10,7 +10,7 @@ from pytest import approx, raises
 
 from lenskit.data import ItemListCollection
 from lenskit.data._adapt import ITEM_COMPAT_COLUMN, USER_COMPAT_COLUMN
-from lenskit.metrics.basic import ListLength
+from lenskit.metrics.basic import ListLength, TestItemCount
 from lenskit.metrics.bulk import RunAnalysis
 from lenskit.metrics.predict import RMSE
 from lenskit.metrics.ranking import DCG, NDCG, RBP, Precision, RecipRank
@@ -40,6 +40,7 @@ def test_recs(demo_recs):
 
     bms = RunAnalysis()
     bms.add_metric(ListLength())
+    bms.add_metric(TestItemCount())
     bms.add_metric(Precision())
     bms.add_metric(NDCG())
     bms.add_metric(DCG())

--- a/tests/eval/test_counts.py
+++ b/tests/eval/test_counts.py
@@ -1,0 +1,16 @@
+from lenskit.metrics import MeasurementCollector, RunAnalysis, UniqueItemCount
+from lenskit.testing import demo_recs, ml_ratings
+
+
+def test_recs(demo_recs):
+    split, recs = demo_recs
+
+    mc = MeasurementCollector()
+    mc.add_metric(UniqueItemCount())
+
+    metrics = mc.measure_run(recs, split.test)
+    scores = metrics.summary_metrics
+    assert "UniqueItemCount" in scores
+
+    items = {i for il in recs.lists() for i in il.ids()}
+    assert scores["UniqueItemCount"] == len(items)


### PR DESCRIPTION
This adds a new `UniqueItemCount` metric that counts the total unique items recommended.

Closes #1005.