### PR TITLE
Convert numeric interaction timestamps

### DIFF
--- a/src/lenskit/data/_adapt.py
+++ b/src/lenskit/data/_adapt.py
@@ -23,7 +23,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from ._builder import DatasetBuilder, TimestampUnit
+from ._builder import DatasetBuilder
 from ._dataset import Dataset
 from ._vocab import Vocabulary
 from .types import ID, AliasedColumn, Column, IDSequence
@@ -111,7 +111,7 @@ def from_interactions_df(
     users: IDSequence | pd.Index | Iterable[ID] | Vocabulary | None = None,
     items: IDSequence | pd.Index | Iterable[ID] | Vocabulary | None = None,
     class_name: str = "rating",
-    timestamp_unit: TimestampUnit | None = None,
+    timestamp_unit: Literal["s", "ms", "us", "ns"] | None = None,
 ) -> Dataset:
     """
     Create a dataset from a data frame of ratings or other user-item

--- a/src/lenskit/data/_adapt.py
+++ b/src/lenskit/data/_adapt.py
@@ -23,7 +23,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from ._builder import DatasetBuilder
+from ._builder import DatasetBuilder, TimestampUnit
 from ._dataset import Dataset
 from ._vocab import Vocabulary
 from .types import ID, AliasedColumn, Column, IDSequence
@@ -111,6 +111,7 @@ def from_interactions_df(
     users: IDSequence | pd.Index | Iterable[ID] | Vocabulary | None = None,
     items: IDSequence | pd.Index | Iterable[ID] | Vocabulary | None = None,
     class_name: str = "rating",
+    timestamp_unit: TimestampUnit | None = None,
 ) -> Dataset:
     """
     Create a dataset from a data frame of ratings or other user-item
