### PR TITLE
Warn about a missing history component only when one could be missing

### DIFF
--- a/src/lenskit/knn/item.py
+++ b/src/lenskit/knn/item.py
@@ -231,13 +231,18 @@ class ItemKNNScorer(Component[ItemList], Trainable):
     def __call__(self, query: QueryInput, items: ItemList) -> ItemList:
         ensure_parallel_init()
 
+        # A caller that hands us a bare user ID has no history-bearing component in
+        # front of us, so an absent history is a pipeline configuration problem. A
+        # caller that hands us a query has already run one, and an absent history
+        # there just means it found nothing for this user — usually an unknown user.
+        query_supplied = isinstance(query, RecQuery)
         query = RecQuery.create(query)
         log = _log.bind(user_id=query.user_id, n_items=len(items))
         trace(log, "beginning prediction")
 
         ratings = query.query_items
         if ratings is None or len(ratings) == 0:
-            if ratings is None:
+            if ratings is None and not query_supplied:
                 log.warning(
                     "no query items, did you omit a history component?", _batch=MISSING_HISTORY_KEY
                 )

--- a/tests/models/test_knn_item_item.py
+++ b/tests/models/test_knn_item_item.py
@@ -13,6 +13,7 @@ import pandas as pd
 import torch
 from numpy.typing import NDArray
 from scipy import linalg as la
+from structlog.testing import capture_logs
 
 import pytest
 from pytest import approx, fixture, mark
@@ -451,3 +452,33 @@ def test_ii_known_preds(ml_ds):
         bad = merged[merged.error.notna() & (merged.error.abs() >= 0.01)]
         _log.error("erroneous predictions:\n%s", bad)
         raise e
+
+
+def test_ii_warns_about_missing_history_component_only_for_a_bare_id():
+    """The missing-history warning should diagnose a pipeline gap, not an unknown user.
+
+    A caller that passes a bare user ID has no history-bearing component in front of
+    the scorer, so an absent history means the pipeline is misconfigured. A caller
+    that passes a query has already run one; an absent history there just means the
+    lookup found nothing, which is the normal result for a user who is not in the
+    training data.
+    """
+    lookup = UserTrainingHistoryLookup()
+    lookup.train(simple_ds)
+    scorer = ItemKNNScorer(k=5)
+    scorer.train(simple_ds)
+    unknown_user = 999
+    assert simple_ds.users.number(unknown_user, missing=None) is None
+
+    query = lookup(unknown_user)
+    assert query.query_items is None
+
+    with capture_logs() as entries:
+        scorer(query, ItemList([6, 7, 8]))
+    assert [e for e in entries if e.get("log_level") == "warning"] == []
+
+    with capture_logs() as entries:
+        scorer(unknown_user, ItemList([6, 7, 8]))
+    assert [e["event"] for e in entries if e.get("log_level") == "warning"] == [
+        "no query items, did you omit a history component?"
+    ]


### PR DESCRIPTION
Fixes #804.

`ItemKNNScorer` emits `no query items, did you omit a history component?` whenever `query.query_items` is None. That covers two very different situations and is only correct for one of them.

`RecQuery.create` returns a query unchanged if it is already a `RecQuery`, and otherwise wraps a bare user ID in a query with no history at all. So an absent history indicates a pipeline gap only when the caller passed something that was not already a query. When a query arrives, a history component has already run, and an empty history is its normal result for a user who is not in the training data — the false positive the issue describes.

The warning is now emitted only in the first case. The second still logs at debug level via the existing `user has no history, returning` message. This follows the direction suggested in the issue (keying off whether the query is a `RecQuery`).

## Reproduction

Against 2026.3.0, with a history component present and doing its job:

```python
lookup = UserTrainingHistoryLookup(); lookup.train(ds)
scorer = ItemKNNScorer(k=5); scorer.train(ds)
scorer(lookup(999), ItemList([6, 7, 8]))   # user 999 is not in ds
```

```
[warning] no query items, did you omit a history component? _batch=lenskit.knn.item.NO_HISTORY user_id=999
```

After the change that call is silent, while `scorer(999, ItemList([6, 7, 8]))` — a bare ID, no history component in front — still warns.

## `UserKNNScorer` is deliberately unchanged

The issue mentions other components. `UserKNNScorer` already handles this correctly: it looks the user up in its training vocabulary before warning, and reports `has no ratings and none provided`, which is accurate and does not blame a component. `ItemKNNScorer` cannot do the same — it retains only `items`, `item_means` and `sim_matrix`, so it has no user vocabulary to consult, which is why the query-shape test is used instead.

## Testing

Adds a regression test asserting both directions via `structlog.testing.capture_logs`. It fails on the first assertion against current `main` and passes with this change. `tests/models/test_knn_item_item.py` is 41 passed / 9 skipped and `test_knn_user_user.py` is 40 passed / 8 skipped with the change applied.

One note on my environment: the Rust toolchain on this machine could not build the extension, so I verified against the released 2026.3.0 wheel with this patch applied to the installed package, running the repo's own test file against it. The change itself is pure Python and touches no compiled code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)