### PR TITLE
Export JSON schemas into the documentation site

### DIFF
--- a/docs/releases/2026.rst
+++ b/docs/releases/2026.rst
@@ -19,6 +19,7 @@ Third feature release in 2026, with more feature updates and bug fixes.  A full 
 fixed issues and merged PRs is on `milestone 2026.4`_.
 
 - Made pipeline schemas more strict to catch misconfiguration errors (:pr:`1193`).
+- Published JSON schemas for configuration and tuning files (:pr:`1194`).
 
 .. _milestone 2026.4: https://github.com/lenskit/lkpy/milestone/29
 

--- a/mise/tasks/build/docs.sh
+++ b/mise/tasks/build/docs.sh
@@ -9,4 +9,10 @@ if [[ $usage_preview ]]; then
     cmd=(sphinx-autobuild)
 fi
 
-echo-run "${cmd[@]}" docs build/site || exit 2
+echo-run "${cmd[@]}" docs build/site || die "doc build failed"
+
+msg "building schemas"
+mkdir -p build/site/schemas
+echo-run python -m lenskit.schemas -o build/site/schemas/config.json --config
+echo-run python -m lenskit.schemas -o build/site/schemas/pipeline.json --pipeline
+echo-run python -m lenskit.schemas -o build/site/schemas/tuner.json --tuner

--- a/src/lenskit/schemas/__main__.py
+++ b/src/lenskit/schemas/__main__.py
@@ -4,28 +4,9 @@
 # Licensed under the MIT license, see LICENSE.md for details.
 # SPDX-License-Identifier: MIT
 
-"""
-Export a LensKit schema.
-
-Usage:
-    lenskit.schemas [-v] [-o file] (--pipeline | --tuner | --config)
-
-Options:
-    -v, --verbose
-        Enable verbose logging.
-    -o FILE, --output=FILE
-        Output file to write schema to.
-    --pipeline
-        Export pipeline schema.
-    --tuner
-        Export tuner schema.
-    --config
-        Export config schema.
-"""
-
+import argparse
 import json
-
-from docopt import docopt
+from pathlib import Path
 
 from lenskit.logging import LoggingConfig, get_logger, stdout_console
 
@@ -36,28 +17,45 @@ from .tuning import TuningSpec
 _log = get_logger("lenskit.schemas")
 
 
-def main(args):
+def main():
+    parser = _arg_parser()
+    args = parser.parse_args()
     lc = LoggingConfig()
-    if args["--verbose"]:
+    if args.verbose:
         lc.set_verbose()
     lc.apply()
 
-    if args["--pipeline"]:
+    if args.pipeline:
         schema = PipelineConfig.model_json_schema()
-    elif args["--tuner"]:
+    elif args.tuner:
         schema = TuningSpec.model_json_schema()
-    else:
+    elif args.config:
         schema = LenskitSettings.model_json_schema()
+    else:  # pragma: nocover
+        raise RuntimeError("no schema specified")
 
-    if out := args["--output"]:
-        _log.info("saving schema to %s", out)
-        with open(out, "w") as f:
+    if args.output:
+        _log.info("saving schema to %s", args.output)
+        with open(args.output, "w") as f:
             json.dump(schema, f, indent=2)
     else:
         console = stdout_console()
         console.print_json(json.dumps(schema))
 
 
+def _arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export a LensKit schema.")
+
+    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose logging")
+    parser.add_argument("-o", "--output", type=Path, metavar="FILE", help="write schema to FILE")
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pipeline", action="store_true", help="export pipeline schema")
+    group.add_argument("--tuner", action="store_true", help="export tuner schema")
+    group.add_argument("--config", action="store_true", help="export config schema")
+
+    return parser
+
+
 if __name__ == "__main__":
-    args = docopt(__doc__)
-    main(args)
+    main()

--- a/src/lenskit/schemas/__main__.py
+++ b/src/lenskit/schemas/__main__.py
@@ -1,0 +1,63 @@
+# This file is part of LensKit.
+# Copyright (C) 2018-2023 Boise State University.
+# Copyright (C) 2023-2026 Drexel University.
+# Licensed under the MIT license, see LICENSE.md for details.
+# SPDX-License-Identifier: MIT
+
+"""
+Export a LensKit schema.
+
+Usage:
+    lenskit.schemas [-v] [-o file] (--pipeline | --tuner | --config)
+
+Options:
+    -v, --verbose
+        Enable verbose logging.
+    -o FILE, --output=FILE
+        Output file to write schema to.
+    --pipeline
+        Export pipeline schema.
+    --tuner
+        Export tuner schema.
+    --config
+        Export config schema.
+"""
+
+import json
+
+from docopt import docopt
+
+from lenskit.logging import LoggingConfig, get_logger, stdout_console
+
+from .pipeline import PipelineConfig
+from .settings import LenskitSettings
+from .tuning import TuningSpec
+
+_log = get_logger("lenskit.schemas")
+
+
+def main(args):
+    lc = LoggingConfig()
+    if args["--verbose"]:
+        lc.set_verbose()
+    lc.apply()
+
+    if args["--pipeline"]:
+        schema = PipelineConfig.model_json_schema()
+    elif args["--tuner"]:
+        schema = TuningSpec.model_json_schema()
+    else:
+        schema = LenskitSettings.model_json_schema()
+
+    if out := args["--output"]:
+        _log.info("saving schema to %s", out)
+        with open(out, "w") as f:
+            json.dump(schema, f, indent=2)
+    else:
+        console = stdout_console()
+        console.print_json(json.dumps(schema))
+
+
+if __name__ == "__main__":
+    args = docopt(__doc__)
+    main(args)

--- a/tests/cli/test-schema-export.sh
+++ b/tests/cli/test-schema-export.sh
@@ -1,0 +1,31 @@
+test-plan 12
+
+run-python -m lenskit.schemas --pipeline -o $TEST_WORK/pipeline.json
+require -f $TEST_WORK/pipeline.json
+title=$(jq -r .title <$TEST_WORK/pipeline.json)
+if (($?)); then
+    not_ok "pipeline.json is invalid JSON"
+else
+    ok "parsed pipeline.json"
+fi
+require $title == PipelineConfig
+
+run-python -m lenskit.schemas --tuner -o $TEST_WORK/tuner.json
+require -f $TEST_WORK/tuner.json
+title=$(jq -r .title <$TEST_WORK/tuner.json)
+if (($?)); then
+    not_ok "tuner.json is invalid JSON"
+else
+    ok "parsed tuner.json"
+fi
+require $title == TuningSpec
+
+run-python -m lenskit.schemas --config -o $TEST_WORK/config.json
+require -f $TEST_WORK/config.json
+title=$(jq -r .title <$TEST_WORK/config.json)
+if (($?)); then
+    not_ok "config.json is invalid JSON"
+else
+    ok "parsed config.json"
+fi
+require $title == LenskitSettings


### PR DESCRIPTION
This exports JSON schemas as part of the documentation site, so we can have editor support for configuration files.