@@ -132,6 +133,9 @@ def from_interactions_df(
             The name of the rating column.
         timestamp_col:
             The name of the timestamp column.
+        timestamp_unit:
+            The unit of numeric timestamp values. If omitted, integer units are
+            inferred and floating-point values are assumed to be seconds.
         user_ids:
             A vocabulary of user IDs.  The data frame is subset to this set of IDs.
         item_ids:
@@ -176,6 +180,7 @@ def from_interactions_df(
         missing=missing,
         allow_repeats=False,
         default=True,
+        timestamp_unit=timestamp_unit,
     )
 
     return dsb.build()

--- a/src/lenskit/data/_builder.py
+++ b/src/lenskit/data/_builder.py
@@ -51,7 +51,6 @@ _log = get_logger(__name__)
 
 type TableInput = pd.DataFrame | pa.Table | dict[str, NDArray[Any]]
 type RelationshipEntities = Sequence[str] | Mapping[str, str | None]
-type TimestampUnit = Literal["s", "ms", "us", "ns"]
 
 type DuplicateAction = Literal["update", "error", "overwrite"]
 """
@@ -392,6 +391,7 @@ class DatasetBuilder:
         interaction: bool | Literal["default"] = False,
         _warning_parent: int = 0,
         remove_repeats: bool | Literal["exact"] = False,
+        timestamp_unit: Literal["s", "ms", "us", "ns"] | None = None,
     ) -> None:
         """
         Add relationship records to the data set.
@@ -424,6 +424,10 @@ class DatasetBuilder:
             remove_repeats:
                 If ``True``, repeated interactions will be removed. If ``"exact"``,
                 duplicated interactions will be removed.
+            timestamp_unit:
+                The unit of numeric values in the ``timestamp`` column. If omitted,
+                integer units are inferred and floating-point values are assumed to
+                be seconds. Numeric timestamps are converted to Arrow timestamps.
         """
         if isinstance(data, pd.DataFrame):
             table = pa.Table.from_pandas(data, preserve_index=False)
@@ -431,6 +435,8 @@ class DatasetBuilder:
             table = pa.table(data)  # type: ignore
         else:
             table = data
+
+        table = _convert_relationship_timestamps(table, timestamp_unit)
 
         log = self._log.bind(class_name=cls, count=table.num_rows)
 
@@ -571,7 +577,7 @@ class DatasetBuilder:
         allow_repeats: bool = True,
         default: bool = False,
         remove_repeats: bool | Literal["exact"] = False,
-        timestamp_unit: TimestampUnit | None = None,
+        timestamp_unit: Literal["s", "ms", "us", "ns"] | None = None,
     ) -> None:
         """
         Add a interaction records to the data set.
@@ -614,7 +620,6 @@ class DatasetBuilder:
                 integer units are inferred and floating-point values are assumed to
                 be seconds. Numeric timestamps are converted to Arrow timestamps.
         """
-        data = _convert_interaction_timestamps(data, timestamp_unit)
         self.add_relationships(
             cls,
             data,
@@ -624,6 +629,7 @@ class DatasetBuilder:
             interaction="default" if default else True,
             _warning_parent=1,
             remove_repeats=remove_repeats,
+            timestamp_unit=timestamp_unit,
         )
 
     def filter_interactions(
@@ -1235,29 +1241,28 @@ def _empty_rel_table(types: list[str]) -> pa.Table:
     return pa.table({num_col_name(t): pa.array([], pa.int32()) for t in types})
 
 
-_TIMESTAMP_UNITS: tuple[TimestampUnit, ...] = ("s", "ms", "us", "ns")
-_TIMESTAMP_UNIT_FACTORS: dict[TimestampUnit, int] = {
+_TIMESTAMP_UNITS: tuple[Literal["s", "ms", "us", "ns"], ...] = (
+    "s",
+    "ms",
+    "us",
+    "ns",
+)
+_TIMESTAMP_UNIT_FACTORS: dict[Literal["s", "ms", "us", "ns"], int] = {
     "s": 1,
     "ms": 1_000,
     "us": 1_000_000,
     "ns": 1_000_000_000,
 }
-_TIMESTAMP_MIN_SECONDS = -2_208_988_800
-_TIMESTAMP_MAX_SECONDS = 4_102_444_800
+_TIMESTAMP_MIN_SECONDS = int(dt.datetime.fromisoformat("1900-01-01T00:00:00+00:00").timestamp())
+_TIMESTAMP_MAX_SECONDS = int(dt.datetime.fromisoformat("2100-01-01T00:00:00+00:00").timestamp())
 
 
-def _convert_interaction_timestamps(
-    data: TableInput, timestamp_unit: TimestampUnit | None
+def _convert_relationship_timestamps(
+    table: pa.Table,
+    timestamp_unit: Literal["s", "ms", "us", "ns"] | None,
 ) -> pa.Table:
     if timestamp_unit is not None and timestamp_unit not in _TIMESTAMP_UNITS:
         raise ValueError(f"invalid timestamp unit {timestamp_unit!r}")
-
-    if isinstance(data, pd.DataFrame):
-        table = pa.Table.from_pandas(data, preserve_index=False)
-    elif isinstance(data, dict):
-        table = pa.table(data)  # type: ignore
-    else:
-        table = data
 
     column_idx = table.schema.get_field_index("timestamp")
     if column_idx < 0:
@@ -1290,7 +1295,9 @@ def _convert_interaction_timestamps(
     return table.set_column(column_idx, "timestamp", converted)
 
 
-def _infer_timestamp_unit(timestamps: pa.ChunkedArray) -> TimestampUnit:
+def _infer_timestamp_unit(
+    timestamps: pa.ChunkedArray,
+) -> Literal["s", "ms", "us", "ns"]:
     valid_count = len(timestamps) - timestamps.null_count
     if valid_count == 0:
         return "s"

--- a/src/lenskit/data/_builder.py
+++ b/src/lenskit/data/_builder.py
@@ -51,6 +51,7 @@ _log = get_logger(__name__)
 
 type TableInput = pd.DataFrame | pa.Table | dict[str, NDArray[Any]]
 type RelationshipEntities = Sequence[str] | Mapping[str, str | None]
+type TimestampUnit = Literal["s", "ms", "us", "ns"]
 
 type DuplicateAction = Literal["update", "error", "overwrite"]
 """
@@ -570,6 +571,7 @@ class DatasetBuilder:
         allow_repeats: bool = True,
         default: bool = False,
         remove_repeats: bool | Literal["exact"] = False,
+        timestamp_unit: TimestampUnit | None = None,
     ) -> None:
         """
         Add a interaction records to the data set.
@@ -607,7 +609,12 @@ class DatasetBuilder:
             remove_repeats:
                 If ``True``, repeated interactions will be removed. If ``"exact"``,
                 duplicated interactions will be removed.
+            timestamp_unit:
+                The unit of numeric values in the ``timestamp`` column. If omitted,
+                integer units are inferred and floating-point values are assumed to
+                be seconds. Numeric timestamps are converted to Arrow timestamps.
         """
