### PR TITLE
Add GitHub Actions group markers to CLI test output

### DIFF
--- a/mise/task-functions.sh
+++ b/mise/task-functions.sh
@@ -40,6 +40,18 @@ echo-run() {
     return "$?"
 }
 
+start-group() {
+    if [[ $CI ]]; then
+        echo "::group::$*"
+    fi
+}
+
+end-group() {
+    if [[ $CI ]]; then
+        echo ::endgroup::
+    fi
+}
+
 git-is-clean() {
     if [[ -z "$(git status -u --porcelain)" ]]; then
         return 0

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -39,9 +39,7 @@ fi
 msg "running ${#test_files[@]} test suites"
 declare -a taps=()
 for test in "${test_files[@]}"; do
-    if [[ $CI ]]; then
-        echo ::group::"CLI test $test"
-    fi
+    start-group "CLI test $test"
     msg "running test $test"
     tap_file="${test%%.sh}.tap"
     dbg "saving output to $tap_file"
@@ -59,13 +57,13 @@ for test in "${test_files[@]}"; do
     if [[ -s "$tap_file" ]]; then
         taps+=("$tap_file")
     fi
-    if [[ $CI ]]; then
-        echo ::endgroup::
-    fi
+    end-group
 done
 
 if [[ $usage_coverage = true ]]; then
+    start-group "test coverage"
     coverage report
+    end-group
 fi
 
 exec prove "${taps[@]}"

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -39,6 +39,9 @@ fi
 msg "running ${#test_files[@]} test suites"
 declare -a taps=()
 for test in "${test_files[@]}"; do
+    if [[ $CI ]]; then
+        echo ::group::"CLI test $test"
+    fi
     msg "running test $test"
     tap_file="${test%%.sh}.tap"
     dbg "saving output to $tap_file"
@@ -55,6 +58,9 @@ for test in "${test_files[@]}"; do
     rm -rf "$TEST_WORK"
     if [[ -s "$tap_file" ]]; then
         taps+=("$tap_file")
+    fi
+    if [[ $CI ]]; then
+        echo ::endgroup::
     fi
 done
 


### PR DESCRIPTION
This updates the CLI tests to use groups in the log output for easier perusal in GitHub Actions.