### PR TITLE
Add interaction="default" to add_relationship_class

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -45,6 +45,7 @@ fixed issues and merged PRs is on `milestone 2026.3`_.
 - Expose batch inference results as a row-by-row iterator (:pr:`1128`).
 - Certain per-request warnings in batch inference are now aggregated (:issue:`1113`, :pr:`1168`).
 - Added :class:`lenskit.metrics.UniqueItemCount` (:issue:`1005`, :pr:`1169`).
+- Added support for ``interaction="default"`` to :meth:`~lenskit.data.DatasetBuilder.add_relationship_class` (:pr:`1174`).
 
 .. _milestone 2026.3: https://github.com/lenskit/lkpy/milestone/28?closed=1
 

--- a/src/lenskit/data/_builder.py
+++ b/src/lenskit/data/_builder.py
@@ -169,7 +169,7 @@ class DatasetBuilder:
         name: str,
         entities: RelationshipEntities,
         allow_repeats: bool = True,
-        interaction: bool = False,
+        interaction: bool | Literal["default"] = False,
     ) -> None:
         """
         Add a relationship class to the dataset.  This usually doesn't need to
@@ -198,7 +198,8 @@ class DatasetBuilder:
                 Whether repeated records for the same combination of entities
                 are allowed.
             interaction:
-                Whether this is an interaction relationship.
+                Whether this is an interaction relationship.  The string ``"default"``
+                marks this as the default interaction relationship.
         """
         if name in self._tables:
             raise ValueError(f"relationship class name “{name}” already defined")
@@ -221,9 +222,12 @@ class DatasetBuilder:
 
         self.schema.relationships[name] = RelationshipSchema(
             entities=e_dict,
-            interaction=interaction,
+            interaction=bool(interaction),
             repeats=AllowableTroolean.ALLOWED if allow_repeats else AllowableTroolean.FORBIDDEN,
         )
+        if interaction == "default":
+            self.schema.default_interaction = name
+
         self._tables[name] = _empty_rel_table(enames)
 
     @overload
@@ -443,10 +447,8 @@ class DatasetBuilder:
                 cls,
                 entities,
                 allow_repeats=allow_repeats,
-                interaction=bool(interaction),
+                interaction=interaction,
             )
-            if interaction == "default":
-                self.schema.default_interaction = cls
             rc_def = self.schema.relationships[cls]
 
         # FIXME: remove this segment when we can make it work

--- a/src/lenskit/data/_dataset.py
+++ b/src/lenskit/data/_dataset.py
@@ -43,7 +43,7 @@ _log = get_logger(__name__)
 type ACTION_FIELDS = Literal["ratings", "timestamps"] | str
 
 
-def _uses_data(func):
+def _uses_data[**P, R](func: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator to make sure the data is loaded.
     """


### PR DESCRIPTION
This adds support for `interaction="default"` to the `add_relationship_class` method, so default interactions can be specified when creating a class.