+        data = _convert_interaction_timestamps(data, timestamp_unit)
         self.add_relationships(
             cls,
             data,
@@ -1226,6 +1233,84 @@ def _expand_and_align_list_array(
 
 def _empty_rel_table(types: list[str]) -> pa.Table:
     return pa.table({num_col_name(t): pa.array([], pa.int32()) for t in types})
+
+
+_TIMESTAMP_UNITS: tuple[TimestampUnit, ...] = ("s", "ms", "us", "ns")
+_TIMESTAMP_UNIT_FACTORS: dict[TimestampUnit, int] = {
+    "s": 1,
+    "ms": 1_000,
+    "us": 1_000_000,
+    "ns": 1_000_000_000,
+}
+_TIMESTAMP_MIN_SECONDS = -2_208_988_800
+_TIMESTAMP_MAX_SECONDS = 4_102_444_800
+
+
+def _convert_interaction_timestamps(
+    data: TableInput, timestamp_unit: TimestampUnit | None
+) -> pa.Table:
+    if timestamp_unit is not None and timestamp_unit not in _TIMESTAMP_UNITS:
+        raise ValueError(f"invalid timestamp unit {timestamp_unit!r}")
+
+    if isinstance(data, pd.DataFrame):
+        table = pa.Table.from_pandas(data, preserve_index=False)
+    elif isinstance(data, dict):
+        table = pa.table(data)  # type: ignore
+    else:
+        table = data
+
+    column_idx = table.schema.get_field_index("timestamp")
+    if column_idx < 0:
+        return table
+
+    timestamps = table.column(column_idx)
+    column_type = timestamps.type
+    if pa.types.is_timestamp(column_type):
+        return table
+
+    if pa.types.is_null(column_type):
+        converted = pa.nulls(len(timestamps), pa.timestamp(timestamp_unit or "s"))
+    elif pa.types.is_floating(column_type):
+        values = pc.if_else(
+            pc.is_nan(timestamps),
+            pa.scalar(None, column_type),
+            timestamps,
+        )
+        if timestamp_unit is None:
+            values = pc.multiply(values, 1_000)
+            timestamp_unit = "ms"
+        values = pc.cast(pc.round(values), pa.int64())
+        converted = pc.cast(values, pa.timestamp(timestamp_unit))
+    elif pa.types.is_integer(column_type):
+        timestamp_unit = timestamp_unit or _infer_timestamp_unit(timestamps)
+        converted = pc.cast(timestamps, pa.timestamp(timestamp_unit))
+    else:
+        return table
+
+    return table.set_column(column_idx, "timestamp", converted)
+
+
+def _infer_timestamp_unit(timestamps: pa.ChunkedArray) -> TimestampUnit:
+    valid_count = len(timestamps) - timestamps.null_count
+    if valid_count == 0:
+        return "s"
+
+    # Loss of integer precision is harmless for this coarse range check, and
+    # permitting it lets us inspect microsecond and nanosecond epoch values.
+    values = pc.cast(timestamps, pa.float64(), safe=False)
+    for unit in _TIMESTAMP_UNITS:
+        factor = _TIMESTAMP_UNIT_FACTORS[unit]
+        in_range = pc.and_(
+            pc.greater_equal(values, float(_TIMESTAMP_MIN_SECONDS * factor)),
+            pc.less(values, float(_TIMESTAMP_MAX_SECONDS * factor)),
+        )
+        in_range_count = pc.sum(pc.fill_null(in_range, False)).as_py() or 0
+        if in_range_count / valid_count >= 0.95:
+            return unit
+
+    raise ValueError(
+        "could not infer timestamp unit because fewer than 95% of values fall between 1900 and 2099"
+    )
 
 
 def _conform_time(time: float | str | dt.datetime, col_type: pa.DataType):

--- a/src/lenskit/data/_relationships.py
+++ b/src/lenskit/data/_relationships.py
@@ -630,6 +630,8 @@ class MatrixRelationshipSet(RelationshipSet):
             values = np.ones(nnz, dtype=np.float32)
         else:
             value_col = self._table.column(attribute)
+            if pa.types.is_timestamp(self._table.field(attribute).type):
+                value_col = value_col.cast(pa.timestamp("s")).cast(pa.int64())
             if value_col.null_count:
                 mask = value_col.is_valid()
                 values = value_col.filter(mask).to_numpy()

--- a/tests/data/test_builder_filter.py
+++ b/tests/data/test_builder_filter.py
@@ -72,14 +72,17 @@ def test_filter_ratings_min_time(
         ml_ratings = ml_ratings.assign(
             timestamp=(ml_ratings["timestamp"] - pd.Timestamp("1970-01-01")) // pd.Timedelta("1s")
         )
+        expected_timestamps = pd.to_datetime(ml_ratings["timestamp"], unit="s")
+    else:
+        expected_timestamps = ml_ratings["timestamp"]
     dsb.add_interactions(
         "rating", ml_ratings, entities=["user", "item"], missing="insert", default=True
     )
-    q = QueryDT.create("2001-01-01", q_fmt, ts_fmt)
+    q = QueryDT.create("2001-01-01", q_fmt, "timestamp")
     dsb.filter_interactions("rating", min_time=q.thresh)
     ds = dsb.build()
     assert ds.interactions().pandas()["timestamp"].min() >= q.compare
-    assert ds.interactions().pandas()["timestamp"].max() == ml_ratings["timestamp"].max()
+    assert ds.interactions().pandas()["timestamp"].max() == expected_timestamps.max()
 
 
 @mark.parametrize(
@@ -95,13 +98,16 @@ def test_filter_ratings_max_time(
         ml_ratings = ml_ratings.assign(
             timestamp=(ml_ratings["timestamp"] - pd.Timestamp("1970-01-01")) // pd.Timedelta("1s")
         )
+        expected_timestamps = pd.to_datetime(ml_ratings["timestamp"], unit="s")
+    else:
+        expected_timestamps = ml_ratings["timestamp"]
     dsb.add_interactions(
         "rating", ml_ratings, entities=["user", "item"], missing="insert", default=True
     )
-    q = QueryDT.create("2001-01-01", q_fmt, ts_fmt)
+    q = QueryDT.create("2001-01-01", q_fmt, "timestamp")
     dsb.filter_interactions("rating", max_time=q.thresh)
     ds = dsb.build()
-    assert ds.interactions().pandas()["timestamp"].min() == ml_ratings["timestamp"].min()
+    assert ds.interactions().pandas()["timestamp"].min() == expected_timestamps.min()
     assert ds.interactions().pandas()["timestamp"].max() < q.compare
 
 
@@ -118,11 +124,12 @@ def test_filter_ratings_min_max_time(
         ml_ratings = ml_ratings.assign(
             timestamp=(ml_ratings["timestamp"] - pd.Timestamp("1970-01-01")) // pd.Timedelta("1s")
         )
+
     dsb.add_interactions(
         "rating", ml_ratings, entities=["user", "item"], missing="insert", default=True
     )
-    q1 = QueryDT.create("2001-01-01", q_fmt, ts_fmt)
-    q2 = QueryDT.create("2004-01-01", q_fmt, ts_fmt)
+    q1 = QueryDT.create("2001-01-01", q_fmt, "timestamp")
+    q2 = QueryDT.create("2004-01-01", q_fmt, "timestamp")
     dsb.filter_interactions("rating", min_time=q1.thresh, max_time=q2.thresh)
     ds = dsb.build()
     assert ds.interactions().pandas()["timestamp"].min() >= q1.compare

--- a/tests/data/test_builder_interactions.py
+++ b/tests/data/test_builder_interactions.py
@@ -218,6 +218,68 @@ def test_add_interactions_preserves_existing_timestamp_type():
     assert log.field("timestamp").type == pa.timestamp("us")
 
 
+def test_add_interactions_respects_explicit_integer_timestamp_unit():
+    value = _REFERENCE_TIMESTAMP_SECONDS * 1_000
+    dsb = DatasetBuilder()
+    dsb.add_interactions(
+        "click",
+        pa.table({"user_id": ["a"], "item_id": ["x"], "timestamp": [value]}),
+        entities=["user", "item"],
+        missing="insert",
+        timestamp_unit="ms",
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp("ms")
+    assert log.column("timestamp").cast(pa.int64()).to_pylist() == [value]
+
+
+def test_add_interactions_converts_null_timestamp_column():
+    dsb = DatasetBuilder()
+    dsb.add_interactions(
+        "click",
+        pa.table(
+            {
+                "user_id": ["a", "b"],
+                "item_id": ["x", "y"],
+                "timestamp": pa.nulls(2),
+            }
+        ),
+        entities=["user", "item"],
+        missing="insert",
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp("s")
+    assert log.column("timestamp").to_pylist() == [None, None]
+
+
+def test_add_interactions_preserves_nonnumeric_timestamp_column():
+    dsb = DatasetBuilder()
+    dsb.add_interactions(
+        "click",
+        pa.table({"user_id": ["a"], "item_id": ["x"], "timestamp": ["unknown"]}),
+        entities=["user", "item"],
+        missing="insert",
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.string()
+    assert log.column("timestamp").to_pylist() == ["unknown"]
+
+
+def test_add_interactions_rejects_invalid_timestamp_unit():
+    dsb = DatasetBuilder()
+    with raises(ValueError, match="invalid timestamp unit"):
+        dsb.add_interactions(
+            "click",
+            pa.table({"user_id": ["a"], "item_id": ["x"], "timestamp": [1]}),
+            entities=["user", "item"],
+            missing="insert",
+            timestamp_unit="minutes",  # type: ignore[arg-type]
+        )
+
+
 def test_add_interactions_promotes_timestamp_units_across_batches():
     dsb = DatasetBuilder()
     dsb.add_interactions(

--- a/tests/data/test_builder_interactions.py
+++ b/tests/data/test_builder_interactions.py
@@ -135,13 +135,18 @@ def test_add_interactions_table():
     assert np.all(mat.rowptrs == [0, 2, 3, 6])
 
 
+# 2023-11-14T22:13:20+00:00 is comfortably inside the supported
+# inference window. Scaling the same instant exercises each epoch unit.
+_REFERENCE_TIMESTAMP_SECONDS = 1_700_000_000
+
+
 @mark.parametrize(
     ("unit", "value"),
     [
-        ("s", 1_700_000_000),
-        ("ms", 1_700_000_000_000),
-        ("us", 1_700_000_000_000_000),
-        ("ns", 1_700_000_000_000_000_000),
+        ("s", _REFERENCE_TIMESTAMP_SECONDS),
+        ("ms", _REFERENCE_TIMESTAMP_SECONDS * 1_000),
+        ("us", _REFERENCE_TIMESTAMP_SECONDS * 1_000_000),
+        ("ns", _REFERENCE_TIMESTAMP_SECONDS * 1_000_000_000),
     ],
 )
 def test_add_interactions_infers_integer_timestamp_unit(unit: str, value: int):
@@ -158,6 +163,22 @@ def test_add_interactions_infers_integer_timestamp_unit(unit: str, value: int):
     assert log.column("timestamp").cast(pa.int64()).to_pylist() == [value]
 
 
+def test_add_relationships_infers_integer_timestamp_unit():
+    value = _REFERENCE_TIMESTAMP_SECONDS * 1_000
+    dsb = DatasetBuilder()
+    dsb.add_relationships(
+        "click",
+        pa.table({"user_id": ["a"], "item_id": ["x"], "timestamp": [value]}),
+        entities=["user", "item"],
+        missing="insert",
+        interaction=True,
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp("ms")
+    assert log.column("timestamp").cast(pa.int64()).to_pylist() == [value]
+
+
 def test_add_interactions_float_timestamp_uses_milliseconds_and_nulls_nan():
     dsb = DatasetBuilder()
     dsb.add_interactions(
@@ -166,7 +187,7 @@ def test_add_interactions_float_timestamp_uses_milliseconds_and_nulls_nan():
             {
                 "user_id": ["a", "b", "c"],
                 "item_id": ["x", "y", "z"],
-                "timestamp": pa.array([1_700_000_000.125, float("nan"), None]),
+                "timestamp": pa.array([_REFERENCE_TIMESTAMP_SECONDS + 0.125, float("nan"), None]),
             }
         ),
         entities=["user", "item"],
@@ -175,11 +196,15 @@ def test_add_interactions_float_timestamp_uses_milliseconds_and_nulls_nan():
 
     log = dsb.build().interaction_table(format="arrow")
     assert log.field("timestamp").type == pa.timestamp("ms")
-    assert log.column("timestamp").cast(pa.int64()).to_pylist() == [1_700_000_000_125, None, None]
+    assert log.column("timestamp").cast(pa.int64()).to_pylist() == [
+        _REFERENCE_TIMESTAMP_SECONDS * 1_000 + 125,
+        None,
+        None,
+    ]
 
 
 def test_add_interactions_preserves_existing_timestamp_type():
-    timestamps = pa.array([1_700_000_000_000_000], type=pa.timestamp("us"))
+    timestamps = pa.array([_REFERENCE_TIMESTAMP_SECONDS * 1_000_000], type=pa.timestamp("us"))
     dsb = DatasetBuilder()
     dsb.add_interactions(
         "click",
@@ -197,13 +222,25 @@ def test_add_interactions_promotes_timestamp_units_across_batches():
     dsb = DatasetBuilder()
     dsb.add_interactions(
         "click",
-        pa.table({"user_id": ["a"], "item_id": ["x"], "timestamp": [1_700_000_000]}),
+        pa.table(
+            {
+                "user_id": ["a"],
+                "item_id": ["x"],
+                "timestamp": [_REFERENCE_TIMESTAMP_SECONDS],
+            }
+        ),
         entities=["user", "item"],
         missing="insert",
     )
     dsb.add_interactions(
         "click",
-        pa.table({"user_id": ["b"], "item_id": ["y"], "timestamp": [1_700_000_000_001]}),
+        pa.table(
+            {
+                "user_id": ["b"],
+                "item_id": ["y"],
+                "timestamp": [_REFERENCE_TIMESTAMP_SECONDS * 1_000 + 1],
+            }
+        ),
         entities=["user", "item"],
         missing="insert",
     )
@@ -211,13 +248,15 @@ def test_add_interactions_promotes_timestamp_units_across_batches():
     log = dsb.build().interaction_table(format="arrow")
     assert log.field("timestamp").type == pa.timestamp("ms")
     assert sorted(log.column("timestamp").cast(pa.int64()).to_pylist()) == [
-        1_700_000_000_000,
-        1_700_000_000_001,
+        _REFERENCE_TIMESTAMP_SECONDS * 1_000,
+        _REFERENCE_TIMESTAMP_SECONDS * 1_000 + 1,
     ]
 
 
 def test_add_interactions_timestamp_inference_tolerates_five_percent_outliers():
-    values = [1_700_000_000] * 19 + [np.iinfo(np.int64).max]
+    # Nineteen in-range values and one outlier exercise the inclusive
+    # 95% threshold without making the inferred unit ambiguous.
+    values = [_REFERENCE_TIMESTAMP_SECONDS] * 19 + [np.iinfo(np.int64).max]
     dsb = DatasetBuilder()
     dsb.add_interactions(
         "click",
@@ -237,6 +276,7 @@ def test_add_interactions_timestamp_inference_tolerates_five_percent_outliers():
 
 
 def test_add_interactions_timestamp_inference_rejects_unrecognizable_values():
+    # The largest int64 is outside 1900 through 2099 under every supported unit.
     dsb = DatasetBuilder()
     with raises(ValueError, match="could not infer timestamp unit"):
         dsb.add_interactions(

--- a/tests/data/test_builder_interactions.py
+++ b/tests/data/test_builder_interactions.py
@@ -135,6 +135,124 @@ def test_add_interactions_table():
     assert np.all(mat.rowptrs == [0, 2, 3, 6])
 
 
+@mark.parametrize(
+    ("unit", "value"),
+    [
+        ("s", 1_700_000_000),
+        ("ms", 1_700_000_000_000),
+        ("us", 1_700_000_000_000_000),
+        ("ns", 1_700_000_000_000_000_000),
+    ],
+)
+def test_add_interactions_infers_integer_timestamp_unit(unit: str, value: int):
+    dsb = DatasetBuilder()
+    dsb.add_interactions(
+        "click",
+        pa.table({"user_id": ["a"], "item_id": ["x"], "timestamp": [value]}),
+        entities=["user", "item"],
+        missing="insert",
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp(unit)
+    assert log.column("timestamp").cast(pa.int64()).to_pylist() == [value]
+
+
+def test_add_interactions_float_timestamp_uses_milliseconds_and_nulls_nan():
+    dsb = DatasetBuilder()
+    dsb.add_interactions(
+        "click",
+        pa.table(
+            {
+                "user_id": ["a", "b", "c"],
+                "item_id": ["x", "y", "z"],
+                "timestamp": pa.array([1_700_000_000.125, float("nan"), None]),
+            }
+        ),
+        entities=["user", "item"],
+        missing="insert",
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp("ms")
+    assert log.column("timestamp").cast(pa.int64()).to_pylist() == [1_700_000_000_125, None, None]
+
+
+def test_add_interactions_preserves_existing_timestamp_type():
+    timestamps = pa.array([1_700_000_000_000_000], type=pa.timestamp("us"))
+    dsb = DatasetBuilder()
+    dsb.add_interactions(
+        "click",
+        pa.table({"user_id": ["a"], "item_id": ["x"], "timestamp": timestamps}),
+        entities=["user", "item"],
+        missing="insert",
+        timestamp_unit="s",
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp("us")
+
+
+def test_add_interactions_promotes_timestamp_units_across_batches():
+    dsb = DatasetBuilder()
+    dsb.add_interactions(
+        "click",
+        pa.table({"user_id": ["a"], "item_id": ["x"], "timestamp": [1_700_000_000]}),
+        entities=["user", "item"],
+        missing="insert",
+    )
+    dsb.add_interactions(
+        "click",
+        pa.table({"user_id": ["b"], "item_id": ["y"], "timestamp": [1_700_000_000_001]}),
+        entities=["user", "item"],
+        missing="insert",
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp("ms")
+    assert sorted(log.column("timestamp").cast(pa.int64()).to_pylist()) == [
+        1_700_000_000_000,
+        1_700_000_000_001,
+    ]
+
+
+def test_add_interactions_timestamp_inference_tolerates_five_percent_outliers():
+    values = [1_700_000_000] * 19 + [np.iinfo(np.int64).max]
+    dsb = DatasetBuilder()
+    dsb.add_interactions(
+        "click",
+        pa.table(
+            {
+                "user_id": [f"u{i}" for i in range(20)],
+                "item_id": [f"i{i}" for i in range(20)],
+                "timestamp": values,
+            }
+        ),
+        entities=["user", "item"],
+        missing="insert",
+    )
+
+    log = dsb.build().interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp("s")
+
+
+def test_add_interactions_timestamp_inference_rejects_unrecognizable_values():
+    dsb = DatasetBuilder()
+    with raises(ValueError, match="could not infer timestamp unit"):
+        dsb.add_interactions(
+            "click",
+            pa.table(
+                {
+                    "user_id": ["a"],
+                    "item_id": ["x"],
+                    "timestamp": [np.iinfo(np.int64).max],
+                }
+            ),
+            entities=["user", "item"],
+            missing="insert",
+        )
+
+
 def test_add_interactions_count_method():
     dsb = DatasetBuilder()
 

--- a/tests/data/test_dataset_convert.py
+++ b/tests/data/test_dataset_convert.py
@@ -6,8 +6,24 @@
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 
 from lenskit.data import from_interactions_df
+
+
+def test_from_interactions_df_forwards_timestamp_unit():
+    data = pd.DataFrame(
+        {
+            "user_id": ["u1", "u2"],
+            "item_id": ["i1", "i2"],
+            "time": [1_700_000_000_123, 1_700_000_000_456],
+        }
+    )
+
+    ds = from_interactions_df(data, timestamp_col="time", timestamp_unit="ms")
+
+    log = ds.interaction_table(format="arrow")
+    assert log.field("timestamp").type == pa.timestamp("ms")
 
 
 def test_item_subset(rng: np.random.Generator, ml_ratings: pd.DataFrame):


### PR DESCRIPTION
Fixes #1183.

This converts numeric interaction timestamps to Arrow timestamp types in both `DatasetBuilder.add_interactions` and `from_interactions_df`.

- adds an explicit `timestamp_unit` option
- infers integer values from seconds through nanoseconds when at least 95 percent fall between 1900 and 2099
- treats floating point values as seconds by default, preserves millisecond precision, and converts NaN to null
- preserves existing timestamp columns and promotes compatible units across batches
- keeps timestamp attributes usable in SciPy sparse matrices as integer seconds

Validation:

- data test suite: 438 passed, 40 skipped, 3 expected failures
- focused timestamp and builder tests: 64 passed
- Ruff lint and format checks passed

Developed with OpenAI Codex assistance. I reviewed and tested the change and remain responsible for it.