### PR TITLE
Make pipeline schemas strict

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -10,6 +10,18 @@ There are no new major paradigm shifts, though — pipelines, datasets, and
 components work as they do in the 2025 series, but with more features, some
 rough corners polished off the interfaces, and hopefully fewer bugs.
 
+.. _2026.4.0:
+
+2026.4.0 (in progress)
+~~~~~~~~~~~~~~~~~~~~~~
+
+Third feature release in 2026, with more feature updates and bug fixes.  A full list of
+fixed issues and merged PRs is on `milestone 2026.4`_.
+
+- Made pipeline schemas more strict to catch misconfiguration errors.
+
+.. _milestone 2026.4: https://github.com/lenskit/lkpy/milestone/29
+
 .. _2026.3.0:
 
 2026.3.0

--- a/src/lenskit/schemas/pipeline.py
+++ b/src/lenskit/schemas/pipeline.py
@@ -111,7 +111,7 @@ class PipelineConfigFragment(BaseModel, extra="allow"):
     "Pipeline metadata."
 
 
-class PipelineConfig(BaseModel):
+class PipelineConfig(BaseModel, extra="forbid"):
     """
     Root type for serialized pipeline configuration.  A pipeline config contains
     the full configuration, components, and wiring for the pipeline, but does
@@ -174,7 +174,7 @@ class PipelineConfig(BaseModel):
         return pipe
 
 
-class PipelineMeta(BaseModel):
+class PipelineMeta(BaseModel, extra="allow"):
     """
     Pipeline metadata.
 
@@ -193,7 +193,7 @@ class PipelineMeta(BaseModel):
     """
 
 
-class PipelineInput(BaseModel):
+class PipelineInput(BaseModel, extra="forbid"):
     """
     Spcification of a pipeline input.
 
@@ -207,7 +207,7 @@ class PipelineInput(BaseModel):
     "The list of types for this input."
 
 
-class PipelineComponent(BaseModel):
+class PipelineComponent(BaseModel, extra="forbid"):
     """
     Specification of a pipeline component.
     """
@@ -231,7 +231,7 @@ class PipelineComponent(BaseModel):
     """
 
 
-class PipelineLiteral(BaseModel):
+class PipelineLiteral(BaseModel, extra="forbid"):
     """
     Literal nodes represented in the pipeline.
 

--- a/tests/tuning/slim-inline-pipeline.toml
+++ b/tests/tuning/slim-inline-pipeline.toml
@@ -1,0 +1,22 @@
+[search]
+method = "tpe"
+max_points = 30
+list_length = 1000
+metric = "RBP"
+
+[space.scorer]
+max_nbrs = { type = "int", min = 100, max = 1000, scale = "log" }
+l1_reg = { type = "float", min = 0.01, max = 100, scale = "log" }
+l2_reg = { type = "float", min = 0.01, max = 100, scale = "log" }
+
+[pipeline.meta]
+name = "SLIM"
+
+[pipeline.options]
+base = "std:topn"
+
+[pipeline.components.scorer]
+class = "lenskit.knn.SLIMScorer"
+
+[pipeline.components.scorer.config]
+max_nbrs = 500

--- a/tests/tuning/test_tuner_setup.py
+++ b/tests/tuning/test_tuner_setup.py
@@ -11,6 +11,9 @@ from pytest import skip
 from lenskit.config import LenskitSettings, reconfigure
 from lenskit.schemas.tuning import TuningSpec
 
+test_dir = Path(__file__).parent
+root_dir = test_dir.parent.parent
+
 
 def test_tuner_spec():
     spec = TuningSpec.load(Path("pipelines/iknn-explicit-search.toml"))
@@ -34,6 +37,32 @@ def test_tuner_merge_defaults():
 
         assert tuner.spec.search.max_points == 30
         assert tuner.spec.search.max_epochs == 15
+
+
+def test_tuner_external_config():
+    try:
+        from lenskit.tuning import PipelineTuner
+    except ImportError:
+        skip("optuna not available")
+
+    spec = TuningSpec.load(root_dir / "pipelines/slim-search.toml")
+    tuner = PipelineTuner(spec)
+
+    pipe = tuner.pipeline
+    assert pipe.components["scorer"].config["max_nbrs"] == 500
+
+
+def test_tuner_inline_config():
+    try:
+        from lenskit.tuning import PipelineTuner
+    except ImportError:
+        skip("optuna not available")
+
+    spec = TuningSpec.load(test_dir / "slim-inline-pipeline.toml")
+    tuner = PipelineTuner(spec)
+
+    pipe = tuner.pipeline
+    assert pipe.components["scorer"].config["max_nbrs"] == 500
 
 
 def test_ray_tuner_space():


### PR DESCRIPTION
We had a suspected bug, which turned out to be misconfiguration, in tuning and default configuration parameters.

This PR adds a test for that behavior we suspected to be buggy, with a corrected version of the configuration file that triggered it. More importantly, it adds `extra="forbid"` to most of the pipeline schema model classes to cause the erroneous configuration to fail with a schema validation error instead of a stranger runtime error.